### PR TITLE
Standardize on hyphenated format names

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -19,7 +19,7 @@
                 "href": {
                     "description": "a URI template, as defined by RFC 6570",
                     "type": "string",
-                    "format": "uritemplate"
+                    "format": "uri-template"
                 },
                 "hrefSchema": {
                     "description": "a schema for validating user input to the URI template, where the input is in the form of a JSON object with property names matching variable names in \"href\"",

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -849,7 +849,7 @@
                     </t>
                 </section>
 
-                <section title="uriref">
+                <section title="uri-reference">
                     <t>
                         This attribute applies to string instances.
                     </t>
@@ -859,7 +859,7 @@
                     </t>
                 </section>
 
-                <section title="uritemplate">
+                <section title="uri-template">
                     <t>
                         This attribute applies to string instances.
                     </t>
@@ -869,7 +869,7 @@
                     </t>
                 </section>
 
-                <section title="jsonpointer">
+                <section title="json-pointer">
                     <t>
                         This attribute applies to string instances.
                     </t>
@@ -965,6 +965,7 @@
                 <list style="hanging">
                     <t hangText="draft-wright-json-schema-validation-01">
                         <list style="symbols">
+                            <t>Standardized on hyphenated format names</t>
                             <t>Split apart additionalItems/items</t>
                             <t>Reworked properties/patternProperties/additionalProperties definition</t>
                             <t>Added "examples" keyword</t>

--- a/links.json
+++ b/links.json
@@ -8,7 +8,7 @@
         "href": {
             "description": "a URI template, as defined by RFC 6570",
             "type": "string",
-            "format": "uritemplate"
+            "format": "uri-template"
         },
         "hrefSchema": {
             "description": "a schema for validating user input to the URI template, where the input is in the form of a JSON object with property names matching variable names in \"href\"",

--- a/schema.json
+++ b/schema.json
@@ -40,7 +40,7 @@
     "properties": {
         "$id": {
             "type": "string",
-            "format": "uriref"
+            "format": "uri-reference"
         },
         "$schema": {
             "type": "string",
@@ -48,7 +48,7 @@
         },
         "$ref": {
             "type": "string",
-            "format": "uriref"
+            "format": "uri-reference"
         },
         "title": {
             "type": "string"


### PR DESCRIPTION
When we had more formats in earlier drafts, all compound names
(such as "date-time") were hyphenated.  Draft 05 added "uriref"
without a hyphen, which started looking weird when we added
"uritemplate" and "jsonpointer" without hyphens to match it.
This makes everything hyphenated (note "hostname" was deemed
to be a single word in this context).

Addresses issue #207.