### PR TITLE
Remove boolean form of exclusive* keywords.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -213,7 +213,6 @@
                     <list>
                         <t>"additionalProperties", whose behavior is defined in terms of "properties" and "patternProperties";</t>
                         <t>"additionalItems", whose behavior is defined in terms of "items"; and</t>
-                        <t>"minimum" and "maximum", whose behavior may change for a special value of "exclusiveMinimum" and "exclusiveMaximum", respectively.</t>
                     </list>
                 </t>
             </section>
@@ -248,21 +247,16 @@
                     The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.
                 </t>
                 <t>
-                    If "exclusiveMaximum" is true, see the validation rules for that keyword instead.
-                    Else if the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".
+                    If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".
                 </t>
             </section>
 
             <section title="exclusiveMaximum">
                 <t>
-                    The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance, or a boolean. Schemas SHOULD NOT use the boolean form.
+                    The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance.
                 </t>
                 <t>
-                    <cref>The boolean form of "exclusiveMaximum" is expected to be removed in the future.</cref>
-                </t>
-                <t>
-                    If "exclusiveMaximum" is true, "maximum" is a number, and the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "maximum".
-                    Else if "exclusiveMaximum" is a number and the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".
+                    If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".
                 </t>
             </section>
 
@@ -271,21 +265,16 @@
                     The value of "minimum" MUST be a number, representing an inclusive upper limit for a numeric instance.
                 </t>
                 <t>
-                    If "exclusiveMinimum" is true, see the validation rules for that keyword instead.
-                    Else if the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".
+                    If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".
                 </t>
             </section>
 
             <section title="exclusiveMinimum">
                 <t>
-                    The value of "exclusiveMinimum" MUST be number, representing an exclusive upper limit for a numeric instance, or a boolean. Schemas SHOULD NOT use the boolean form.
+                    The value of "exclusiveMinimum" MUST be number, representing an exclusive upper limit for a numeric instance.
                 </t>
                 <t>
-                    <cref>The boolean form of "exclusiveMinimum" is expected to be removed in the future.</cref>
-                </t>
-                <t>
-                    If "exclusiveMinimum" is true, "minimum" is a number, and the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "minimum".
-                    Else if "exclusiveMinimum" is a number and the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".
+                    If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".
                 </t>
             </section>
 
@@ -691,8 +680,7 @@
     "definitions": {
         "positiveInteger": {
             "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0,
         }
     }
 }

--- a/schema.json
+++ b/schema.json
@@ -54,22 +54,19 @@
         "default": {},
         "multipleOf": {
             "type": "number",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0
         },
         "maximum": {
             "type": "number"
         },
         "exclusiveMaximum": {
-            "type": "boolean",
-            "default": false
+            "type": "number"
         },
         "minimum": {
             "type": "number"
         },
         "exclusiveMinimum": {
-            "type": "boolean",
-            "default": false
+            "type": "number"
         },
         "maxLength": { "$ref": "#/definitions/positiveInteger" },
         "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
@@ -143,10 +140,6 @@
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" }
-    },
-    "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
     },
     "default": {}
 }


### PR DESCRIPTION
Yet another alternative to #185 and #189.  This just drops the boolean keywords and does the minimal changes necessary to implement that.

@epoberezkin, if you want to make it impossible for both `minimum` and `exclusiveMinimum` to appear together (and likewise for `maximum` and `exclusiveMaximum`) could you please file that as a separate issue like you did with the `items` and `additionalItems` dependencies?  All of those cases are ones that work without the dependencies but could be more helpful with, so let's discuss that whole concept on its own.  Maybe even just broaden #209 to cover all of these meta-schema dependency questions?  Then we could sort it all out at once and if it gets sorted before this gets merged (if it ever does) I will update this patch accordingly.