### PR TITLE
Define subschemas -> child instances in core

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -297,6 +297,127 @@
             </t>
         </section>
 
+        <section title="Applying subschemas to child instances">
+            <t>
+                The keywords in this section are used to control which subschemas
+                apply to child instances.  They are independent of any specific
+                schema vocabulary.  Vocabulary specifications SHOULD define any
+                vocabulary-specific effects of applying subschemas.
+            </t>
+            <section title="$items">
+                <t>
+                    The value of "$items" MUST be either an object or an array of objects.
+                    Each object MUST be a valid subschema.
+                </t>
+                <t>
+                    If absent, it can be considered present with an empty schema.
+                </t>
+                <t>
+                    This keyword applies only to array instances.
+                </t>
+                <t>
+                    If "$items" is a schema, that subschema applies to all elements
+                    in the instance array.
+                </t>
+                <t>
+                    If "$items" is an array of schemas, each subschema applies to
+                    the child instance element at the same position, if any.
+                </t>
+            </section>
+
+            <section title="$additionalItems">
+                <t>
+                    The value of "$additionalItems" MUST be valid subschema.
+                </t>
+                <t>
+                    If absent, it can be considered present with an empty schema.
+                </t>
+                <t>
+                    This keyword applies only to array instances.
+                </t>
+                <t>
+                    If "$items" is an array of schemas, the "$additionalItems"
+                    schema applies to every element of the instance array at
+                    a position greater than the size of "$items".
+                </t>
+                <t>
+                    Otherwise, "$additionalItems" MUST be ignored, as the "$items"
+                    schema (possibly the default value of an empty schema) is
+                    applied to all instance array elements.
+                </t>
+            </section>
+
+            <section title="$properties">
+                <t>
+                    The value of "$properties" MUST be an object. Each value of this object
+                    MUST be a a valid subschema.
+                </t>
+                <t>
+                    If absent, it can be considered the same as an empty object.
+                </t>
+                <t>
+                    This keyword applies only to object instances.
+                </t>
+                <t>
+                    For each property name that appears in both the "$properties" value
+                    and the instance object, the subschema given for that property
+                    name is applied to the value of that property in the instance object.
+                </t>
+            </section>
+
+            <section title="$patternProperties">
+                <t>
+                    The value of "$patternProperties" MUST be an object. Each property name
+                    of this object SHOULD be a valid regular expression, according to the
+                    ECMA 262 regular expression dialect. Each property value of this object
+                    MUST be a valid subschema.
+                </t>
+                <t>
+                    If absent, it can be considered the same as an empty object.
+                </t>
+                <t>
+                    This keyword applies only to object instances.
+                </t>
+                <t>
+                    For each instance object property name that matches any
+                    regular expressions that appear as a property name in this keyword's
+                    value, the subschemas associated with each matching pattern
+                    are applied to the value of that instance property.
+                </t>
+            </section>
+
+            <section title="$additionalProperties">
+                <t>
+                    The value of "$additionalProperties" MUST be a valid subschema.
+                </t>
+                <t>
+                    If "$additionalProperties" is absent, it may be considered present with
+                    an empty schema as a value.
+                </t>
+                <t>
+                    This keyword applies only to object instances.
+                </t>
+                <t>
+                    The keyword's subschema is applied only to the instance object
+                    property values whose property names neither appear in "$properties"
+                    nor match any regular expression in "$patternProperties".
+                </t>
+            </section>
+
+            <section title="Compatibility with earlier drafts">
+                <t>
+                    Implementations MAY support "items", "additionalItems", "properties",
+                    "patternProperties", and "additionalProperties" as synonyms for their
+                    dollar sign-prefixed equivalents for aiding in migrating from earlier
+                    drafts.  An implementation that supports any of these keywords
+                    SHOULD support all of them.
+                </t>
+                <t>
+                    Schema authors SHOULD NOT use these forms of the keywords.
+                </t>
+            </section>
+        </section>
+
         <section title="Schema references with $ref">
             <t>
                 Any time a subschema is expected, a schema may instead use an object containing a "$ref" property.

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -170,15 +170,14 @@
 
             <section title="Validation of primitive types and child values">
                 <t>
-                    Two of the primitive types, array and object, allow for child values.  The validation of
-                    the primitive type is considered separately from the validation of child instances.
+                    Two of the primitive types, array and object, allow for child values.
+                    The JSON Schema core specification defines keywords that determine
+                    which subschemas are applied to each child value.
                 </t>
                 <t>
-                    For arrays, primitive type validation consists of validating restrictions on length.
-                </t>
-                <t>
-                    For objects, primitive type validation consists of validating restrictions on the presence
-                    or absence of property names.
+                    Validation of arrays and objects succeed if, in addition to validating
+                    against any relevant validation keywords, each child instance
+                    successfully validates against all subschemas that apply to it.
                 </t>
             </section>
 
