### PR TITLE
String arrays default to empty.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -461,6 +461,10 @@
                     An object instance is valid against this keyword if its
                     property set contains all elements in this keyword's array value.
                 </t>
+                <t>
+                    If this keyword is not present, it may be considered present
+                    as an empty array.
+                </t>
             </section>
 
             <section title="properties">
@@ -604,7 +608,7 @@
             </section>
 
             <section title="anyOf">
-                    <t>
+                <t>
                     This keyword's value MUST be an array. This array MUST have at least one
                     element.
                 </t>

--- a/schema.json
+++ b/schema.json
@@ -32,7 +32,8 @@
         "stringArray": {
             "type": "array",
             "items": { "type": "string" },
-            "uniqueItems": true
+            "uniqueItems": true,
+            "defaultItems": []
         }
     },
     "type": "object",


### PR DESCRIPTION
Also, be clear about the defaulting in the description for "required".

This comes from https://github.com/json-schema-org/json-schema-spec/issues/69#issuecomment-262079319