### PR TITLE
Clarify "items"/"additionalItems" interaction.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -350,6 +350,11 @@
                     if every instance element at a position greater than the size
                     of "items" validates against "additionalItems".
                 </t>
+                <t>
+                    Otherwise, "additionalItems" MUST be ignored, as the "items"
+                    schema (possibly the default value of an empty schema) is
+                    applied to all elements.
+                </t>
             </section>
 
             <section title="maxItems">


### PR DESCRIPTION
In #135 the question of whether additionalItems could fail validation
if items is not defined was raised.  Since items defines a default
value of {}, it is never undefined, which is clarified in this change.