### PR TITLE
Add "$ref", numeric exclusive*, default empty string arrays to meta-schemas, standardize meta-schema formats

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -2,48 +2,46 @@
     "$schema": "http://json-schema.org/draft/hyper-schema#",
     "id": "http://json-schema.org/draft/hyper-schema#",
     "title": "JSON Hyper-Schema",
-    "allOf": [
-        {"$ref": "http://json-schema.org/draft-04/schema#"}
-    ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [
-                {"type": "boolean"},
-                {"$ref": "#"}
+                { "type": "boolean" },
+                { "$ref": "#" }
             ]
         },
         "additionalProperties": {
             "anyOf": [
-                {"type": "boolean"},
-                {"$ref": "#"}
+                { "type": "boolean" },
+                { "$ref": "#" }
             ]
         },
         "dependencies": {
             "additionalProperties": {
                 "anyOf": [
-                    {"$ref": "#"},
-                    {"type": "array"}
+                    { "$ref": "#" },
+                    { "type": "array" }
                 ]
             }
         },
         "items": {
             "anyOf": [
-                {"$ref": "#"},
-                {"$ref": "#/definitions/schemaArray"}
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
             ]
         },
         "definitions": {
-            "additionalProperties": {"$ref": "#"}
+            "additionalProperties": { "$ref": "#" }
         },
         "patternProperties": {
-            "additionalProperties": {"$ref": "#"}
+            "additionalProperties": { "$ref": "#" }
         },
         "properties": {
-            "additionalProperties": {"$ref": "#"}
+            "additionalProperties": { "$ref": "#" }
         },
-        "allOf": {"$ref": "#/definitions/schemaArray"},
-        "anyOf": {"$ref": "#/definitions/schemaArray"},
-        "oneOf": {"$ref": "#/definitions/schemaArray"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" },
 
         "base": {
@@ -52,7 +50,7 @@
         },
         "links": {
             "type": "array",
-            "items": {"$ref": "#/definitions/linkDescription"}
+            "items": { "$ref": "#/definitions/linkDescription" }
         },
         "media": {
             "type": "object",
@@ -66,17 +64,26 @@
                     "type": "string"
                 }
             }
+        },
+        "readOnly": {
+            "description": "If true, indicates that the value of this property is controlled by the server.",
+            "type": "boolean",
+            "default": "false"
         }
     },
     "definitions": {
-        "schemaArray": {
-            "type": "array",
-            "items": {"$ref": "#"}
+        "schemaArray": [
+            "allOf": [
+                { "$ref": "http://json-schema.org/drafts/schema" }
+                {
+                    "items": { "$ref": "#" }
+                }
+            ]
         },
         "linkDescription": {
             "title": "Link Description Object",
             "type": "object",
-            "required": ["href"],
+            "required": [ "href" ],
             "properties": {
                 "href": {
                     "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
@@ -92,7 +99,7 @@
                 },
                 "targetSchema": {
                     "description": "JSON Schema describing the link target",
-                    "$ref": "#"
+                    "allOf": [ { "$ref": "#" } ]
                 },
                 "mediaType": {
                     "description": "media type (as defined by RFC 2046) describing the link target",
@@ -109,7 +116,7 @@
                 },
                 "schema": {
                     "description": "Schema describing the data to submit along with the request",
-                    "$ref": "#"
+                    "allOf": [ { "$ref": "#" } ]
                 }
             }
         }
@@ -118,10 +125,6 @@
         {
             "rel": "self",
             "href": "{+id}"
-        },
-        {
-            "rel": "full",
-            "href": "{+($ref)}"
         }
     ]
 }

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -2,6 +2,56 @@
     "$schema": "http://json-schema.org/draft/hyper-schema#",
     "id": "http://json-schema.org/draft/hyper-schema#",
     "title": "JSON Hyper-Schema",
