### PR TITLE
hyperschema: remove obsolete references to core terminology definitions

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -106,7 +106,7 @@
             </t>
 
             <t>
-                The terms "schema", "instance" and "property" are to be interpreted as defined in the <xref target="json-schema">JSON Schema core
+                The terms "schema" and "instance" are to be interpreted as defined in the <xref target="json-schema">JSON Schema core
                 specification</xref>.
             </t>
         </section>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -993,7 +993,8 @@ GET /foo/
                 Brad Bowman,
                 Gowry Sankar,
                 Donald Pipowitch,
-                and Dave Finlay
+                Dave Finlay,
+                and Denis Laxalde
                 for their submissions and patches to the document.
             </t>
         </section>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -106,7 +106,7 @@
             </t>
 
             <t>
-                The terms "schema", "instance", "property" and "item" are to be interpreted as defined in the <xref target="json-schema">JSON Schema core
+                The terms "schema", "instance" and "property" are to be interpreted as defined in the <xref target="json-schema">JSON Schema core
                 specification</xref>.
             </t>
         </section>


### PR DESCRIPTION
At the beginning of hyperschema document, there's:

> The terms "schema", "instance", "property" and "item" are to be interpreted as defined in the JSON Schema core specification.


but core specification does no longer defines "property" and "item" (from 3cbfc8bcab58ce6c0397f205534d2a4cede76ce8 AFAICT). I guess the former is assumed by JSON terminology; the latter may be confusing w.r.t. to collection+item terminology that appears in sections about links. So removing both references.