### PR TITLE
Correct "mediaType" to "type" in example.

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -331,7 +331,7 @@
 {
     "type": "string",
     "media": {
-        "mediaType": "text/html"
+        "type": "text/html"
     }
 }
 ]]>


### PR DESCRIPTION
"mediaType" is an LDO keyword.  The keyword in the "media" object
is just plain "type".