+    "definitions": {
+        "schemaArray": [
+            "allOf": [
+                { "$ref": "http://json-schema.org/drafts/schema" }
+                {
+                    "items": { "$ref": "#" }
+                }
+            ]
+        },
+        "linkDescription": {
+            "title": "Link Description Object",
+            "type": "object",
+            "required": [ "href" ],
+            "properties": {
+                "href": {
+                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+                    "type": "string"
+                },
+                "rel": {
+                    "description": "relation to the target resource of the link",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "a title for the link",
+                    "type": "string"
+                },
+                "targetSchema": {
+                    "description": "JSON Schema describing the link target",
+                    "allOf": [ { "$ref": "#" } ]
+                },
+                "mediaType": {
+                    "description": "media type (as defined by RFC 2046) describing the link target",
+                    "type": "string"
+                },
+                "method": {
+                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
+                    "type": "string"
+                },
+                "encType": {
+                    "description": "The media type in which to submit data along with the request",
+                    "type": "string",
+                    "default": "application/json"
+                },
+                "schema": {
+                    "description": "Schema describing the data to submit along with the request",
+                    "allOf": [ { "$ref": "#" } ]
+                }
+            }
+        }
+    },
     "allOf": [ { "$ref": "http://json-schema.org/draft/schema#" } ],
     "properties": {
         "additionalItems": {
@@ -69,56 +119,6 @@
             "description": "If true, indicates that the value of this property is controlled by the server.",
             "type": "boolean",
             "default": "false"
-        }
-    },
-    "definitions": {
-        "schemaArray": [
-            "allOf": [
-                { "$ref": "http://json-schema.org/drafts/schema" }
-                {
-                    "items": { "$ref": "#" }
-                }
-            ]
-        },
-        "linkDescription": {
-            "title": "Link Description Object",
-            "type": "object",
-            "required": [ "href" ],
-            "properties": {
-                "href": {
-                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
-                    "type": "string"
-                },
-                "rel": {
-                    "description": "relation to the target resource of the link",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "a title for the link",
-                    "type": "string"
-                },
-                "targetSchema": {
-                    "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "mediaType": {
-                    "description": "media type (as defined by RFC 2046) describing the link target",
-                    "type": "string"
-                },
-                "method": {
-                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
-                    "type": "string"
-                },
-                "encType": {
-                    "description": "The media type in which to submit data along with the request",
-                    "type": "string",
-                    "default": "application/json"
-                },
-                "schema": {
-                    "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
-                }
-            }
         }
     },
     "links": [

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -3,11 +3,11 @@
     "id": "http://json-schema.org/draft/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
-        "schemaArray": [
+        "schemaArray": {
             "allOf": [
-                { "$ref": "http://json-schema.org/drafts/schema" }
+                { "$ref": "http://json-schema.org/drafts/schema" },
                 {
-                    "items": { "$ref": "#" }
+                    "items": { "$ref": "#/definitions/subSchema" }
                 }
             ]
         },
@@ -30,7 +30,7 @@
                 },
                 "targetSchema": {
                     "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
+                    "allOf": [ { "$ref": "#/definitions/subSchema" } ]
                 },
                 "mediaType": {
                     "description": "media type (as defined by RFC 2046) describing the link target",
@@ -47,52 +47,64 @@
                 },
                 "schema": {
                     "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
+                    "allOf": [ { "$ref": "#/definitions/subSchema" } ]
                 }
             }
+        },
+        "subSchema": {
+            "oneOf": [
+                {
+                    "allOf": [
+                        { "$ref": "#" },
+                        { "$ref": "http://json-schema.org/draft/schema#/definitions/notJsonReference" }
+                    ]
+                },
+                { "$ref": "http://json-schema.org/draft/schema#/definitions/jsonReference" }
+            ]
         }
     },
+
     "allOf": [ { "$ref": "http://json-schema.org/draft/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ]
         },
         "additionalProperties": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ]
         },
         "dependencies": {
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
+                    { "$ref": "#/definitions/subSchema" },
                     { "type": "array" }
                 ]
             }
         },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$ref": "#/definitions/subSchema" },
                 { "$ref": "#/definitions/schemaArray" }
             ]
         },
         "definitions": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subSchema" }
         },
         "patternProperties": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subSchema" }
         },
         "properties": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subSchema" }
         },
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" },
+        "not": { "$ref": "#/definitions/subSchema" },
 
         "base": {
             "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",

--- a/links.json
+++ b/links.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft/hyper-schema#",
+    "id": "http://json-schema.org/draft/links#",
+    "title": "Link Description Object",
+    "type": "object",
+    "required": [ "href" ],
+    "properties": {
+        "href": {
+            "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+            "type": "string"
+        },
+        "rel": {
+            "description": "relation to the target resource of the link",
+            "type": "string"
+        },
+        "title": {
+            "description": "a title for the link",
+            "type": "string"
+        },
+        "targetSchema": {
+            "description": "JSON Schema describing the link target",
+            "allOf": [ { "$ref": "hyper-schema#" } ]
+        },
+        "mediaType": {
+            "description": "media type (as defined by RFC 2046) describing the link target",
+            "type": "string"
+        },
+        "method": {
+                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
+            "type": "string"
+        },
+        "encType": {
+            "description": "The media type in which to submit data along with the request",
+            "type": "string",
+            "default": "application/json"
+        },
+        "schema": {
+            "description": "Schema describing the data to submit along with the request",
+            "allOf": [ { "$ref": "hyper-schema#" } ]
+        }
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
-    "id": "http://json-schema.org/draft/schema#",
     "$schema": "http://json-schema.org/draft/schema#",
-    "description": "Core schema meta-schema",
+    "id": "http://json-schema.org/draft/schema#",
+    "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
             "type": "array",
@@ -19,7 +19,15 @@
             ]
         },
         "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
         },
         "stringArray": {
             "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -20,7 +20,6 @@
         },
         "schemaArray": {
             "type": "array",
-            "minItems": 1,
             "items": { "$ref": "#/definitions/subSchema" }
         },
         "positiveInteger": {
@@ -47,7 +46,8 @@
         "stringArray": {
             "type": "array",
             "items": { "type": "string" },
-            "uniqueItems": true
+            "uniqueItems": true,
+            "default": []
         },
         "subSchema": {
             "oneOf": [
@@ -80,22 +80,13 @@
         "default": {},
         "multipleOf": {
             "type": "number",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0
         },
         "maximum": {
             "type": "number"
         },
-        "exclusiveMaximum": {
-            "type": "boolean",
-            "default": false
-        },
         "minimum": {
             "type": "number"
-        },
-        "exclusiveMinimum": {
-            "type": "boolean",
-            "default": false
         },
         "maxLength": { "$ref": "#/definitions/positiveInteger" },
         "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
@@ -181,9 +172,39 @@
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#/definitions/subSchema" }
     },
-    "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
-    },
+    "allOf": [
+        {
+            "oneOf": [
+                {
+                    "exclusiveMaximum": { "type": "number" }
+                },
+                {
+                    "exclusiveMaximum": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "dependencies": {
+                        "exclusiveMaximum": [ "maximum" ]
+                    }
+                }
+            ]
+        },
+        {
+            "oneOf": [
+                {
+                    "exclusiveMinimum": { "type": "number" }
+                },
+                {
+                    "exclusiveMinimum": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "dependencies": {
+                        "exclusiveMinimum": [ "minimum" ]
+                    }
+                }
+            ]
+        }
+    ],
     "default": {}
 }

