### PR TITLE
"method" does not constrain HTTP methods

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -702,7 +702,7 @@ GET /foo/
                 </t>
             </section>
 
-            <section title="targetSchema">
+            <section title="targetSchema" anchor="targetSchema">
                 <t>
                     This property provides a schema that is expected to describe
                     the link target's representation.  Depending on the protocol,
@@ -873,17 +873,35 @@ GET /foo/
                         This property specifies that the client can construct a templated query or non-idempotent request to a resource.
                     </t>
                     <t>
-                        If "method" is "get", the link identifies how a user can compute the URI of an arbitrary resource. For example, how to compute a link to a page of search results relating to the instance, for a user-selected query term. Despite being named after GET, there is no constraint on the method or protocol used to interact with the remote resource.
+                        If "method" is "get", the link identifies how a client can compute the URI of an arbitrary resource.
+                        For example, how to compute a link to a page of search results relating to the instance, for a user-selected query term.
                     </t>
                     <t>
-                        If "method" is "post", the link specifies how a user can construct a document to submit to the link target for evaluation.
+                        If "method" is "post", the link specifies how a client can construct
+                        a document to submit to the link target for evaluation.
+                        This option is most useful for requests requiring a payload that is not described
+                        in terms of the target representation, since the target
+                        representation is described by <xref target="targetSchema">"targetSchema"</xref>.
+                    </t>
+                    <t>
+                        Despite being named after HTTP's GET and POST, the presence,
+                        absence, or value of this keyword does not impose any constraints
+                        on either the protocol or method used to interact with the remote resource.
+                        In particular, the same Link Description Object may be used
+                        for multiple protocol methods.
+                    </t>
+                    <t>
+                        For protocol methods whose request format is derived from
+                        the target representation, if "method" is "post" then
+                        <xref target="schema">"schema"</xref> and
+                        <xref target="encType">"encTYpe"</xref> SHOULD be ignored.
                     </t>
                     <t>
                         Values for this property SHOULD be lowercase, and SHOULD be compared case-insensitive. Use of other values not defined here SHOULD be ignored.
                     </t>
                 </section>
 
-                <section title="encType">
+                <section title="encType" anchor="encType">
                     <t>
                         If present, this property indicates the media type format the client should use to encode a query parameter or send to the server.
                         If the method is "get", this will indicate how to encode the query-string that is appended to the "href" link target.
@@ -933,7 +951,9 @@ GET /foo/
                     </t>
 
                     <t>
-                        This is a separate concept from the "targetSchema" property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "schema" which describes the user-submitted request data to be evaluated by the resource.
+                        This is a separate concept from the <xref target="targetSchema">"targetSchema"</xref> property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "schema" which describes the user-submitted request data to be evaluated by the resource.
+                        "schema" is intended for use with requests that have payloads that are not
+                        defined in terms of the target representation.
                     </t>
                 </section>
             </section>


### PR DESCRIPTION
**PLEASE do not use this PR to debate changes that have already been made and published.**

_I am aware that changes made to `"method"` in draft-wright-json-schema-hyperschema-00 are still controversial.  This is not the forum to debate those changes.  Try #96 for that.  This PR is just attempting clarify the existing intent so that we can get more valuable feedback for draft-wright-json-schema-hyperschema-01 a.k.a. Draft 06._

_@awwright if this wording does not clarify your intent I'd be more than happy to approve a PR from you with wording that does.  Or edit this one.  I am not trying to advocate for a particular interpretation in this PR._

"method" already documented that "method": "get" does not constrain
the LDO to GET.  Clarify that "post" also does not constrain the
LDO to HTTP POST, and that the LDO can be used with multiple methods.

The "schema" and "targetSchema" keywords are used with relevant
HTTP methods regardless of the presence, absence, or value of
JSON Hyper-Schema LDO "method".  This is consistent with the
existing wording of both "schema" and "targetSchema" around the
construction of PUT requests.

See also #277.