### PR TITLE
Another attempt at clarifying objects/arrays.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -159,31 +159,6 @@
 
         <section title="General validation considerations">
 
-            <section title="Keywords and instance primitive types">
-                <t>
-                    Most validation keywords only constrain values within a certain primitive type.
-                    When the type of the instance is not of the type targeted by the keyword, the
-                    validation succeeds.
-                </t>
-                <t>
-                    For example, the "maxLength" keyword will only restrict certain strings (that are too long) from being valid.
-                    If the instance is a number, boolean, null, array, or object, the keyword passes validation.
-                </t>
-            </section>
-
-            <section title="Validation of primitive types and child values">
-                <t>
-                    Two of the primitive types, array and object, allow for child values.
-                    The validation of the primitive type is considered separately from
-                    the validation of child instances.
-                </t>
-                <t>
-                    Note that while array elements are validated by at most one
-                    subschema, object property values may be validated by several
-                    subschemas from "properties" and "patternProperties".
-                </t>
-            </section>
-
             <section title="Constraints and missing keywords">
                 <t>
                     Each JSON Schema validation keyword adds constraints that
@@ -227,6 +202,11 @@
             </t>
 
             <section title="Validation keywords for numeric instances (number and integer)">
+                <t>
+                    These keywords apply only to numbers (including integers).
+                    Validation of other types against these keywords always succeeds.
+                </t>
+
                 <section title="multipleOf">
                     <t>
                         The value of "multipleOf" MUST be a number, strictly greater than 0.
@@ -274,6 +254,10 @@
             </section>
 
             <section title="Validation keywords for strings">
+                <t>
+                    These keywords apply only to strings.  Validation
+                    of other types against these keywords always succeeds.
+                </t>
 
                 <section title="maxLength">
                     <t>
@@ -320,9 +304,11 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for arrays as primitive types">
+            <section title="Validation keywords for arrays">
                 <t>
-                    These keywords validate characteristics of arrays independent of their contents.
+                    These keywords validate characteristics of arrays as a whole,
+                    rather than validating specific array elements.
+                    Validation of other instance types against these keywords always succeeds.
                 </t>
 
                 <section title="maxItems">
@@ -347,22 +333,7 @@
                         Omitting this keyword has the same behavior as a value of 0.
                     </t>
                 </section>
-            </section>
 
-            <section title="Validation keywords for array contents">
-                <t>
-                    These keywords validate conditions, specifically existence and uniqueness, across all array contents.
-                </t>
-                <section title="contains">
-                    <t>
-                        The value of this keyword MUST be an object.  This object MUST be
-                        a valid JSON Schema.
-                    </t>
-                    <t>
-                        An array instance is valid against "contains" if at least one of
-                        its elements is valid against the given schema.
-                    </t>
-                </section>
                 <section title="uniqueItems">
                     <t>
                         The value of this keyword MUST be a boolean.
@@ -376,26 +347,34 @@
                         Omitting this keyword has the same behavior as a value of false.
                     </t>
                 </section>
+
+                <section title="contains">
+                    <t>
+                        The value of this keyword MUST be an object.  This object MUST be
+                        a valid JSON Schema.
+                    </t>
+                    <t>
+                        An array instance is valid against "contains" if at least one of
+                        its elements is valid against the given schema.
+                    </t>
+                </section>
             </section>
 
             <section title="Validating array elements with subschemas">
                 <t>
                     These keywords determine which subschemas apply to each element of an array.
+                    Validation of other instance types against these keywords always succeeds.
                 </t>
                 <section title="items">
                     <t>
                         The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
                     </t>
                     <t>
-                        This keyword determines how child instances validate for arrays,
-                        and does not directly validate the immediate instance itself.
-                    </t>
-                    <t>
-                        If "items" is a schema, child validation succeeds if all elements
+                        If "items" is a schema, validation succeeds if all elements
                         in the array successfully validate against that schema.
                     </t>
                     <t>
-                        If "items" is an array of schemas, child validation succeeds if
+                        If "items" is an array of schemas, validation succeeds if
                         each element of the instance validates against the schema at the
                         same position, if any.
                     </t>
@@ -409,18 +388,16 @@
                         The value of "additionalItems" MUST be a valid JSON Schema.
                     </t>
                     <t>
-                        This keyword determines how child instances validate for arrays,
-                        and does not directly validate the immediate instance itself.
-                    </t>
-                    <t>
-                        If "items" is an array of schemas, child validation succeeds
-                        if every instance element at a position greater than the size
-                        of "items" validates against "additionalItems".
+                        If "items" is an array of schemas, validation against
+                        "additionalItems" succeeds if every instance element at
+                        a position greater than the size of "items" validates
+                        against the "additionalItems" schema.
                     </t>
                     <t>
                         Otherwise, "additionalItems" MUST be ignored, as the "items"
-                        schema (possibly the default value of an empty schema) is
-                        applied to all elements.
+                        schema is applied to all elements.  Since omitting "items"
+                        has the same behavior as an empty "items" schema, "additonalItems"
+                        MUST be ignored if "items" is omitted.
                     </t>
                     <t>
                         Omitting this keyword has the same behavior as an empty schema.
@@ -428,9 +405,10 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for objects as primitive types">
+            <section title="Validation keywords for objects">
                 <t>
                     These keywords validate characteristics of objects independent of the values of their properties.
+                    Validation of other instance types against these keywords always succeeds.
                 </t>
 
                 <section title="maxProperties">
@@ -490,6 +468,7 @@
             <section title="Validating object properties with subschemas">
                 <t>
                     These keywords determine which subschemas apply to each property of an object.
+                    Validation of other instance types against these keywords always succeeds.
                 </t>
 
                 <section title="properties">
@@ -498,11 +477,7 @@
                         Each value of this object MUST be a valid JSON Schema.
                     </t>
                     <t>
-                        This keyword determines how child instances validate for objects,
-                        and does not directly validate the immediate instance itself.
-                    </t>
-                    <t>
-                        Child validation succeeds if, for each name that appears in both
+                        Validation succeeds if, for each name that appears in both
                         the instance and as a name within this keyword's value, the child
                         instance for that name successfully validates against the
                         corresponding schema.
@@ -520,13 +495,7 @@
                         MUST be a valid JSON Schema.
                     </t>
                     <t>
-                        This keyword determines how child instances validate for objects,
-                        and does not directly validate the immediate instance itself.
-                        Validation of the primitive instance type against this keyword
-                        always succeeds.
-                    </t>
-                    <t>
-                        Child validation succeeds if, for each instance name that matches any
+                        Validation succeeds if, for each instance property name that matches any
                         regular expressions that appear as a property name in this keyword's value,
                         the child instance for that name successfully validates against each
                         schema that corresponds to a matching regular expression.
@@ -541,17 +510,11 @@
                         The value of "additionalProperties" MUST be a valid JSON Schema.
                     </t>
                     <t>
