### PR TITLE
Example JSON bugfixes

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -487,7 +487,7 @@
         "single": {
             "$id": "#item",
             "type": "integer"
-        },
+        }
     }
 }
 ]]>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -139,7 +139,7 @@
         "authorId": {
             "type": "integer"
         },
-        "imgDataPng": {
+        "imgData": {
             "title": "Article Illustration (thumbnail)",
             "type": "string",
             "media": {
@@ -239,7 +239,7 @@
         },
         {
             "rel": "next",
-            "href": "{next_id}"
+            "href": "{nextId}"
         }
     ]
 }
@@ -251,8 +251,8 @@
                     <artwork>
 <![CDATA[
 {
-    "id": "41",
-    "next_id": "42"
+    "id": 41,
+    "nextId": 42
 }
 ]]>
                     </artwork>


### PR DESCRIPTION
Removing a stray comma, and fixing "imgDataPng" to be "imgData",
which is the name by which it is called multiple times in the
surrounding text.

Also, all examples are camelCase except for "next_id", so I switched
it to "nextId" for consistency.

All examples now parse correctly as JSON, and as far as I can tell
match the surrounding text (although I did just kind of skim for
that part).