### PR TITLE
Remove confusing use of "absolute" URI.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -296,8 +296,8 @@
             </t>
             <t>
                 The root schema of a JSON Schema document SHOULD use this keyword.
-                The value of this keyword MUST be a <xref target="RFC3986">URI</xref> (an "absolute" URI),
-                and this URI MUST be normalized.
+                The value of this keyword MUST be a <xref target="RFC3986">URI</xref>
+                (containing a scheme) and this URI MUST be normalized.
                 The current schema MUST be valid against the meta-schema identified by this URI.
             </t>
             <t>


### PR DESCRIPTION
The value of "$schema" is not required to be an absolute URI
as defined by RFC 3986 (with a scheme, but no fragment).  It just
needs to be a URI and not a relative reference.

This is particularly important as the meta-schemas include
an empty fragment in their id URIs, which would be illegal if
RFC 3986 section 4.3 Absolute URIs were required.