-                        This keyword determines how child instances validate for objects,
-                        and does not directly validate the immediate instance itself.
-                    </t>
-                    <t>
-                        Child validation with "additionalProperties" applies only to the child
-                        values of instance names that do not match any names in "properties",
-                        and do not match any regular expression in "patternProperties".
-                    </t>
-                    <t>
-                        For all such properties, child validation succeeds if the child instance
-                        validates against the "additionalProperties" schema.
+                        Validation succeeds if, for each instance property name
+                        that does not match any names in "properties",
+                        and does not match any regular expression in "patternProperties",
+                        the child instance for that name successfully validates against
+                        the "additionalProperties" schema.
                     </t>
                     <t>
                         Omitting this keyword has the same behavior as an empty schema.
@@ -564,6 +527,8 @@
                     <t>
                         This keyword specifies rules that are evaluated if the instance is an object and
                         contains a certain property.
+                        Validation against instances of types other than object
+                        always succeeds.
                     </t>
                     <t>
                         This keyword's value MUST be an object. Each property specifies a dependency.

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -584,7 +584,7 @@
                         </t>
 
                         <t>
-                            Elements in the array MAY be of any type, including null.
+                            Elements in the array might be of any value, including null.
                         </t>
                         <t>
                             An instance validates successfully against this keyword if its value is

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -12,6 +12,7 @@
 <!ENTITY RFC7159 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7159.xml">
 ]>
 <?rfc toc="yes"?>
+<?rfc tocdepth="4"?>
 <?rfc symrefs="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
@@ -51,8 +52,9 @@
         <abstract>
             <t>
                 JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.
-                This document specifies a vocabulary for JSON Schema to describe the structure of JSON documents,
-                and provide hints for user interfaces working with JSON data.
+                This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents,
+                provide hints for user interfaces working with JSON data,
+                and to make assertions about what a valid document must look like.
             </t>
         </abstract>
 
@@ -306,337 +308,351 @@
 
             <section title="Validation keywords for arrays">
                 <t>
-                    These keywords validate characteristics of arrays as a whole,
-                    rather than validating specific array elements.
-                    Validation of other instance types against these keywords always succeeds.
+                    These keywords apply only to arrays.  Validation of other
+                    instance types against these keywords always succeeds.
                 </t>
+                <section title="Basic array validation keywords">
+                    <t>
+                        These keywords validate characteristics of arrays as a whole,
+                        rather than validating specific array elements.
+                    </t>
 
-                <section title="maxItems">
-                    <t>
-                        The value of this keyword MUST be a non-negative integer.
-                    </t>
-                    <t>
-                        An array instance is valid against "maxItems" if its size is
-                        less than, or equal to, the value of this keyword.
-                    </t>
+                    <section title="maxItems">
+                        <t>
+                            The value of this keyword MUST be a non-negative integer.
+                        </t>
+                        <t>
+                            An array instance is valid against "maxItems" if its size is
+                            less than, or equal to, the value of this keyword.
+                        </t>
+                    </section>
+
+                    <section title="minItems">
+                        <t>
+                            The value of this keyword MUST be a non-negative integer.
+                        </t>
+                        <t>
+                            An array instance is valid against "minItems" if its size is
+                            greater than, or equal to, the value of this keyword.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as a value of 0.
+                        </t>
+                    </section>
+
+                    <section title="uniqueItems">
+                        <t>
+                            The value of this keyword MUST be a boolean.
+                        </t>
+                        <t>
+                            If this keyword has boolean value false, the instance validates
+                            successfully. If it has boolean value true, the instance validates
+                            successfully if all of its elements are unique.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as a value of false.
+                        </t>
+                    </section>
                 </section>
 
-                <section title="minItems">
+                <section title="Validating array elements with subschemas">
                     <t>
-                        The value of this keyword MUST be a non-negative integer.
+                        These keywords determine which subschemas apply to each element of an array,
+                        and can be used to apply other schema vocabularies to child instances.
                     </t>
-                    <t>
-                        An array instance is valid against "minItems" if its size is
-                        greater than, or equal to, the value of this keyword.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as a value of 0.
-                    </t>
-                </section>
+                    <section title="items">
+                        <t>
+                            The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
+                        </t>
+                        <t>
+                            If "items" is a schema, validation succeeds if all elements
+                            in the array successfully validate against that schema.
+                        </t>
+                        <t>
+                            If "items" is an array of schemas, validation succeeds if
+                            each element of the instance validates against the schema at the
+                            same position, if any.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty schema.
+                        </t>
+                    </section>
 
-                <section title="uniqueItems">
-                    <t>
-                        The value of this keyword MUST be a boolean.
-                    </t>
-                    <t>
-                        If this keyword has boolean value false, the instance validates
-                        successfully. If it has boolean value true, the instance validates
-                        successfully if all of its elements are unique.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as a value of false.
-                    </t>
-                </section>
-            </section>
+                    <section title="additionalItems">
+                        <t>
+                            The value of "additionalItems" MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            If "items" is an array of schemas, validation against
+                            "additionalItems" succeeds if every instance element at
+                            a position greater than the size of "items" validates
+                            against the "additionalItems" schema.
+                        </t>
+                        <t>
+                            Otherwise, "additionalItems" MUST be ignored, as the "items"
+                            schema is applied to all elements.  Since omitting "items"
+                            has the same behavior as an empty "items" schema, "additionalItems"
+                            MUST be ignored if "items" is omitted.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty schema.
+                        </t>
+                    </section>
 
-            <section title="Validating array elements with subschemas">
-                <t>
-                    These keywords determine which subschemas apply to each element of an array.
-                    Validation of other instance types against these keywords always succeeds.
-                </t>
-                <section title="items">
-                    <t>
-                        The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
-                    </t>
-                    <t>
-                        If "items" is a schema, validation succeeds if all elements
-                        in the array successfully validate against that schema.
-                    </t>
-                    <t>
-                        If "items" is an array of schemas, validation succeeds if
-                        each element of the instance validates against the schema at the
-                        same position, if any.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty schema.
-                    </t>
-                </section>
-
-                <section title="additionalItems">
-                    <t>
-                        The value of "additionalItems" MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        If "items" is an array of schemas, validation against
-                        "additionalItems" succeeds if every instance element at
-                        a position greater than the size of "items" validates
-                        against the "additionalItems" schema.
-                    </t>
-                    <t>
-                        Otherwise, "additionalItems" MUST be ignored, as the "items"
-                        schema is applied to all elements.  Since omitting "items"
-                        has the same behavior as an empty "items" schema, "additonalItems"
-                        MUST be ignored if "items" is omitted.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty schema.
-                    </t>
-                </section>
-
-                <section title="contains">
-                    <t>
-                        The value of this keyword MUST be an object.  This object MUST be
-                        a valid JSON Schema.
-                    </t>
-                    <t>
-                        An array instance is valid against "contains" if at least one of
-                        its elements is valid against the given schema.
-                    </t>
+                    <section title="contains">
+                        <t>
+                            The value of this keyword MUST be an object.  This object MUST be
+                            a valid JSON Schema.
+                        </t>
+                        <t>
+                            An array instance is valid against "contains" if at least one of
+                            its elements is valid against the given schema.
+                        </t>
+                    </section>
                 </section>
             </section>
 
             <section title="Validation keywords for objects">
                 <t>
