### PR TITLE
Correct number of primitive types from seven to six.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -552,7 +552,7 @@
                     an array, elements of the array MUST be strings and MUST be unique.
                 </t>
                 <t>
-                    String values MUST be one of the seven primitive types defined by
+                    String values MUST be one of the six primitive types defined by
                     the core specification.
                 </t>
                 <t>


### PR DESCRIPTION
The core spec lists six primitive types in section 4.2 (null, boolean, object, array, number, string), but this sentence claims there are seven. Correct it to match.

I'm not sure if this is the right fix - it's also possible that seven is correct, but the reference to the core spec is wrong. Presumably "integer" is meant to be allowed here too - but the type "integer" is nowhere defined - not in the core spec, or the validation spec.