### PR TITLE
Wording clarifications in general considerations.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -191,7 +191,11 @@
                 </t>
             </section>
 
-            <section title="Missing keywords">
+            <section title="Constraints and missing keywords">
+                <t>
+                    Each JSON Schema validation keyword adds constraints that
+                    an instance must satisfy in order to successfully validate.
+                </t>
                 <t>
                     Validation keywords that are missing never restrict validation.
                     In some cases, this no-op behavior is identical to a keyword that exists with certain values,
@@ -199,13 +203,13 @@
                 </t>
             </section>
 
-            <section title="Linearity">
-                <!-- I call this "linear" in the same manner e.g. waves are linear, they don't interact with each other -->
+            <section title="Keyword independence">
                 <t>
-                    Validation keywords typically operate independent of each other, without affecting each other.
+                    Validation keywords typically operate independently, without
+                    affecting each other's outcomes.
                 </t>
                 <t>
-                    For author convenience, there are some exceptions:
+                    For schema author convenience, there are some exceptions:
                     <list>
                         <t>"additionalProperties", whose behavior is defined in terms of "properties" and "patternProperties";</t>
                         <t>"additionalItems", whose behavior is defined in terms of "items"; and</t>


### PR DESCRIPTION
These are the leftover bits of Issue #55 and some clarifications
requested in a comment on issue #101 that have not already been
added in some other PR for some other issue.

These specific chagnes were previously approved in #143, but so
many other things have changed since #143 that most of it was
no longer relevant, so I closed it and started these changes over.

In particular, explaining {} and {"not": {}} is no longer needed
as they are covered while introducing "true" and "false" schemas
in the core specification, so that is no longer included in this
change.

Likewise, the parent/child validation descriptions have been
modified in several PRs and no longer has the problems that were
previously a concern.