### PR TITLE
Standardise use of hyphens with 'non'

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -522,7 +522,7 @@
                 <section title="Inline dereferencing and fragments">
                     <t>
                         When using inline dereferencing, a resolution scope may lead to a URI which
-                        has a non empty fragment part which is not a JSON Pointer, as in this
+                        has a non-empty fragment part which is not a JSON Pointer, as in this
                         example:
                     </t>
 

--- a/jsonschema-schema.xml
+++ b/jsonschema-schema.xml
@@ -17,7 +17,7 @@
 <?rfc rfcedstyle="yes"?>
 <rfc category="info" docName="draft-fge-json-schema-validation-01" ipr="trust200902">
     <front>
-        <title abbrev="JSON Schema">JSON Schema: interactive and non interactive validation</title>
+        <title abbrev="JSON Schema">JSON Schema: interactive and non-interactive validation</title>
 
         <author fullname="Geraint Luff" initials="G" surname="Luff" role="editor">
             <address>
@@ -64,7 +64,7 @@
         <abstract>
             <t>
                 JSON Schema (application/schema+json) has several purposes, one of which is instance
-                validation. The validation process may be interactive or non interactive. For
+                validation. The validation process may be interactive or non-interactive. For
                 instance, applications may use JSON Schema to build a user interface enabling
                 interactive content generation in addition to user input checking, or validate data
                 retrieved from various sources. This specification describes schema keywords


### PR DESCRIPTION
The only "non interactive" without hyphenation I have left in is the title of an earlier publication.