### PR TITLE
Allow booleans in "contains" per schema.json

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -412,8 +412,7 @@
 
             <section title="contains">
                 <t>
-                    The value of this keyword MUST be an object.  This object MUST be
-                    a valid JSON Schema.
+                    The value of this keyword MUST be a valid JSON Schema.
                 </t>
                 <t>
                     An array instance is valid against "contains" if at least one of


### PR DESCRIPTION
The documentation for "contains" appears to contradict `schema.json`; it says:

> The value of this keyword MUST be an object.  This object MUST be a valid JSON Schema.

However, `schema.json` refers to the root schema, which may be object or boolean.

It seems simplest to say:

> The value of this keyword MUST be a valid JSON Schema.

While `"contains": true` seems to me to have little value, given the general approach that `true` is a schema equivalent to the empty schema `{}` and `false` is a schema equivalent to `{ "not":{} }`, making this an exception to the overall rule seems an unnecessary burden, and I suspect it is an oversight.