### PR TITLE
Allow boolean schemas everywhere (root and subschemas)

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -185,12 +185,34 @@
                 </t>
             </section>
 
-            <section title="JSON Schema document">
+            <section title="JSON Schema documents">
                 <t>
                     A JSON Schema document, or simply a schema, is a JSON document used to describe an instance.
                     A schema is itself interpreted as an instance.
-                    A JSON schema MUST be an object.
+                    A JSON Schema MUST be an object or a boolean, where boolean values are equivalent to object schemas as follows.
                 </t>
+                <figure>
+                    <preamble>
+                        true:
+                    </preamble>
+                    <artwork>
+<![CDATA[
+{}
+]]>
+                    </artwork>
+                </figure>
+                <figure>
+                    <preamble>
+                        false:
+                    </preamble>
+                    <artwork>
+<![CDATA[
+{
+    "not": {}
+}
+]]>
+                    </artwork>
+                </figure>
                 <t>
                     Properties that are used to describe the instance are called keywords, or schema keywords.
                     The meaning of properties is specified by the vocabulary that the schema is using.
@@ -230,6 +252,9 @@
                 <t>
                     In this example document, the schema titled "array item" is a subschema,
                     and the schema titled "root" is the root schema.
+                </t>
+                <t>
+                    As with the root schema, a subschema MUST be an object or a boolean.
                 </t>
             </section>
 
@@ -299,7 +324,8 @@
 
         <section title="Schema references with $ref">
             <t>
-                Any time a subschema is expected, a schema may instead use an object containing a "$ref" property.
+                In addition to a boolean value or an object using schema kewyords defined
+                in the meta-schema, a schema may be represnted by an object containing a "$ref" property.
                 The value of the $ref is a URI Reference.
                 Resolved against the current URI base, it identifies the URI of a schema to use.
                 All other properties in a "$ref" object MUST be ignored.
@@ -323,7 +349,7 @@
                     <xref target="RFC3986">RFC3986 Section 5.1</xref> defines how to determine the default base URI of a document.
                 </t>
                 <t>
-                    Informatively, the initial base URI of a schema is the URI it was found at, or a suitable substitute URI if none is known.
+                    Informatively, the initial base URI of a schema is the URI at which it was found, or a suitable substitute URI if none is known.
                 </t>
             </section>
 
@@ -660,6 +686,7 @@ User-Agent: so-cool-json-schema/1.0.2 curl/7.43.0
                     <t hangText="draft-wright-json-schema-01">
                         <list style="symbols">
                             <t>Updated intro</t>
+                            <t>Allowed for any schema to be a boolean</t>
                         </list>
                     </t>
                     <t hangText="draft-wright-json-schema-00">

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -327,8 +327,7 @@
 
             <section title="items">
                 <t>
-                    The value of "items" MUST be either an object or an array of objects.
-                    Each object MUST be a valid JSON Schema.
+                    The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
                 </t>
                 <t>
                     If absent, it can be considered present with an empty schema.
@@ -350,8 +349,7 @@
 
             <section title="additionalItems">
                 <t>
-                    The value of "additionalItems" MUST be a boolean or an object.
-                    If it is an object, the object MUST be a valid JSON Schema.
+                    The value of "additionalItems" MUST be a valid JSON Schema.
                 </t>
                 <t>
                     If absent, it can be considered present with an empty schema.
@@ -466,7 +464,7 @@
             <section title="properties">
                 <t>
                     The value of "properties" MUST be an object. Each value of this object
-                    MUST be an object, and each object MUST be a valid JSON Schema.
+                    MUST be a valid JSON Schema.
                 </t>
                 <t>
                     If absent, it can be considered the same as an empty object.
@@ -487,7 +485,7 @@
                     The value of "patternProperties" MUST be an object. Each property name
                     of this object SHOULD be a valid regular expression, according to the
                     ECMA 262 regular expression dialect. Each property value of this object
-                    MUST be an object, and each object MUST be a valid JSON Schema.
+                    MUST be a valid JSON Schema.
                 </t>
                 <t>
                     If absent, it can be considered the same as an empty object.
@@ -506,8 +504,7 @@
 
             <section title="additionalProperties">
                 <t>
-                    The value of "additionalProperties" MUST be a boolean or an
-                    object.  If it is an object, the object MUST be a valid JSON Schema.
+                    The value of "additionalProperties" MUST be a valid JSON Schema.
                 </t>
                 <t>
                     If "additionalProperties" is absent, it may be considered present with
@@ -535,12 +532,11 @@
                 </t>
                 <t>
                     This keyword's value MUST be an object. Each property specifies a dependency.
-                    Each dependency value MUST be an object or an array.
+                    Each dependency value MUST be an array or a valid JSON Schema.
                 </t>
                 <t>
-                    If the dependency value is an object, it MUST be a valid JSON Schema. If the
-                    dependency key is a property in the instance, the dependency value must validate
-                    against the entire instance.
+                    If the dependency value is a subschema, and the dependency key is a property
+                    in the instance, the entire instance must validate against the dependency value.
                 </t>
                 <t>
                     If the dependency value is an array, each element in the array,


### PR DESCRIPTION
This implements issue #101, including root schemas.

@awwright requested this form of the solution to compare against PR #128,
which only defines booleans for subschemas.  The idea is that it is sometimes
useful to have an entire schema which always passes or always fails, and
the idiom should be the same everywhere.

Note that with [RFC 7159](https://tools.ietf.org/html/rfc7159#section-2),
the restriction that JSON documents could only be arrays or objects
was removed, so a single boolean value is a valid JSON document.

I slightly prefer this to PR #128, myself.

Also add JSON Reference objects as legal schemas in the meta-schema.

Since "$ref" is now only allowed as a JSON Reference where a schema
is acceptable, it can now be described in JSON Schema and included
in the "anyOf" that defines legal subschemas.