### PR TITLE
Add meta-schema version numbers, fix reference.

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft/hyper-schema#",
-    "$id": "http://json-schema.org/draft/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-06/hyper-schema#",
+    "$id": "http://json-schema.org/draft-06/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
         "schemaArray": {
             "allOf": [
-                { "$ref": "http://json-schema.org/drafts/schema" },
+                { "$ref": "http://json-schema.org/draft-06/schema#/definitions/schemaArray" },
                 {
                     "items": { "$ref": "#" }
                 }
@@ -57,7 +57,7 @@
             }
         }
     },
-    "allOf": [ { "$ref": "http://json-schema.org/draft/schema#" } ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
     "properties": {
         "additionalItems": {
             "anyOf": [

--- a/links.json
+++ b/links.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft/hyper-schema#",
-    "$id": "http://json-schema.org/draft/links#",
+    "$schema": "http://json-schema.org/draft-06/hyper-schema#",
+    "$id": "http://json-schema.org/draft-06/links#",
     "title": "Link Description Object",
     "type": "object",
     "required": [ "href" ],

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft/schema#",
-    "$id": "http://json-schema.org/draft/schema#",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "http://json-schema.org/draft-06/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {


### PR DESCRIPTION
We are not using "latest"-style URIs anymore.

schemaArray in hyper-schema is intended to reference the schemaArray
in schema and just "allOf" the hyper-schema {"$ref": "#"} into the "items".

Addresses https://github.com/json-schema-org/json-schema-spec/issues/206#issuecomment-283775164