@@ -310,53 +309,6 @@
                 </t>
             </section>
 
-            <section title="items">
-                <t>
-                    The value of "items" MUST be either an object or an array of objects.
-                    Each object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    If absent, it can be considered present with an empty schema.
-                </t>
-                <t>
-                    This keyword controls child instance validation.  Validation of the
-                    primitive instance type against this keyword always succeeds.
-                </t>
-                <t>
-                    If "items" is a schema, child validation succeeds if all elements
-                    in the array successfully validate against that schema.
-                </t>
-                <t>
-                    If "items" is an array of schemas, child validation succeeds if
-                    each element of the instance validates against the schema at the
-                    same position, if any.
-                </t>
-            </section>
-
-            <section title="additionalItems">
-                <t>
-                    The value of "additionalItems" MUST be a boolean or an object.
-                    If it is an object, the object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    If absent, it can be considered present with an empty schema.
-                </t>
-                <t>
-                    This keyword controls child instance validation.  Validation of the
-                    primitive instance type against this keyword always succeeds.
-                </t>
-                <t>
-                    If "items" is an array of schemas, child validation succeeds
-                    if every instance element at a position greater than the size
-                    of "items" validates against "additionalItems".
-                </t>
-                <t>
-                    Otherwise, "additionalItems" MUST be ignored, as the "items"
-                    schema (possibly the default value of an empty schema) is
-                    applied to all elements.
-                </t>
-            </section>
-
             <section title="maxItems">
                 <t>
                     The value of this keyword MUST be an integer. This integer MUST be
@@ -445,71 +397,6 @@
                 <t>
                     An object instance is valid against this keyword if its
                     property set contains all elements in this keyword's array value.
-                </t>
-            </section>
-
-            <section title="properties">
-                <t>
-                    The value of "properties" MUST be an object. Each value of this object
-                    MUST be an object, and each object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    If absent, it can be considered the same as an empty object.
-                </t>
-                <t>
-                    This keyword controls child instance validation.  Validation of the
-                    primitive instance type against this keyword always succeeds.
-                </t>
-                <t>
-                    Child validation succeeds if, for each name that appears in both
-                    the instance and as a name within this keyword's value, the instance
-                    value successfully validates against the corresponding schema.
-                </t>
-            </section>
-
-            <section title="patternProperties">
-                <t>
-                    The value of "patternProperties" MUST be an object. Each property name
-                    of this object SHOULD be a valid regular expression, according to the
-                    ECMA 262 regular expression dialect. Each property value of this object
-                    MUST be an object, and each object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    If absent, it can be considered the same as an empty object.
-                </t>
-                <t>
-                    This keyword controls child instance validation.  Validation of the
-                    primitive instance type against this keyword always succeeds.
-                </t>
-                <t>
-                    Child validation succeeds if, for each instance name that matches any
-                    regular expressions that appear as a property name in this keyword's value,
-                    the child instance for that name successfully validates against each
-                    schema that corresponds to a matching regular expression.
-                </t>
-            </section>
-
-            <section title="additionalProperties">
-                <t>
-                    The value of "additionalProperties" MUST be a boolean or an
-                    object.  If it is an object, the object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    If "additionalProperties" is absent, it may be considered present with
-                    an empty schema as a value.
-                </t>
-                <t>
-                    This keyword controls child instance validation.  Validation of the
-                    primitive instance type against this keyword always succeeds.
-                </t>
-                <t>
-                    Child validation with "additionalProperties" applies only to the child
-                    values of instance names that do not match any names in "properties",
-                    and do not match any regular expression in "patternProperties".
-                </t>
-                <t>
-                    For all such properties, child validation succeeds if the child instance
-                    validates against the "additionalProperties" schema.
                 </t>
             </section>
 


### PR DESCRIPTION
This is a trial balloon for #161.  While it seems like a radical change,
aside from using the "$" prefix for the keywords in question, there is no change
to any behavior.

This moves several keywords that control which subschemas apply
to which child instances from validation to core.  The only
actual validation that these keywords defined was that all child
instances need to validate against all applicable subschemas.

This simple child validation principle has been moved up to
the general considerations section of the validation spec.

The moved keywords are now prefixed with "$", which is what we've
discussed doing for all core keywords (Another potential core
keyword would be "$data", for instance, as it would be used in
multiple vocabularies depending on which proposals we accept,
if any.)

As with "id" vs "$id" and the boolean forms of
exclusiveMinimum/Maximum, the old forms are still allowed but
expected to be removed before RFC.  Migrating an old schema
to the new form is trivial, and was discussed before we decided
to rename "id".  It is equally applicable here.