### PR TITLE
Move hyper-schema definitions to top.

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -2,6 +2,56 @@
     "$schema": "http://json-schema.org/draft/hyper-schema#",
     "id": "http://json-schema.org/draft/hyper-schema#",
     "title": "JSON Hyper-Schema",
+    "definitions": {
+        "schemaArray": {
+            "allOf": [
+                { "$ref": "http://json-schema.org/drafts/schema" },
+                {
+                    "items": { "$ref": "#" }
+                }
+            ]
+        },
+        "linkDescription": {
+            "title": "Link Description Object",
+            "type": "object",
+            "required": [ "href" ],
+            "properties": {
+                "href": {
+                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
+                    "type": "string"
+                },
+                "rel": {
+                    "description": "relation to the target resource of the link",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "a title for the link",
+                    "type": "string"
+                },
+                "targetSchema": {
+                    "description": "JSON Schema describing the link target",
+                    "allOf": [ { "$ref": "#" } ]
+                },
+                "mediaType": {
+                    "description": "media type (as defined by RFC 2046) describing the link target",
+                    "type": "string"
+                },
+                "method": {
+                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
+                    "type": "string"
+                },
+                "encType": {
+                    "description": "The media type in which to submit data along with the request",
+                    "type": "string",
+                    "default": "application/json"
+                },
+                "schema": {
+                    "description": "Schema describing the data to submit along with the request",
+                    "allOf": [ { "$ref": "#" } ]
+                }
+            }
+        }
+    },
     "allOf": [ { "$ref": "http://json-schema.org/draft/schema#" } ],
     "properties": {
         "additionalItems": {
@@ -69,56 +119,6 @@
             "description": "If true, indicates that the value of this property is controlled by the server.",
             "type": "boolean",
             "default": "false"
-        }
-    },
-    "definitions": {
-        "schemaArray": {
-            "allOf": [
-                { "$ref": "http://json-schema.org/drafts/schema" },
-                {
-                    "items": { "$ref": "#" }
-                }
-            ]
-        },
-        "linkDescription": {
-            "title": "Link Description Object",
-            "type": "object",
-            "required": [ "href" ],
-            "properties": {
-                "href": {
-                    "description": "a URI template, as defined by RFC 6570, with the addition of the $, ( and ) characters for pre-processing",
-                    "type": "string"
-                },
-                "rel": {
-                    "description": "relation to the target resource of the link",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "a title for the link",
-                    "type": "string"
-                },
-                "targetSchema": {
-                    "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "mediaType": {
-                    "description": "media type (as defined by RFC 2046) describing the link target",
-                    "type": "string"
-                },
-                "method": {
-                    "description": "specifies that the client can construct a templated query (\"get\") or non-idempotent request (\"post\") to a resource.",
-                    "type": "string"
-                },
-                "encType": {
-                    "description": "The media type in which to submit data along with the request",
-                    "type": "string",
-                    "default": "application/json"
-                },
-                "schema": {
-                    "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
-                }
-            }
         }
     },
     "links": [


### PR DESCRIPTION
This brings it in line with the core/validation meta-schema and
with the standardized format proposed for Draft 05.