-                    These keywords validate characteristics of objects independent of the values of their properties.
-                    Validation of other instance types against these keywords always succeeds.
+                    These keywords apply only to objects.  Validation of other
+                    instance types against these keywords always succeeds.
                 </t>
+                <section title="Basic object validation keywords">
+                    <t>
+                        These keywords validate characteristics of objects
+                        independent of the values of their properties.
+                    </t>
 
-                <section title="maxProperties">
-                    <t>
-                        The value of this keyword MUST be a non-negative integer.
-                    </t>
-                    <t>
-                        An object instance is valid against "maxProperties" if its
-                        number of properties is less than, or equal to, the value of this
-                        keyword.
-                    </t>
+                    <section title="maxProperties">
+                        <t>
+                            The value of this keyword MUST be a non-negative integer.
+                        </t>
+                        <t>
+                            An object instance is valid against "maxProperties" if its
+                            number of properties is less than, or equal to, the value of this
+                            keyword.
+                        </t>
+                    </section>
+
+                    <section title="minProperties">
+                        <t>
+                            The value of this keyword MUST be a non-negative integer.
+                        </t>
+                        <t>
+                            An object instance is valid against "minProperties" if its
+                            number of properties is greater than, or equal to, the value of this
+                            keyword.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as a value of 0.
+                        </t>
+                    </section>
+
+                    <section title="required">
+                        <t>
+                            The value of this keyword MUST be an array.
+                            Elements of this array, if any, MUST be strings, and MUST be unique.
+                        </t>
+                        <t>
+                            An object instance is valid against this keyword if every item in the array
+                            is the name of a property in the instance.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty array.
+                        </t>
+                    </section>
                 </section>
 
-                <section title="minProperties">
+                <section title="Validating objects with subschemas">
                     <t>
-                        The value of this keyword MUST be a non-negative integer.
+                        These keywords determine which subschemas apply to an object,
+                        its property name set, or specific property values within the object.
+                        They can be used to apply other schema vocabularies to objects, their property names, or property values.
                     </t>
-                    <t>
-                        An object instance is valid against "minProperties" if its
-                        number of properties is greater than, or equal to, the value of this
-                        keyword.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as a value of 0.
-                    </t>
-                </section>
 
-                <section title="required">
-                    <t>
-                        The value of this keyword MUST be an array.
-                        Elements of this array, if any, MUST be strings, and MUST be unique.
-                    </t>
-                    <t>
-                        An object instance is valid against this keyword if every item in the array
-                        is the name of a property in the instance.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty array.
-                    </t>
-                </section>
-            </section>
+                    <section title="properties">
+                        <t>
+                            The value of "properties" MUST be an object.
+                            Each value of this object MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            Validation succeeds if, for each name that appears in both
+                            the instance and as a name within this keyword's value, the child
+                            instance for that name successfully validates against the
+                            corresponding schema.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty object.
+                        </t>
+                    </section>
 
-            <section title="Validating objects with subschemas">
-                <t>
-                    These keywords determine which subschemas apply to each property of an object.
-                    Validation of other instance types against these keywords always succeeds.
-                </t>
+                    <section title="patternProperties">
+                        <t>
+                            The value of "patternProperties" MUST be an object. Each property name
+                            of this object SHOULD be a valid regular expression, according to the
+                            ECMA 262 regular expression dialect. Each property value of this object
+                            MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            Validation succeeds if, for each instance property name that matches any
+                            regular expressions that appear as a property name in this keyword's value,
+                            the child instance for that name successfully validates against each
+                            schema that corresponds to a matching regular expression.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty object.
+                        </t>
+                    </section>
 
-                <section title="properties">
-                    <t>
-                        The value of "properties" MUST be an object.
-                        Each value of this object MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        Validation succeeds if, for each name that appears in both
-                        the instance and as a name within this keyword's value, the child
-                        instance for that name successfully validates against the
-                        corresponding schema.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty object.
-                    </t>
-                </section>
+                    <section title="additionalProperties">
+                        <t>
+                            The value of "additionalProperties" MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            Validation succeeds if, for each instance property name
+                            that does not match any names in "properties",
+                            and does not match any regular expression in "patternProperties",
+                            the child instance for that name successfully validates against
+                            the "additionalProperties" schema.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty schema.
+                        </t>
+                    </section>
 
-                <section title="patternProperties">
-                    <t>
-                        The value of "patternProperties" MUST be an object. Each property name
-                        of this object SHOULD be a valid regular expression, according to the
-                        ECMA 262 regular expression dialect. Each property value of this object
-                        MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        Validation succeeds if, for each instance property name that matches any
-                        regular expressions that appear as a property name in this keyword's value,
-                        the child instance for that name successfully validates against each
-                        schema that corresponds to a matching regular expression.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty object.
-                    </t>
-                </section>
+                    <section title="propertyNames">
+                        <t>
+                            The value of "propertyNames" MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            If the instance is an object, this keyword validates if every property name in the instance
+                            validates against the provided schema.
+                            Note the property name that the schema is testing will always be a string.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty schema.
+                        </t>
+                    </section>
 
-                <section title="additionalProperties">
-                    <t>
-                        The value of "additionalProperties" MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        Validation succeeds if, for each instance property name
-                        that does not match any names in "properties",
-                        and does not match any regular expression in "patternProperties",
-                        the child instance for that name successfully validates against
-                        the "additionalProperties" schema.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty schema.
-                    </t>
-                </section>
-
-                <section title="propertyNames">
-                    <t>
-                        The value of "propertyNames" MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        If the instance is an object, this keyword validates if every property name in the instance
-                        validates against the provided schema.
-                        Note the property name that the schema is testing will always be a string.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty schema.
-                    </t>
-                </section>
-
-                <section title="dependencies">
-                    <t>
-                        This keyword specifies rules that are evaluated if the instance is an object and
-                        contains a certain property.
-                        Validation against instances of types other than object
-                        always succeeds.
-                    </t>
-                    <t>
-                        This keyword's value MUST be an object. Each property specifies a dependency.
-                        Each dependency value MUST be an array or a valid JSON Schema.
-                    </t>
-                    <t>
-                        If the dependency value is a subschema, and the dependency key is a property
-                        in the instance, the entire instance must validate against the dependency value.
-                    </t>
-                    <t>
-                        If the dependency value is an array, each element in the array,
-                        if any, MUST be a string, and MUST be unique. If the dependency key is
-                        a property in the instance, each of the items in the dependency
-                        value must be a property that exists in the instance.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty object.
-                    </t>
+                    <section title="dependencies">
+                        <t>
+                            This keyword specifies rules that are evaluated if the instance is an object and
+                            contains a certain property.
+                            Validation against instances of types other than object
+                            always succeeds.
+                        </t>
+                        <t>
+                            This keyword's value MUST be an object. Each property specifies a dependency.
+                            Each dependency value MUST be an array or a valid JSON Schema.
+                        </t>
+                        <t>
+                            If the dependency value is a subschema, and the dependency key is a property
+                            in the instance, the entire instance must validate against the dependency value.
+                        </t>
+                        <t>
+                            If the dependency value is an array, each element in the array,
+                            if any, MUST be a string, and MUST be unique. If the dependency key is
+                            a property in the instance, each of the items in the dependency
+                            value must be a property that exists in the instance.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty object.
+                        </t>
+                    </section>
                 </section>
             </section>
 
             <section title="Validation keywords for any instance type">
 
