### PR TITLE
Add "const" keyword for constant values.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -546,6 +546,16 @@
                 </t>
             </section>
 
+            <section title="const">
+                <t>
+                    The value of this keyword MAY be of any type, including null.
+                </t>
+                <t>
+                    An instance validates successfully against this keyword if its value is
+                    equal to the value of the keyword.
+                </t>
+            </section>
+
             <section title="type">
                 <t>
                     The value of this keyword MUST be either a string or an array. If it is

--- a/schema.json
+++ b/schema.json
@@ -124,6 +124,7 @@
                 ]
             }
         },
+        "const": {},
         "enum": {
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
This addresses issue #58, which got quite a few upvotes and has
a "draft 6" milestone.

I used the shorter "const" that several people suggested rather
than "constant", but obviously that's easy to change if the longer
form is preferred.

The wording was pretty much directly lifted from "enum".