### PR TITLE
Remove subsections for "hostname" format.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -787,19 +787,14 @@
                     </t>
                 </section>
                 <section title="hostname">
-                    <section title="Applicability">
-                        <t>
-                            This attribute applies to string instances.
-                        </t>
-                    </section>
-
-                    <section title="Validation">
-                        <t>
-                            A string instance is valid against this attribute if it is a valid
-                            representation for an Internet host name, as defined by <xref
-                            target="RFC1034">RFC 1034, section 3.1</xref>.
-                        </t>
-                    </section>
+                    <t>
+                        This attribute applies to string instances.
+                    </t>
+                    <t>
+                        A string instance is valid against this attribute if it is a valid
+                        representation for an Internet host name, as defined by <xref
+                        target="RFC1034">RFC 1034, section 3.1</xref>.
+                    </t>
                 </section>
 
                 <section title="ipv4">


### PR DESCRIPTION
The formats all had these subsections in an earlier draft but they
were removed, which was a good thing.
Apparently "hostname" was overlooked in the removal.