-                <section title="enum">
-                    <t>
-                        The value of this keyword MUST be an array. This array SHOULD have at
-                        least one element. Elements in the array SHOULD be unique.
-                    </t>
+                <section title="Basic universal validation keywords">
+                    <section title="enum">
+                        <t>
+                            The value of this keyword MUST be an array. This array SHOULD have at
+                            least one element. Elements in the array SHOULD be unique.
+                        </t>
 
-                    <t>
-                        Elements in the array MAY be of any type, including null.
-                    </t>
-                    <t>
-                        An instance validates successfully against this keyword if its value is
-                        equal to one of the elements in this keyword's array value.
-                    </t>
+                        <t>
+                            Elements in the array MAY be of any type, including null.
+                        </t>
+                        <t>
+                            An instance validates successfully against this keyword if its value is
+                            equal to one of the elements in this keyword's array value.
+                        </t>
+                    </section>
+
+                    <section title="const">
+                        <t>
+                            The value of this keyword MAY be of any type, including null.
+                        </t>
+                        <t>
+                            An instance validates successfully against this keyword if its value is
+                            equal to the value of the keyword.
+                        </t>
+                    </section>
+
+                    <section title="type">
+                        <t>
+                            The value of this keyword MUST be either a string or an array. If it is
+                            an array, elements of the array MUST be strings and MUST be unique.
+                        </t>
+                        <t>
+                            String values MUST be one of the six primitive types
+                            ("null", "boolean", "object", "array", "number", or "string"),
+                            or "integer" which matches any number with a zero fractional part.
+                        </t>
+                        <t>
+                            An instance validates if and only if the instance is in any of the sets listed for this keyword.
+                        </t>
+                    </section>
                 </section>
 
-                <section title="const">
+                <section title="Applying subschemas with boolean logic">
                     <t>
-                        The value of this keyword MAY be of any type, including null.
+                        These keywords combine or modify the validation results
+                        of their subschema(s) with boolean operations.
                     </t>
-                    <t>
-                        An instance validates successfully against this keyword if its value is
-                        equal to the value of the keyword.
-                    </t>
-                </section>
+                    <section title="allOf">
+                        <t>
+                            This keyword's value MUST be a non-empty array.
+                            Each item of the array MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            An instance validates successfully against this keyword if it validates
+                            successfully against all schemas defined by this keyword's value.
+                        </t>
+                    </section>
 
-                <section title="type">
-                    <t>
-                        The value of this keyword MUST be either a string or an array. If it is
-                        an array, elements of the array MUST be strings and MUST be unique.
-                    </t>
-                    <t>
-                        String values MUST be one of the six primitive types
-                        ("null", "boolean", "object", "array", "number", or "string"),
-                        or "integer" which matches any number with a zero fractional part.
-                    </t>
-                    <t>
-                        An instance validates if and only if the instance is in any of the sets listed for this keyword.
-                    </t>
-                </section>
-            </section>
+                    <section title="anyOf">
+                        <t>
+                            This keyword's value MUST be a non-empty array.
+                            Each item of the array MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            An instance validates successfully against this keyword if it validates
+                            successfully against at least one schema defined by this keyword's value.
+                        </t>
+                    </section>
 
-            <section title="Applying subschemas with boolean logic">
-                <t>
-                    These keywords combine or modify the validation results
-                    of their subschema(s) with boolean operations.
-                </t>
-                <section title="allOf">
-                    <t>
-                        This keyword's value MUST be a non-empty array.
-                        Each item of the array MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        An instance validates successfully against this keyword if it validates
-                        successfully against all schemas defined by this keyword's value.
-                    </t>
-                </section>
+                    <section title="oneOf">
+                        <t>
+                            This keyword's value MUST be a non-empty array.
+                            Each item of the array MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            An instance validates successfully against this keyword if it validates
+                            successfully against exactly one schema defined by this keyword's value.
+                        </t>
+                    </section>
 
-                <section title="anyOf">
-                    <t>
-                        This keyword's value MUST be a non-empty array.
-                        Each item of the array MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        An instance validates successfully against this keyword if it validates
-                        successfully against at least one schema defined by this keyword's value.
-                    </t>
-                </section>
-
-                <section title="oneOf">
-                    <t>
-                        This keyword's value MUST be a non-empty array.
-                        Each item of the array MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        An instance validates successfully against this keyword if it validates
-                        successfully against exactly one schema defined by this keyword's value.
-                    </t>
-                </section>
-
-                <section title="not">
-                    <t>
-                        This keyword's value MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        An instance is valid against this keyword if it fails to validate
-                        successfully against the schema defined by this keyword.
-                    </t>
+                    <section title="not">
+                        <t>
+                            This keyword's value MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            An instance is valid against this keyword if it fails to validate
+                            successfully against the schema defined by this keyword.
+                        </t>
+                    </section>
                 </section>
             </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -161,6 +161,18 @@
 
         <section title="General validation considerations">
 
+            <section title="Keywords and instance primitive types">
+                <t>
+                    Most validation keywords only constrain values within a certain primitive type.
+                    When the type of the instance is not of the type targeted by the keyword, the
+                    validation succeeds.
+                </t>
+                <t>
+                    For example, the "maxLength" keyword will only restrict certain strings (that are too long) from being valid.
+                    If the instance is a number, boolean, null, array, or object, the keyword passes validation.
+                </t>
+            </section>
+
             <section title="Constraints and missing keywords">
                 <t>
                     Each JSON Schema validation keyword adds constraints that

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -347,17 +347,6 @@
                         Omitting this keyword has the same behavior as a value of false.
                     </t>
                 </section>
