### PR TITLE
Remove "method" and analogies to HTML forms.

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -10,7 +10,6 @@
 <!ENTITY rfc5988 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml">
 <!ENTITY rfc6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
 <!ENTITY rfc7231 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml">
-<!ENTITY html5 SYSTEM "http://xml.resource.org/public/rfc/bibxml4/reference.W3C.CR-html5-20140731.xml">
 ]>
 <?rfc toc="yes"?>
 <?rfc symrefs="yes"?>
@@ -390,8 +389,13 @@
 
             <section title="Links and data">
                 <t>
-                    "Form"-like functionality can be defined by use of the <xref target="method">"method"</xref> and <xref target="submissionSchema">"submissionSchema"</xref> keywords, which supplies a schema describing the data to supply to the server.
-                    Functionality equivalent to dynamic URI generation is available through the <xref target="href">"href"</xref> template and <xref target="hrefSchema">"hrefSchema"</xref>.
+                    Data input functionality can be defined by use of the
+                    <xref target="submissionSchema">"submissionSchema"</xref> and
+                    <xref target="submissionEncType">"submissionEncType"</xref> keywords,
+                    which supply a description of data to send to the target resource for processing.
+                    Functionality equivalent to dynamic URI generation is available through
+                    the <xref target="href">"href"</xref> template and
+                    <xref target="hrefSchema">"hrefSchema"</xref>.
                 </t>
                 <t>
                     The simplest kind of link has an "href" with no template variables, and no "submissionSchema".  This does not
@@ -407,9 +411,7 @@
                     data to resolve the template, and falls back to resolving any remaining variables from the instance.
                 </t>
                 <t>
-                    A link with a "submissionSchema" allows submitting external data either as a request body (if "method" is "post"),
-                    or as a URI query string (if "method" is "get").  Such a query string replaces any query string
-                    present after the "href" template is resolved.
+                    A link with a "submissionSchema" allows submitting data for processing.
                 </t>
                 <t>
                     See the individual keyword descriptions below for details related to each of these cases.
@@ -579,8 +581,8 @@
                 </figure>
                 <t>
                     <cref>
-                        The above example simulates the behavior found in earlier drafts using only "hrefSchema",
-                        which would allow the concurrent use of "submissionSchema" on a "post" link.
+                        The above example simulates the behavior handled in earlier drafts
+                        with a "method" of "get" by using the new "hrefSchema" keyword.
                     </cref>
                 </t>
             </section>
@@ -863,81 +865,30 @@ GET /foo/
                 </section>
             </section>
 
-            <section title="Submission Form Properties">
+            <section title="submissionEncType" anchor="submissionEncType">
                 <t>
-                    The following properties also apply to Link Description Objects, and provide functionality analogous to <xref target="W3C.CR-html5-20140731">HTML forms</xref>, by providing a means for making a request with client- or user-selected information.
+                    If present, this property indicates the media type format the
+                    client should use to for the request payload described by
+                    <xref target="submissionSchema">"submissionSchema"</xref>.
                 </t>
+                <t>
+                    Omitting this keyword has the same behavior as a value of application/json.
+                </t>
+                <t>
+                    Note that "submissionEncType" and "submissionSchema"
+                    are not restricted to HTTP URIs.
 
-                <section title="method" anchor="method">
-                    <t>
-                        This property specifies that the client can construct a templated query or non-idempotent request to a resource.
-                    </t>
-                    <t>
-                        If "method" is "get", the link identifies how a user can compute the URI of an arbitrary resource. For example, how to compute a link to a page of search results relating to the instance, for a user-selected query term. Despite being named after GET, there is no constraint on the method or protocol used to interact with the remote resource.
-                    </t>
-                    <t>
-                        If "method" is "post", the link specifies how a user can construct a document to submit to the link target for evaluation.
-                    </t>
-                    <t>
-                        Values for this property SHOULD be lowercase, and SHOULD be compared case-insensitive. Use of other values not defined here SHOULD be ignored.
-                    </t>
-                </section>
-
-                <section title="submissionEncType" anchor="submissionEncType">
-                    <t>
-                        If present, this property indicates the media type format the client should use to encode a query parameter or send to the server.
-                        If the method is "get", this will indicate how to encode the query-string that is appended to the "href" link target.
-                        If the method is "post", this indicates which media type to send to the server and how to encode it.
-
-                        <figure>
-                            <preamble>For example, with the following schema:</preamble>
-                            <artwork>
-<![CDATA[{
-    "links": [{
-        "submissionEncType": "application/x-www-form-urlencoded",
-        "method": "get",
-        "href": "/Product/",
-        "submissionSchema": {
-            "properties": {
-                "name": {
-                    "description": "name of the product"
-                }
-            }
-        }
-    }]
-}]]>
-                            </artwork>
-                            <postamble>This indicates that the client can query the server for instances that have a specific name.</postamble>
-                        </figure>
-
-                        <figure>
-                            <preamble>For example:</preamble>
-                            <artwork>
-<![CDATA[
-/Product/?name=Slinky
-]]>
-                            </artwork>
-                        </figure>
-                    </t>
-                    <t>
-                        If the method is "post", "application/json" is the default media type.
-                    </t>
-                    <t>
-                        As noted under <xref target="method">method</xref>, these fields
-                        are not restricted to HTTP URIs.
-
-                        <figure>
-                            <preamble>
-                                For example, this link indicates that if you want to
-                                send an email to the author of the context resource,
-                                your client needs to ask for both a plain text
-                                and an HTML representation.
-                            </preamble>
-                            <artwork>
+                    <figure>
+                        <preamble>
+                            For example, this link indicates that if you want to
+                            send an email to the author of the context resource,
+                            your client needs to ask for both a plain text
+                            and an HTML representation.
+                        </preamble>
+                        <artwork>
 <![CDATA[{
     "links": [{
         "submissionEncType": "multipart/alternative; boundary=ab12",
-        "method": "post",
         "rel": "author",
         "href": "mailto:someone@example.com{?subject}",
         "hrefSchema": {
@@ -963,26 +914,29 @@ GET /foo/
         }
     }]
 }]]>
