### PR TITLE
Add "format" validation to the meta-schema.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -137,6 +137,7 @@
                 }
             ]
         },
+        "format": { "type": "string" },
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },


### PR DESCRIPTION
Fixes old repo issues:
https://github.com/json-schema/json-schema/issues/84
https://github.com/json-schema/json-schema/issues/198

Previously submitted to the old repository by IvanGoncharov as commit 472c32b
and pull request #163 with original comment:

Added validation according to
http://json-schema.org/latest/json-schema-validation.html#anchor105

Merged into the old repo by geraintluff on May 8, 2015.