-
-                <section title="contains">
-                    <t>
-                        The value of this keyword MUST be an object.  This object MUST be
-                        a valid JSON Schema.
-                    </t>
-                    <t>
-                        An array instance is valid against "contains" if at least one of
-                        its elements is valid against the given schema.
-                    </t>
-                </section>
             </section>
 
             <section title="Validating array elements with subschemas">
@@ -403,6 +392,17 @@
                         Omitting this keyword has the same behavior as an empty schema.
                     </t>
                 </section>
+
+                <section title="contains">
+                    <t>
+                        The value of this keyword MUST be an object.  This object MUST be
+                        a valid JSON Schema.
+                    </t>
+                    <t>
+                        An array instance is valid against "contains" if at least one of
+                        its elements is valid against the given schema.
+                    </t>
+                </section>
             </section>
 
             <section title="Validation keywords for objects">
@@ -436,20 +436,6 @@
                     </t>
                 </section>
 
-                <section title="propertyNames">
-                    <t>
-                        The value of "propertyNames" MUST be a valid JSON Schema.
-                    </t>
-                    <t>
-                        If the instance is an object, this keyword validates if every property name in the instance
-                        validates against the provided schema.
-                        Note the property name that the schema is testing will always be a string.
-                    </t>
-                    <t>
-                        Omitting this keyword has the same behavior as an empty schema.
-                    </t>
-                </section>
-
                 <section title="required">
                     <t>
                         The value of this keyword MUST be an array.
@@ -465,7 +451,7 @@
                 </section>
             </section>
 
-            <section title="Validating object properties with subschemas">
+            <section title="Validating objects with subschemas">
                 <t>
                     These keywords determine which subschemas apply to each property of an object.
                     Validation of other instance types against these keywords always succeeds.
@@ -520,9 +506,21 @@
                         Omitting this keyword has the same behavior as an empty schema.
                     </t>
                 </section>
-            </section>
 
-            <section title="Conditional validation based on object properties">
+                <section title="propertyNames">
+                    <t>
+                        The value of "propertyNames" MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        If the instance is an object, this keyword validates if every property name in the instance
+                        validates against the provided schema.
+                        Note the property name that the schema is testing will always be a string.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty schema.
+                    </t>
+                </section>
+
                 <section title="dependencies">
                     <t>
                         This keyword specifies rules that are evaluated if the instance is an object and
@@ -591,7 +589,13 @@
                         An instance validates if and only if the instance is in any of the sets listed for this keyword.
                     </t>
                 </section>
+            </section>
 
+            <section title="Applying subschemas with boolean logic">
+                <t>
+                    These keywords combine or modify the validation results
+                    of their subschema(s) with boolean operations.
+                </t>
                 <section title="allOf">
                     <t>
                         This keyword's value MUST be a non-empty array.

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -51,9 +51,8 @@
         <abstract>
             <t>
                 JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.
-                This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents,
-                provide hints for user interfaces working with JSON data,
-                and to make assertions about what a valid document must look like.
+                This document specifies a vocabulary for JSON Schema to describe the structure of JSON documents,
+                and provide hints for user interfaces working with JSON data.
             </t>
         </abstract>
 
@@ -179,21 +178,9 @@
                     the validation of child instances.
                 </t>
                 <t>
-                    For arrays, primitive type validation consists of validating
-                    restrictions on length with "minItems" and "maxItems", while
-                    "items" and "additionalItems" determine which subschemas apply
-                    to which elements of the array.  In addition, "uniqueItems"
-                    and "contains" validate array contents as a whole.
-                </t>
-                <t>
-                    For objects, primitive type validation consists of validating
-                    restrictions on which and how many properties appear with
-                    "required", "minProperties", "maxProperties", "propertyNames",
-                    and the string array form of "dependencies", while "properties",
-                    "patternProperties", and "additionalProperties" determine which
-                    subschemas apply to which object property values.
-                    In addition, the schema form of "dependencies" validates the
-                    object as a whole based on the presence of specific property names.
+                    Note that while array elements are validated by at most one
+                    subschema, object property values may be validated by several
+                    subschemas from "properties" and "patternProperties".
                 </t>
             </section>
 
@@ -239,415 +226,451 @@
                 Validation keywords in a schema impose requirements for successful validation of an instance.
             </t>
 
-            <section title="multipleOf">
-                <t>
-                    The value of "multipleOf" MUST be a number, strictly greater than 0.
-                </t>
-                <t>
-                    A numeric instance is valid only if division by this keyword's value results in an integer.
-                </t>
+            <section title="Validation keywords for numeric instances (number and integer)">
+                <section title="multipleOf">
+                    <t>
+                        The value of "multipleOf" MUST be a number, strictly greater than 0.
+                    </t>
+                    <t>
+                        A numeric instance is valid only if division by this keyword's value results in an integer.
+                    </t>
+                </section>
+
+                <section title="maximum">
+                    <t>
+                        The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.
+                    </t>
+                    <t>
+                        If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".
+                    </t>
+                </section>
+
+                <section title="exclusiveMaximum">
+                    <t>
+                        The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance.
+                    </t>
+                    <t>
+                        If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".
+                    </t>
+                </section>
+
+                <section title="minimum">
+                    <t>
+                        The value of "minimum" MUST be a number, representing an inclusive upper limit for a numeric instance.
+                    </t>
+                    <t>
+                        If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".
+                    </t>
+                </section>
+
+                <section title="exclusiveMinimum">
+                    <t>
+                        The value of "exclusiveMinimum" MUST be number, representing an exclusive upper limit for a numeric instance.
+                    </t>
+                    <t>
+                        If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".
+                    </t>
+                </section>
             </section>
 
-            <section title="maximum">
-                <t>
-                    The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.
-                </t>
-                <t>
-                    If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".
-                </t>
+            <section title="Validation keywords for strings">
+
+                <section title="maxLength">
+                    <t>
+                        The value of this keyword MUST be a non-negative integer.</t>
+                    <t>
+                        A string instance is valid against this keyword if its
+                        length is less than, or equal to, the value of this keyword.
+                    </t>
+                    <t>
+                        The length of a string instance is defined as the number of its
+                        characters as defined by <xref target="RFC7159">RFC 7159</xref>.
+                    </t>
+                </section>
+
+                <section title="minLength">
+                    <t>
+                        The value of this keyword MUST be a non-negative integer.
+                    </t>
+                    <t>
+                        A string instance is valid against this keyword if its
+                        length is greater than, or equal to, the value of this keyword.
+                    </t>
+
+                    <t>
+                        The length of a string instance is defined as the number of its
+                        characters as defined by <xref target="RFC7159">RFC 7159</xref>.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as a value of 0.
+                    </t>
+                </section>
+
+                <section title="pattern">
+                    <t>
+                        The value of this keyword MUST be a string. This string SHOULD be a
+                        valid regular expression, according to the ECMA 262 regular expression
+                        dialect.
+                    </t>
+                    <t>
+                        A string instance is considered valid if the regular
+                        expression matches the instance successfully. Recall: regular
+                        expressions are not implicitly anchored.
+                    </t>
+                </section>
             </section>
 
