### PR TITLE
README changes (80 chars/line; use recommended single top level heading;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
-## Welcome to JSON Schema
+# JSON Schema
+
+## Welcome
 
 This repository contains the current, and historical, JSON Schema
 specifications.
 
 ## Call for reviews
 
-Specifications are starting to get written. Reviews, comments and suggestions
-are of paramount importance to JSON Schema. It is humbly asked to you, dear
-reader, that you bring your contribution.
+Specifications are starting to get written. Reviews, comments, and suggestions
+are of paramount importance to JSON Schema. It is humbly asked of you, dear
+reader, that you bring your contributions.
 
 ## The website
 
-The JSON Schema web site is at http://json-schema.org/
+The JSON Schema web site is at <http://json-schema.org/>.
 
 ## License
 
-The source material in this repository is licensed under the AFL or BSD license.
+The source material in this repository is licensed under the AFL v3.0
+or BSD 3 revised license.
+
+## Development
+
+1.  [Download and install Python](https://www.python.org/downloads/), being
+    sure to add Python to the system path.
+
+2.  Follow the [install instructions for xml2rfc](https://pypi.python.org/pypi/xml2rfc/).
+    (It was problematic for me on Windows, so for me the simplest solution
+    was to downgrade Python to 2.7.11 and utilize the [lxml installer](https://pypi.python.org/pypi/lxml/3.5.0#downloads)
+    for 2.7, avoiding certain errors for the C++ compiler with this library
+    used by xml2rfc.)
+
+3.  Run `npm install`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "json-schema-spec",
+  "version": "0.4.0",
+  "description": "Current and historical JSON Schema specifications",
+  "main": "schema.json",
+  "scripts": {
+    "install": "npm run make",
+    "make": "npm run text && npm run html",
+    "text-core": "xml2rfc --text jsonschema-core.xml -o jsonschema-core.txt",
+    "text-schema": "xml2rfc --text jsonschema-schema.xml -o jsonschema-schema.txt",
+    "text-hyperschema": "xml2rfc --text jsonschema-hyperschema.xml -o jsonschema-hyperschema.txt",
+    "text": "npm run text-core && npm run text-schema && npm run text-hyperschema",
+    "html-core": "xml2rfc --html jsonschema-core.xml -o jsonschema-core.html",
+    "html-schema": "xml2rfc --html jsonschema-schema.xml -o jsonschema-schema.html",
+    "html-hyperschema": "xml2rfc --html jsonschema-hyperschema.xml -o jsonschema-hyperschema.html",
+    "html": "npm run html-core && npm run html-schema && npm run html-hyperschema",
+    "clean": "rm -f jsonschema-core.html jsonschema-core.txt jsonschema-schema.html jsonschema-schema.txt jsonschema-hyperschema.html jsonschema-hyperschema.txt",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/json-schema-org/json-schema-spec.git"
+  },
+  "keywords": [
+    "json",
+    "json",
+    "schema"
+  ],
+  "author": "",
+  "contributors": [],
+  "dependencies": {},
+  "engines": {},
+  "license": "(BSD-3-Clause OR AFL-3.0)",
+  "bugs": {
+    "url": "https://github.com/json-schema-org/json-schema-spec/issues"
+  },
+  "homepage": "https://github.com/json-schema-org/json-schema-spec#readme"
+}


### PR DESCRIPTION
more specific licenses; dev. steps);
allow building via npm (avoids Make problems/dependency on Windows and established build pattern).

I didn't know the authors/contributors to add or whether my change to a more specific license was accurate, and let me know whatever other changes you might want.