--- a/schema.json
+++ b/schema.json
@@ -3,10 +3,25 @@
     "id": "http://json-schema.org/draft/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
+        "jsonReferece": {
+            "type": "object",
+            "properties": {
+                "$ref": {
+                    "type": "string",
+                    "format": "uriref"
+                }
+            },
+            "required": [ "$ref" ]
+        },
+        "notJsonReference": {
+            "not": {
+                "required": [ "$ref" ]
+            }
+        },
         "schemaArray": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "#" }
+            "items": { "$ref": "#/definitions/subSchema" }
         },
         "positiveInteger": {
             "type": "integer",
@@ -33,6 +48,17 @@
             "type": "array",
             "items": { "type": "string" },
             "uniqueItems": true
+        },
+        "subSchema": {
+            "oneOf": [
+                {
+                    "allOf": [
+                        { "$ref": "#" },
+                        { "$ref": "#/definitions/notJsonReference" }
+                    ]
+                },
+                { "$ref": "#/definitions/jsonReference" }
+            ]
         }
     },
     "type": "object",
@@ -80,13 +106,13 @@
         "additionalItems": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ],
             "default": {}
         },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$ref": "#/definitions/subSchema" },
                 { "$ref": "#/definitions/schemaArray" }
             ],
             "default": {}
@@ -104,30 +130,30 @@
         "additionalProperties": {
             "anyOf": [
                 { "type": "boolean" },
-                { "$ref": "#" }
+                { "$ref": "#/definitions/subSchema" }
             ],
             "default": {}
         },
         "definitions": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subSchema" },
             "default": {}
         },
         "properties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subSchema" },
             "default": {}
         },
         "patternProperties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subSchema" },
             "default": {}
         },
         "dependencies": {
             "type": "object",
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
+                    { "$ref": "#/definitions/subSchema" },
                     { "$ref": "#/definitions/stringArray" }
                 ]
             }
@@ -153,7 +179,7 @@
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" }
+        "not": { "$ref": "#/definitions/subSchema" }
     },
     "dependencies": {
         "exclusiveMaximum": [ "maximum" ],


### PR DESCRIPTION
This is the corresponding change to json-schema-org/json-schema-org.github.io#57
Like that PR, is broken into several commits to make the diffs much easier to read.
It also has meta-schema changes for #77 numeric exclusives and #69 defaulting string arrays to empty arrays, which are the last bits to finish those two issues.

The commits in the sequence are:

* First standardize the formatting, title vs description usage, and order of major sections
* Remove descriptions from hyper-schema.json because they are too easy to get out of sync, and we do not have descriptions in schema.json
* Restore the links meta-schema
* Add JSON reference
* Reorganize the schemas to use either a normal object or a json reference, and never allow an object with a "$ref" property to validate as a non-reference.
* Update the exclusive numeric limits and default empty string arrays.

NOTE:  Various outstanding PRs will be reworked to put their meta-schema changes on top of this as soon as it is merged.  In particular this will simplify and clarify both #128 and #167 .