-            <section title="exclusiveMaximum">
+            <section title="Validation keywords for arrays as primitive types">
                 <t>
-                    The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance.
+                    These keywords validate characteristics of arrays independent of their contents.
                 </t>
-                <t>
-                    If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".
-                </t>
+
+                <section title="maxItems">
+                    <t>
+                        The value of this keyword MUST be a non-negative integer.
+                    </t>
+                    <t>
+                        An array instance is valid against "maxItems" if its size is
+                        less than, or equal to, the value of this keyword.
+                    </t>
+                </section>
+
+                <section title="minItems">
+                    <t>
+                        The value of this keyword MUST be a non-negative integer.
+                    </t>
+                    <t>
+                        An array instance is valid against "minItems" if its size is
+                        greater than, or equal to, the value of this keyword.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as a value of 0.
+                    </t>
+                </section>
             </section>
 
-            <section title="minimum">
+            <section title="Validation keywords for array contents">
                 <t>
-                    The value of "minimum" MUST be a number, representing an inclusive upper limit for a numeric instance.
+                    These keywords validate conditions, specifically existence and uniqueness, across all array contents.
                 </t>
-                <t>
-                    If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".
-                </t>
+                <section title="contains">
+                    <t>
+                        The value of this keyword MUST be an object.  This object MUST be
+                        a valid JSON Schema.
+                    </t>
+                    <t>
+                        An array instance is valid against "contains" if at least one of
+                        its elements is valid against the given schema.
+                    </t>
+                </section>
+                <section title="uniqueItems">
+                    <t>
+                        The value of this keyword MUST be a boolean.
+                    </t>
+                    <t>
+                        If this keyword has boolean value false, the instance validates
+                        successfully. If it has boolean value true, the instance validates
+                        successfully if all of its elements are unique.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as a value of false.
+                    </t>
+                </section>
             </section>
 
-            <section title="exclusiveMinimum">
+            <section title="Validating array elements with subschemas">
                 <t>
-                    The value of "exclusiveMinimum" MUST be number, representing an exclusive upper limit for a numeric instance.
+                    These keywords determine which subschemas apply to each element of an array.
                 </t>
-                <t>
-                    If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".
-                </t>
+                <section title="items">
+                    <t>
+                        The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
+                    </t>
+                    <t>
+                        This keyword determines how child instances validate for arrays,
+                        and does not directly validate the immediate instance itself.
+                    </t>
+                    <t>
+                        If "items" is a schema, child validation succeeds if all elements
+                        in the array successfully validate against that schema.
+                    </t>
+                    <t>
+                        If "items" is an array of schemas, child validation succeeds if
+                        each element of the instance validates against the schema at the
+                        same position, if any.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty schema.
+                    </t>
+                </section>
+
+                <section title="additionalItems">
+                    <t>
+                        The value of "additionalItems" MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        This keyword determines how child instances validate for arrays,
+                        and does not directly validate the immediate instance itself.
+                    </t>
+                    <t>
+                        If "items" is an array of schemas, child validation succeeds
+                        if every instance element at a position greater than the size
+                        of "items" validates against "additionalItems".
+                    </t>
+                    <t>
+                        Otherwise, "additionalItems" MUST be ignored, as the "items"
+                        schema (possibly the default value of an empty schema) is
+                        applied to all elements.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty schema.
+                    </t>
+                </section>
             </section>
 
-            <section title="maxLength">
+            <section title="Validation keywords for objects as primitive types">
                 <t>
-                    The value of this keyword MUST be a non-negative integer.</t>
-                <t>
-                    A string instance is valid against this keyword if its
-                    length is less than, or equal to, the value of this keyword.
+                    These keywords validate characteristics of objects independent of the values of their properties.
                 </t>
-                <t>
-                    The length of a string instance is defined as the number of its
-                    characters as defined by <xref target="RFC7159">RFC 7159</xref>.
-                </t>
+
+                <section title="maxProperties">
+                    <t>
+                        The value of this keyword MUST be a non-negative integer.
+                    </t>
+                    <t>
+                        An object instance is valid against "maxProperties" if its
+                        number of properties is less than, or equal to, the value of this
+                        keyword.
+                    </t>
+                </section>
+
+                <section title="minProperties">
+                    <t>
+                        The value of this keyword MUST be a non-negative integer.
+                    </t>
+                    <t>
+                        An object instance is valid against "minProperties" if its
+                        number of properties is greater than, or equal to, the value of this
+                        keyword.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as a value of 0.
+                    </t>
+                </section>
+
+                <section title="propertyNames">
+                    <t>
+                        The value of "propertyNames" MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        If the instance is an object, this keyword validates if every property name in the instance
+                        validates against the provided schema.
+                        Note the property name that the schema is testing will always be a string.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty schema.
+                    </t>
+                </section>
+
+                <section title="required">
+                    <t>
+                        The value of this keyword MUST be an array.
+                        Elements of this array, if any, MUST be strings, and MUST be unique.
+                    </t>
+                    <t>
+                        An object instance is valid against this keyword if every item in the array
+                        is the name of a property in the instance.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty array.
+                    </t>
+                </section>
             </section>
 
-            <section title="minLength">
+            <section title="Validating object properties with subschemas">
                 <t>
-                    The value of this keyword MUST be a non-negative integer.
-                </t>
-                <t>
-                    A string instance is valid against this keyword if its
-                    length is greater than, or equal to, the value of this keyword.
+                    These keywords determine which subschemas apply to each property of an object.
                 </t>
 
-                <t>
-                    The length of a string instance is defined as the number of its
-                    characters as defined by <xref target="RFC7159">RFC 7159</xref>.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as a value of 0.
-                </t>
+                <section title="properties">
+                    <t>
+                        The value of "properties" MUST be an object.
+                        Each value of this object MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        This keyword determines how child instances validate for objects,
+                        and does not directly validate the immediate instance itself.
+                    </t>
+                    <t>
+                        Child validation succeeds if, for each name that appears in both
+                        the instance and as a name within this keyword's value, the child
+                        instance for that name successfully validates against the
+                        corresponding schema.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty object.
+                    </t>
+                </section>
+
+                <section title="patternProperties">
+                    <t>
+                        The value of "patternProperties" MUST be an object. Each property name
+                        of this object SHOULD be a valid regular expression, according to the
+                        ECMA 262 regular expression dialect. Each property value of this object
+                        MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        This keyword determines how child instances validate for objects,
+                        and does not directly validate the immediate instance itself.
+                        Validation of the primitive instance type against this keyword
+                        always succeeds.
+                    </t>
+                    <t>
+                        Child validation succeeds if, for each instance name that matches any
+                        regular expressions that appear as a property name in this keyword's value,
+                        the child instance for that name successfully validates against each
+                        schema that corresponds to a matching regular expression.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty object.
+                    </t>
+                </section>
+
+                <section title="additionalProperties">
+                    <t>
+                        The value of "additionalProperties" MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        This keyword determines how child instances validate for objects,
+                        and does not directly validate the immediate instance itself.
+                    </t>
+                    <t>
+                        Child validation with "additionalProperties" applies only to the child
+                        values of instance names that do not match any names in "properties",
+                        and do not match any regular expression in "patternProperties".
+                    </t>
+                    <t>
+                        For all such properties, child validation succeeds if the child instance
+                        validates against the "additionalProperties" schema.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty schema.
+                    </t>
+                </section>
             </section>
 
