### PR TITLE
Fix hyper-schema meta-schema self link.

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -129,7 +129,7 @@
     "links": [
         {
             "rel": "self",
-            "href": "{+id}"
+            "href": "{+%24id}"
         }
     ]
 }


### PR DESCRIPTION
"id" became "$id", and we handle "$" through percent-encoding

URI Templates reserve "$", but do not specify how percent-encoding
is to be used, except that implementations should be consistent about
it.  We document that we always percent-decode variables before
resolving them.