### PR TITLE
Update jsonschema-hyperschema.xml

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -813,9 +813,11 @@ GET /foo/
         "encType": "application/x-www-form-urlencoded",
         "method": "get",
         "href": "/Product/",
-        "properties": {
-            "name": {
-                "description": "name of the product"
+        "schema": {
+            "properties": {
+                "name": {
+                    "description": "name of the product"
+                }
             }
         }
     }]


### PR DESCRIPTION
According to https://github.com/json-schema-org/json-schema-org.github.io/blob/master/draft-04/links it is not possible to have a `properties` field inside a link description object.