-            <section title="pattern">
-                <t>
-                    The value of this keyword MUST be a string. This string SHOULD be a
-                    valid regular expression, according to the ECMA 262 regular expression
-                    dialect.
-                </t>
-                <t>
-                    A string instance is considered valid if the regular
-                    expression matches the instance successfully. Recall: regular
-                    expressions are not implicitly anchored.
-                </t>
+            <section title="Conditional validation based on object properties">
+                <section title="dependencies">
+                    <t>
+                        This keyword specifies rules that are evaluated if the instance is an object and
+                        contains a certain property.
+                    </t>
+                    <t>
+                        This keyword's value MUST be an object. Each property specifies a dependency.
+                        Each dependency value MUST be an array or a valid JSON Schema.
+                    </t>
+                    <t>
+                        If the dependency value is a subschema, and the dependency key is a property
+                        in the instance, the entire instance must validate against the dependency value.
+                    </t>
+                    <t>
+                        If the dependency value is an array, each element in the array,
+                        if any, MUST be a string, and MUST be unique. If the dependency key is
+                        a property in the instance, each of the items in the dependency
+                        value must be a property that exists in the instance.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as an empty object.
+                    </t>
+                </section>
             </section>
 
-            <section title="items">
-                <t>
-                    The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
-                </t>
-                <t>
-                    This keyword determines how child instances validate for arrays,
-                    and does not directly validate the immediate instance itself.
-                </t>
-                <t>
-                    If "items" is a schema, child validation succeeds if all elements
-                    in the array successfully validate against that schema.
-                </t>
-                <t>
-                    If "items" is an array of schemas, child validation succeeds if
-                    each element of the instance validates against the schema at the
-                    same position, if any.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty schema.
-                </t>
+            <section title="Validation keywords for any instance type">
+
+                <section title="enum">
+                    <t>
+                        The value of this keyword MUST be an array. This array SHOULD have at
+                        least one element. Elements in the array SHOULD be unique.
+                    </t>
+
+                    <t>
+                        Elements in the array MAY be of any type, including null.
+                    </t>
+                    <t>
+                        An instance validates successfully against this keyword if its value is
+                        equal to one of the elements in this keyword's array value.
+                    </t>
+                </section>
+
+                <section title="const">
+                    <t>
+                        The value of this keyword MAY be of any type, including null.
+                    </t>
+                    <t>
+                        An instance validates successfully against this keyword if its value is
+                        equal to the value of the keyword.
+                    </t>
+                </section>
+
+                <section title="type">
+                    <t>
+                        The value of this keyword MUST be either a string or an array. If it is
+                        an array, elements of the array MUST be strings and MUST be unique.
+                    </t>
+                    <t>
+                        String values MUST be one of the six primitive types
+                        ("null", "boolean", "object", "array", "number", or "string"),
+                        or "integer" which matches any number with a zero fractional part.
+                    </t>
+                    <t>
+                        An instance validates if and only if the instance is in any of the sets listed for this keyword.
+                    </t>
+                </section>
+
+                <section title="allOf">
+                    <t>
+                        This keyword's value MUST be a non-empty array.
+                        Each item of the array MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        An instance validates successfully against this keyword if it validates
+                        successfully against all schemas defined by this keyword's value.
+                    </t>
+                </section>
+
+                <section title="anyOf">
+                    <t>
+                        This keyword's value MUST be a non-empty array.
+                        Each item of the array MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        An instance validates successfully against this keyword if it validates
+                        successfully against at least one schema defined by this keyword's value.
+                    </t>
+                </section>
+
+                <section title="oneOf">
+                    <t>
+                        This keyword's value MUST be a non-empty array.
+                        Each item of the array MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        An instance validates successfully against this keyword if it validates
+                        successfully against exactly one schema defined by this keyword's value.
+                    </t>
+                </section>
+
+                <section title="not">
+                    <t>
+                        This keyword's value MUST be a valid JSON Schema.
+                    </t>
+                    <t>
+                        An instance is valid against this keyword if it fails to validate
+                        successfully against the schema defined by this keyword.
+                    </t>
+                </section>
             </section>
 
