### PR TITLE
Tighten up wording of 'Default values for missing keywords'

### DIFF
--- a/jsonschema-schema.xml
+++ b/jsonschema-schema.xml
@@ -212,8 +212,9 @@
             <section title="Default values for missing keywords">
 
                 <t>
-                    Some keywords, if absent, MAY be regarded by implementations as having
-                    a default value. In this case, the default value will be mentioned.
+                    Where keywords are specified which MAY be absent but which have a default value
+                    described, implementations MUST produce the same results whether the keyword is
+                    absent or whether it is present and has the default value.
                 </t>
 
             </section>


### PR DESCRIPTION
I believe the intention of the previous wording here was that
implementations could represent default values by changing the
in-memory representation of the schema so that the default values are
present, rather than by changing the code which acts on the in-memory
representation to follow the default behaviour each time.

However, the wording was also open to other interpretations, e.g. that
implementations could ignore default values entirely (and might
therefore cause errors or behave in the opposite manner if the default
value is boolean true).

Since there is nothing in this schema which would be affected by such
changes to  the in-memory representation, it can be assumed that this
representation is entirely within the domain of the implementation and
there is no need to explicitly permit inference of defaults; the only
real requirement is that the result be the same.