### PR TITLE
"method" does not constrain HTTP methods

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -701,7 +701,7 @@ GET /foo/
                 </t>
             </section>
 
-            <section title="targetSchema">
+            <section title="targetSchema" anchor="targetSchema">
                 <t>
                     This property provides a schema that is expected to describe the link target, including what a client can expect if it makes an HTTP GET request, and what it should send if it replaces the resource in an HTTP PUT request. This property is advisory only.
                 </t>
@@ -855,10 +855,19 @@ GET /foo/
                         This property specifies that the client can construct a templated query or non-idempotent request to a resource.
                     </t>
                     <t>
-                        If "method" is "get", the link identifies how a user can compute the URI of an arbitrary resource. For example, how to compute a link to a page of search results relating to the instance, for a user-selected query term. Despite being named after GET, there is no constraint on the method or protocol used to interact with the remote resource.
+                        If "method" is "get", the link identifies how a user can compute the URI of an arbitrary resource. For example, how to compute a link to a page of search results relating to the instance, for a user-selected query term.
                     </t>
                     <t>
                         If "method" is "post", the link specifies how a user can construct a document to submit to the link target for evaluation.
+                    </t>
+                    <t>
+                        Despite being named after HTTP's GET and POST, the presence,
+                        absence, or value of this keyword does not impose any constraints
+                        on either the method or protocol used to interact with the remote resource.
+                        In particular, the same Link Description Object may be used
+                        for multiple protocol methods.  For protocol methods whose
+                        request format is described by <xref target="targetSchema">"targetSchema"</xref>,
+                        if "method" is "post" then <xref target="schema">"schema"</xref> is ignored.
                     </t>
                     <t>
                         Values for this property SHOULD be lowercase, and SHOULD be compared case-insensitive. Use of other values not defined here SHOULD be ignored.
@@ -915,7 +924,7 @@ GET /foo/
                     </t>
 
                     <t>
-                        This is a separate concept from the "targetSchema" property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "schema" which describes the user-submitted request data to be evaluated by the resource.
+                        This is a separate concept from the <xref target="targetSchema">"targetSchema"</xref> property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "schema" which describes the user-submitted request data to be evaluated by the resource.
                     </t>
                 </section>
             </section>


### PR DESCRIPTION
"method" already documented that "method": "get" does not constrain
the LDO to GET.  Clarify that "post" also does not constrain the
LDO to HTTP POST, and that the LDO can be used with multiple methods.

The "schema" and "targetSchema" keywords are used with relevant
HTTP methods regardless of the presence, absence, or value of
JSON Hyper-Schema LDO "method".  This is consistent with the
existing wording of both "schema" and "targetSchema" around the
construction of PUT requests.