-                            </artwork>
-                        </figure>
-                    </t>
-                </section>
+                        </artwork>
+                    </figure>
+                </t>
+            </section>
 
-                <section title="submissionSchema" anchor="submissionSchema">
-                    <t>
-                        This property contains a schema which defines the acceptable structure of the document being encoded according to the "submissionEncType" property.
-                    </t>
+            <section title="submissionSchema" anchor="submissionSchema">
+                <t>
+                    This property contains a schema which defines the acceptable structure
+                    of the document to be encoded according to the "submissionEncType" property
+                    and sent to the target resource for processing.  This can be viewed as
+                    describing the domain of the processing function implemented by the
+                    target resource.
+                </t>
 
-                    <t>
-                        Note that this does not define the structure for URI template variables.  That is handed by <xref target="hrefSchema">"hrefSchema"</xref>.  If the method is "get" and the resolved URI Template has a query string, the query string produced by input validated against "submissionSchema" replaces the existing query string.
-                    </t>
-
-                    <t>
-                        This is a separate concept from the <xref target="targetSchema">"targetSchema"</xref> property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "submissionSchema" which describes the user-submitted request data to be evaluated by the resource.
-                        "submissionSchema" is intended for use with requests that have payloads that are not
-                        defined in terms of the target representation.
-                    </t>
-                </section>
+                <t>
+                    This is a separate concept from the <xref target="targetSchema">"targetSchema"</xref> property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "submissionSchema" which describes the user-submitted request data to be evaluated by the resource.
+                    "submissionSchema" is intended for use with requests that have payloads that are not
+                    defined in terms of the target representation.
+                </t>
+                <t>
+                    Omitting "submissionSchema" or setting the entire schema to "false" prevents
+                    any external data from being accepted.
+                </t>
             </section>
         </section>
 
@@ -1018,7 +972,6 @@ GET /foo/
             &rfc5789;
             &rfc5988;
             &rfc7231;
-            &html5;
         </references>
 
         <section title="Acknowledgments">
@@ -1061,6 +1014,7 @@ GET /foo/
                             <t>Clarified HTTP use with "targetSchema"</t>
                             <t>Renamed "schema" to "submissionSchema"</t>
                             <t>Renamed "encType" to "submissionEncType"</t>
+                            <t>Removed "method"</t>
                         </list>
                     </t>
                     <t hangText="draft-wright-json-schema-hyperschema-00">


### PR DESCRIPTION
***NOTE:  Review this with whitespace changes turned off!!!***
https://github.com/json-schema-org/json-schema-spec/pull/292/files?w=1

This has been split out from #290.  It should not be merged without also
resolving the other parts of that larger change somehow, which will
likely restore some reference to HTML forms.

-----

The feedback to draft-wright-json-schema-hyperschema-00 and from
the final review for draft-wright-json-schema-hyperschema-01
has made it clear that "method" is extremely confusing, and no
two people can agree on the correct usage.  The only clear
impulse is to use the draft-luff-json-hyper-schema-00 meaning
(explicit specification of HTTP methods), which is not the
desired approach.

"method" is not actually necessary now that "hrefSchema" and
"submissionSchema" have separated the roles that were previously
both implemented by "schema" depending on the value of "method".
Therefore remove it to prevent incorrect assumptions about its
behavior and gather feedback on what behavior is truly needed.

With "method" gone, it makes sense to remove the references to
HTML forms as the analogy is no longer direct.  However, there are
still open issues around both whether and how to explicitly
indicate HTML form vs anchor semantics, and whether and how to
allow directly specifying HTTP methods (as was allowed by
draft-luff-json-hyper-schema-00).

Since there are no longer citations of HTML, that reference has
been removed.  If a new keyword is added for HTML form semantics,
then it will be restored as needed.