-            <section title="additionalItems">
-                <t>
-                    The value of "additionalItems" MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    This keyword determines how child instances validate for arrays,
-                    and does not directly validate the immediate instance itself.
-                </t>
-                <t>
-                    If "items" is an array of schemas, child validation succeeds
-                    if every instance element at a position greater than the size
-                    of "items" validates against "additionalItems".
-                </t>
-                <t>
-                    Otherwise, "additionalItems" MUST be ignored, as the "items"
-                    schema (possibly the default value of an empty schema) is
-                    applied to all elements.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty schema.
-                </t>
-            </section>
-
-            <section title="maxItems">
-                <t>
-                    The value of this keyword MUST be a non-negative integer.
-                </t>
-                <t>
-                    An array instance is valid against "maxItems" if its size is
-                    less than, or equal to, the value of this keyword.
-                </t>
-            </section>
-
-            <section title="minItems">
-                <t>
-                    The value of this keyword MUST be a non-negative integer.
-                </t>
-                <t>
-                    An array instance is valid against "minItems" if its size is
-                    greater than, or equal to, the value of this keyword.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as a value of 0.
-                </t>
-            </section>
-
-            <section title="uniqueItems">
-                <t>
-                    The value of this keyword MUST be a boolean.
-                </t>
-                <t>
-                    If this keyword has boolean value false, the instance validates
-                    successfully. If it has boolean value true, the instance validates
-                    successfully if all of its elements are unique.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as a value of false.
-                </t>
-            </section>
-
-            <section title="contains">
-                <t>
-                    The value of this keyword MUST be an object.  This object MUST be
-                    a valid JSON Schema.
-                </t>
-                <t>
-                    An array instance is valid against "contains" if at least one of
-                    its elements is valid against the given schema.
-                </t>
-            </section>
-
-            <section title="maxProperties">
-                <t>
-                    The value of this keyword MUST be a non-negative integer.
-                </t>
-                <t>
-                    An object instance is valid against "maxProperties" if its
-                    number of properties is less than, or equal to, the value of this
-                    keyword.
-                </t>
-            </section>
-
-            <section title="minProperties">
-                <t>
-                    The value of this keyword MUST be a non-negative integer.
-                </t>
-                <t>
-                    An object instance is valid against "minProperties" if its
-                    number of properties is greater than, or equal to, the value of this
-                    keyword.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as a value of 0.
-                </t>
-            </section>
-
-            <section title="required">
-                <t>
-                    The value of this keyword MUST be an array.
-                    Elements of this array, if any, MUST be strings, and MUST be unique.
-                </t>
-                <t>
-                    An object instance is valid against this keyword if every item in the array is
-                    the name of a property in the instance.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty array.
-                </t>
-            </section>
-
-            <section title="properties">
-                <t>
-                    The value of "properties" MUST be an object.
-                    Each value of this object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    This keyword determines how child instances validate for objects,
-                    and does not directly validate the immediate instance itself.
-                </t>
-                <t>
-                    Child validation succeeds if, for each name that appears in both
-                    the instance and as a name within this keyword's value, the child
-                    instance for that name successfully validates against the
-                    corresponding schema.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty object.
-                </t>
-            </section>
-
-            <section title="patternProperties">
-                <t>
-                    The value of "patternProperties" MUST be an object. Each property name
-                    of this object SHOULD be a valid regular expression, according to the
-                    ECMA 262 regular expression dialect. Each property value of this object
-                    MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    This keyword determines how child instances validate for objects,
-                    and does not directly validate the immediate instance itself.
-                    Validation of the primitive instance type against this keyword
-                    always succeeds.
-                </t>
-                <t>
-                    Child validation succeeds if, for each instance name that matches any
-                    regular expressions that appear as a property name in this keyword's value,
-                    the child instance for that name successfully validates against each
-                    schema that corresponds to a matching regular expression.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty object.
-                </t>
-            </section>
-
-            <section title="additionalProperties">
-                <t>
-                    The value of "additionalProperties" MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    This keyword determines how child instances validate for objects,
-                    and does not directly validate the immediate instance itself.
-                </t>
-                <t>
-                    Child validation with "additionalProperties" applies only to the child
-                    values of instance names that do not match any names in "properties",
-                    and do not match any regular expression in "patternProperties".
-                </t>
-                <t>
-                    For all such properties, child validation succeeds if the child instance
-                    validates against the "additionalProperties" schema.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty schema.
-                </t>
-            </section>
-
-            <section title="dependencies">
-                <t>
-                    This keyword specifies rules that are evaluated if the instance is an object and
-                    contains a certain property.
-                </t>
-                <t>
-                    This keyword's value MUST be an object. Each property specifies a dependency.
-                    Each dependency value MUST be an array or a valid JSON Schema.
-                </t>
-                <t>
-                    If the dependency value is a subschema, and the dependency key is a property
-                    in the instance, the entire instance must validate against the dependency value.
-                </t>
-                <t>
-                    If the dependency value is an array, each element in the array,
-                    if any, MUST be a string, and MUST be unique. If the dependency key is
-                    a property in the instance, each of the items in the dependency
-                    value must be a property that exists in the instance.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty object.
-                </t>
-            </section>
-
-            <section title="propertyNames">
-                <t>
-                    The value of "propertyNames" MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    If the instance is an object, this keyword validates if every property name in the instance
-                    validates against the provided schema.
-                    Note the property name that the schema is testing will always be a string.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as an empty schema.
-                </t>
-            </section>
-
-            <section title="enum">
-                <t>
-                    The value of this keyword MUST be an array. This array SHOULD have at
-                    least one element. Elements in the array SHOULD be unique.
-                </t>
-                <t>
-                    An instance validates successfully against this keyword if its value is
-                    equal to one of the elements in this keyword's array value.
-                </t>
-                <t>
-                    Elements in the array might be of any value, including null.
-                </t>
-            </section>
-
-            <section title="const">
-                <t>
-                    The value of this keyword MAY be of any type, including null.
-                </t>
-                <t>
-                    An instance validates successfully against this keyword if its value is
-                    equal to the value of the keyword.
-                </t>
-            </section>
-
-            <section title="type">
-                <t>
-                    The value of this keyword MUST be either a string or an array. If it is
-                    an array, elements of the array MUST be strings and MUST be unique.
-                </t>
-                <t>
-                    String values MUST be one of the six primitive types
-                    ("null", "boolean", "object", "array", "number", or "string"),
-                    or "integer" which matches any number with a zero fractional part.
-                </t>
-                <t>
-                    An instance validates if and only if the instance is in any of the sets listed for this keyword.
-                </t>
-            </section>
-
-            <section title="allOf">
-                <t>
-                    This keyword's value MUST be a non-empty array.
-                    Each item of the array MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    An instance validates successfully against this keyword if it validates
-                    successfully against all schemas defined by this keyword's value.
-                </t>
-            </section>
-
-            <section title="anyOf">
-                <t>
-                    This keyword's value MUST be a non-empty array.
-                    Each item of the array MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    An instance validates successfully against this keyword if it validates
-                    successfully against at least one schema defined by this keyword's value.
-                </t>
-            </section>
-
-            <section title="oneOf">
-                <t>
-                    This keyword's value MUST be a non-empty array.
-                    Each item of the array MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    An instance validates successfully against this keyword if it validates
-                    successfully against exactly one schema defined by this keyword's value.
-                </t>
-            </section>
-
-            <section title="not">
-                <t>
-                    This keyword's value MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    An instance is valid against this keyword if it fails to validate
-                    successfully against the schema defined by this keyword.
-                </t>
-            </section>
-        </section>
-
-        <section title="Metadata keywords">
             <section title="definitions">
                 <t>
                     This keyword's value MUST be an object.
@@ -673,7 +696,7 @@
     "definitions": {
         "positiveInteger": {
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "exclusiveMinimum": 0
         }
     }
 }
@@ -682,7 +705,9 @@
                     </figure>
                 </t>
             </section>
+        </section>
 
+        <section title="Metadata keywords">
             <section title='"title" and "description"'>
                 <t>
                     The value of both of these keywords MUST be a string.


### PR DESCRIPTION
**NOTE:**  I'm putting this up because @awwright and I both thought that my last attempt to clarify this still wasn't quite getting it.  Since this moves a lot of things around the diff looks **much** worse than the changes actually are.  It's better to grab this XML file and build it locally to see the changes.

While I like this approach better, I do not feel strongly enough about it to insist on it (or anything like it) going in for Draft 06.  I'm just posting it as an idea, and if it doesn't get support quickly I'll be happy to drop it.

----

This goes back to Draft 04's approach of grouping keywords,
but mostly retaining Draft 05's more concise wording and
per-keyword organization.

The general considerations section on validating primitive types
and child values has been simplified, and the details have been
moved down to each grouping of array or object keywords.  This
puts the information near where it is most relevant, which
allows removing some of the more confusing working in the
keywords that apply to child values.