### PR TITLE
Clarify options for resolving template variables

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -463,6 +463,15 @@
                             unresolved MUST be resolved from the resource instance data.
                         </t>
 
+                        <t>
+                            If a URI Template variable corresponds to both an instance value
+                            and a schema for external data, an application MAY choose to
+                            present the instance value to the user as a default value.
+                            This will ensure that, if the user takes no action to change
+                            the value, the effect of resolving from the client or instace
+                            data will be the same.
+                        </t>
+
                         <section title="Converting to strings">
                             <t>
                                 When any value referenced by the URI template is null, a boolean or a number, then it should first be converted into a string as follows:
@@ -576,6 +585,12 @@
     }]
 }]]>
                     </artwork>
+                    <postamble>
+                        Note that this example is identical to a server pre-computing
+                        the path component of the URI (with "{id}") while the query
+                        string component is handled by client input as with an HTML
+                        "method"="get" form.
+                    </postamble>
                 </figure>
                 <t>
                     <cref>


### PR DESCRIPTION
Addresses #288 

If a variable can be resolved from either the instance or from
client data, the instance data may be used as a default when
asking for client data.

Also clarify how "hrefSchema" can handle a server-computed
URI path with client-supplied data string, as in traditional
HTML "get" forms.  This should address @awwright's
https://github.com/json-schema-org/json-schema-spec/issues/288#issuecomment-290522156
