### PR TITLE
Add non-http "method": "post" LDO example

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -918,8 +918,53 @@ GET /foo/
 ]]>
                             </artwork>
                         </figure>
-
+                    </t>
+                    <t>
                         If the method is "post", "application/json" is the default media type.
+                    </t>
+                    <t>
+                        As noted under <xref target="method">method</xref>, these fields
+                        are not restricted to HTTP URIs.
+
+                        <figure>
+                            <preamble>
+                                For example, this link indicates that if you want to
+                                send an email to the author of the context resource,
+                                your client needs to ask for both a plain text
+                                and an HTML representation.
+                            </preamble>
+                            <artwork>
+<![CDATA[{
+    "links": [{
+        "encType": "multipart/alternative; boundary=abc123",
+        "method": "post",
+        "rel": "author",
+        "href": "mailto:someone@example.com{?subject}",
+        "hrefSchema": {
+            "type": "object",
+            "properties": {
+                "subject": { "type": "string" }
+            },
+            "required": ["subject"]
+        },
+        "schema": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "string",
+                    "media": { "type": "text/plain; charset=utf8" }
+                },
+                {
+                    "type": "string",
+                    "media": { "type": "text/html" }
+                }
+            ],
+            "minItems": 2
+        }
+    }]
+}]]>
+                            </artwork>
+                        </figure>
                     </t>
                 </section>
 


### PR DESCRIPTION
**_This PR need not necessarily go into Draft 06_**

I'm posting this mostly to illustrate some of the arguments in #280, particularly around avoiding coupling of JSON Hyper-Schema and any particular URI scheme or protocol.

If we can't figure out a reasonable mapping for `mailto:` then we might be missing something.  Although that something will probably need to wait until Draft 07 for a fix.

I am aware that it's more common to use an HTTP request to ask the server to send mail, but I think this still makes a good example.  If the client for this resource runs in a known environment, it could be reasonable to expect the client to send mail if it wants to.

---

Add an example showing how a non-HTTP URI scheme can be used,
showing a form for constructing an email with two different
representations, as well as requiring a subject.