### PR TITLE
Add the "contains" keyword for array instances.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -367,6 +367,17 @@
                 </t>
             </section>
 
+            <section title="contains">
+                <t>
+                    The value of this keyword MUST be an object.  This object MUST be
+                    a valid JSON Schema.
+                </t>
+                <t>
+                    An array instance is valid against "contains" if at least one of
+                    its elements is valid against the given schema.
+                </t>
+            </section>
+
             <section title="maxProperties">
                 <t>
                     The value of this keyword MUST be an integer. This integer MUST be

--- a/schema.json
+++ b/schema.json
@@ -87,6 +87,7 @@
             "type": "boolean",
             "default": false
         },
+        "contains": { "$ref": "#" },
         "maxProperties": { "$ref": "#/definitions/positiveInteger" },
         "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
         "required": { "$ref": "#/definitions/stringArray" },


### PR DESCRIPTION
This addresses the enhancement requested in issues #32 and #63.
Only the single-schema form from #63 is added here as the multi-schema form
did not gather significant support in the absence of a clear use case.
