### PR TITLE
Provide guidance on hyperschema and validation

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -185,6 +185,27 @@
                 <postamble>The base-64 data has been abbreviated for readability.</postamble>
             </figure>
 
+            <section title="Interaction with validation">
+                <t>
+                    Hyper-schemas MUST NOT be applied to an instance if the instance fails
+                    to validate against the validation keywords within or containing the hyper-schema.
+                    Hyper-schema keywords in branches of an "anyOf" or "oneOf" that do not
+                    validate, or in a "dependencies" subschema that is not relevant
+                    to the instance, MUST be ignored.
+                </t>
+                <t>
+                    Hyper-schema keywords in a subschema contained within
+                    a "not", at any depth, including any number of intervening
+                    additional "not" subschemas, MUST be ignored.
+                </t>
+                <t>
+                    If the subschema for a "contains" keyword contains hyper-schema
+                    keywords they MUST be applied to all array elements that validate
+                    against the schema.  While finding a single validating element
+                    is sufficient to determine the validation outcome, when hyper-schema
+                    keywords are present, the subschema MUST be evaluated against all array elements.
+                </t>
+            </section>
         </section>
 
         <section title="Meta-schema">


### PR DESCRIPTION
This documents the assumptions I have found myself forced to
make while writing a generic hyper-client.  There are other workable
assumptions so the exact form (and the use of MUST vs SHOULD)
is open to debate.

It's been commonly assumed that hyper-schema keywords apply only
when validation is successful.  Be explicit about this, and resolve
ambiguous situations.

Most notably, remove any burden on implementations to figure out
what to do with situations such as:

{"not": {"not": {"links": [...]}}}

where the schema containing links technically must validate against
the instance, but any less trivial nesting of "not"s
(including such situations as a "not" inside of a "oneOf" branch
that fails validation while the overall "oneOf" succeeds) rapidly
becomes extremely difficult to reason about.