### PR TITLE
Restore exclusive* dependencies, update metaschema

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -258,6 +258,9 @@
                     The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance, or a boolean. Schemas SHOULD NOT use the boolean form.
                 </t>
                 <t>
+                    If "exclusiveMaximum" is a boolean, then "maximum" MUST be present, and "exclusiveMinimum" (if present) MUST also be a boolean.
+                </t>
+                <t>
                     <cref>The boolean form of "exclusiveMaximum" is expected to be removed in the future.</cref>
                 </t>
                 <t>
@@ -279,6 +282,9 @@
             <section title="exclusiveMinimum">
                 <t>
                     The value of "exclusiveMinimum" MUST be number, representing an exclusive upper limit for a numeric instance, or a boolean. Schemas SHOULD NOT use the boolean form.
+                </t>
+                <t>
+                    If "exclusiveMinimum" is a boolean, then "minimum" MUST be present, and "exclusiveMaximum" (if present) MUST also be a boolean.
                 </t>
                 <t>
                     <cref>The boolean form of "exclusiveMinimum" is expected to be removed in the future.</cref>

--- a/schema.json
+++ b/schema.json
@@ -54,23 +54,38 @@
         "default": {},
         "multipleOf": {
             "type": "number",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0
         },
         "maximum": {
             "type": "number"
         },
-        "exclusiveMaximum": {
-            "type": "boolean",
-            "default": false
-        },
         "minimum": {
             "type": "number"
         },
-        "exclusiveMinimum": {
-            "type": "boolean",
-            "default": false
-        },
+        "oneOf": [
+            {
+                "exclusiveMaximum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "number"
+                }
+            },
+            {
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "dependencies": {
+                    "exclusiveMaximum": [ "maximum" ],
+                    "exclusiveMinimum": [ "minimum" ]
+                }
+            }
+        ],
         "maxLength": { "$ref": "#/definitions/positiveInteger" },
         "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
         "pattern": {
@@ -143,10 +158,6 @@
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" }
-    },
-    "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
     },
     "default": {}
 }


### PR DESCRIPTION
This restores dependencies that got dropped somewhere between
draft 04 and 05 (not clear where), superseding both the 4th
commit of #168 and also #185.

It adds a reasonable restriction that the boolean vs numeric
forms not be mixed for exclusiveMinimum and exclusiveMaximum,
and implements the correct meta-scheam for this.  Which needs
a oneOf to corectly group the dependencies, but no longer needs
an extra allOf or anyOf to allow minimum and maximum to change
types independently.