### PR TITLE
Add note about current meta-schema URIs

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -180,6 +180,15 @@
 
         </section>
 
+        <section title="Meta-schema">
+            <t>
+                The current URI for the JSON Schema Validation is &lt;http://json-schema.org/draft-04/hyper-schema#&gt;.
+            </t>
+            <t>
+                <cref>A revision describing newly added keywords will be added in the future.</cref>
+            </t>
+        </section>
+
         <section title="Schema keywords">
             <section title="base">
                 <t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -207,6 +207,15 @@
 
         </section>
 
+        <section title="Meta-schema">
+            <t>
+                The current URI for the JSON Schema Validation is &lt;http://json-schema.org/draft-04/schema#&gt;.
+            </t>
+            <t>
+                <cref>A revision describing newly added keywords will be added in the future.</cref>
+            </t>
+        </section>
+
         <section title="Validation keywords">
             <t>
                 Validation keywords in a schema impose requirements for successfully validating an instance.


### PR DESCRIPTION
The current drafts don't actually list a meta-schema URI.

Previous drafts listed a URI in "core", but this was effectively the same thing.

Add a note until we figure out how to publish the meta-schema.