### PR TITLE
Standardize format of meta-schemas.

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -2,48 +2,46 @@
     "$schema": "http://json-schema.org/draft/hyper-schema#",
     "id": "http://json-schema.org/draft/hyper-schema#",
     "title": "JSON Hyper-Schema",
-    "allOf": [
-        {"$ref": "http://json-schema.org/draft-04/schema#"}
-    ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [
-                {"type": "boolean"},
-                {"$ref": "#"}
+                { "type": "boolean" },
+                { "$ref": "#" }
             ]
         },
         "additionalProperties": {
             "anyOf": [
-                {"type": "boolean"},
-                {"$ref": "#"}
+                { "type": "boolean" },
+                { "$ref": "#" }
             ]
         },
         "dependencies": {
             "additionalProperties": {
                 "anyOf": [
-                    {"$ref": "#"},
-                    {"type": "array"}
+                    { "$ref": "#" },
+                    { "type": "array" }
                 ]
             }
         },
         "items": {
             "anyOf": [
-                {"$ref": "#"},
-                {"$ref": "#/definitions/schemaArray"}
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
             ]
         },
         "definitions": {
-            "additionalProperties": {"$ref": "#"}
+            "additionalProperties": { "$ref": "#" }
         },
         "patternProperties": {
-            "additionalProperties": {"$ref": "#"}
+            "additionalProperties": { "$ref": "#" }
         },
         "properties": {
-            "additionalProperties": {"$ref": "#"}
+            "additionalProperties": { "$ref": "#" }
         },
-        "allOf": {"$ref": "#/definitions/schemaArray"},
-        "anyOf": {"$ref": "#/definitions/schemaArray"},
-        "oneOf": {"$ref": "#/definitions/schemaArray"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" },
 
         "base": {
@@ -52,7 +50,7 @@
         },
         "links": {
             "type": "array",
-            "items": {"$ref": "#/definitions/linkDescription"}
+            "items": { "$ref": "#/definitions/linkDescription" }
         },
         "media": {
             "type": "object",
@@ -66,17 +64,26 @@
                     "type": "string"
                 }
             }
+        },
+        "readOnly": {
+            "description": "If true, indicates that the value of this property is controlled by the server.",
+            "type": "boolean",
+            "default": "false"
         }
     },
     "definitions": {
         "schemaArray": {
-            "type": "array",
-            "items": {"$ref": "#"}
+            "allOf": [
+                { "$ref": "http://json-schema.org/drafts/schema" },
+                {
+                    "items": { "$ref": "#" }
+                }
+            ]
         },
         "linkDescription": {
             "title": "Link Description Object",
             "type": "object",
-            "required": ["href"],
+            "required": [ "href" ],
             "properties": {
                 "href": {
                     "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
@@ -92,7 +99,7 @@
                 },
                 "targetSchema": {
                     "description": "JSON Schema describing the link target",
-                    "$ref": "#"
+                    "allOf": [ { "$ref": "#" } ]
                 },
                 "mediaType": {
                     "description": "media type (as defined by RFC 2046) describing the link target",
@@ -109,7 +116,7 @@
                 },
                 "schema": {
                     "description": "Schema describing the data to submit along with the request",
-                    "$ref": "#"
+                    "allOf": [ { "$ref": "#" } ]
                 }
             }
         }
@@ -118,10 +125,6 @@
         {
             "rel": "self",
             "href": "{+id}"
-        },
-        {
-            "rel": "full",
-            "href": "{+($ref)}"
         }
     ]
 }

--- a/links.json
+++ b/links.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft/hyper-schema#",
+    "id": "http://json-schema.org/draft/links#",
+    "title": "Link Description Object",
+    "type": "object",
+    "required": [ "href" ],
+    "properties": {
+        "href": {
+            "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+            "type": "string"
+        },
+        "rel": {
+            "description": "relation to the target resource of the link",
+            "type": "string"
+        },
+        "title": {
+            "description": "a title for the link",
+            "type": "string"
+        },
+        "targetSchema": {
+            "description": "JSON Schema describing the link target",
+            "allOf": [ { "$ref": "hyper-schema#" } ]
+        },
+        "mediaType": {
+            "description": "media type (as defined by RFC 2046) describing the link target",
+            "type": "string"
+        },
+        "method": {
+                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
+            "type": "string"
+        },
+        "encType": {
+            "description": "The media type in which to submit data along with the request",
+            "type": "string",
+            "default": "application/json"
+        },
+        "schema": {
+            "description": "Schema describing the data to submit along with the request",
+            "allOf": [ { "$ref": "hyper-schema#" } ]
+        }
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
-    "id": "http://json-schema.org/draft/schema#",
     "$schema": "http://json-schema.org/draft/schema#",
-    "description": "Core schema meta-schema",
+    "id": "http://json-schema.org/draft/schema#",
+    "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
             "type": "array",
@@ -19,7 +19,15 @@
             ]
         },
         "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
         },
         "stringArray": {
             "type": "array",


### PR DESCRIPTION
This brings formatting and most of the initial field ordering
in line with the Draft 05 meta-schemas proposed in the web site
repo.

Also ensure that hyper-schema's definition of "schemaArray"
cannot get out of sync with schema's, and add the link schema.