### PR TITLE
Reformat XML documents to 100 columns length

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -51,18 +51,21 @@
                 JSON Schema asserts what a JSON document must look like,
                 ways to extract information from it,
                 and how to interact with it,
-                ideal for annotating existing JSON APIs that would not otherwise have hypermedia controls or be machine-readable.
+                ideal for annotating existing JSON APIs that would not otherwise have hypermedia
+                controls or be machine-readable.
             </t>
         </abstract>
         <note title="Note to Readers">
             <t>
-                The issues list for this draft can be found at <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
+                The issues list for this draft can be found at
+                <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
             </t>
             <t>
                 For additional information, see <eref target="http://json-schema.org/"/>.
             </t>
             <t>
-                To provide feedback, use this issue tracker, the communication methods listed on the homepage, or email the document editors.
+                To provide feedback, use this issue tracker, the communication methods listed on the
+                homepage, or email the document editors.
             </t>
         </note>
     </front>
@@ -108,26 +111,34 @@
                 This document proposes a new media type "application/schema+json" to identify a JSON
                 Schema for describing JSON data.
                 JSON Schemas are themselves JSON documents.
-                This, and related specifications, define keywords allowing authors to describe JSON data in several ways.
+                This, and related specifications, define keywords allowing authors to describe JSON
+                data in several ways.
             </t>
 
             <section title="Validation">
                 <t>
-                    JSON Schema describes the structure of a JSON document (for instance, required properties and length limitations).
-                    Applications can use this information to validate instances (check that constraints are met), or inform interfaces to collect user input such that the constraints are satisfied.
+                    JSON Schema describes the structure of a JSON document (for instance, required
+                    properties and length limitations).
+                    Applications can use this information to validate instances (check that
+                    constraints are met), or inform interfaces to collect user input such that the
+                    constraints are satisfied.
                 </t>
                 <t>
-                    Validation behaviour and keywords are specified in <xref target="json-schema-validation">a separate document</xref>.
+                    Validation behaviour and keywords are specified in
+                    <xref target="json-schema-validation">a separate document</xref>.
                 </t>
             </section>
 
             <section title="Hypermedia and Linking">
                 <t>
                     JSON Hyper-Schema describes the hypertext structure of a JSON document.
-                    This includes link relations from the instance to other resources, interpretation of instances as multimedia data, and submission data required to use an API.
+                    This includes link relations from the instance to other resources,
+                    interpretation of instances as multimedia data, and submission data required to
+                    use an API.
                 </t>
                 <t>
-                    Hyper-schema behaviour and keywords are specified in <xref target="json-hyper-schema">a separate document</xref>.
+                    Hyper-schema behaviour and keywords are specified in
+                    <xref target="json-hyper-schema">a separate document</xref>.
                 </t>
             </section>
         </section>
@@ -136,22 +147,29 @@
 
             <section title="JSON Document">
                 <t>
-                    A JSON document is an information resource (series of octets) described by the application/json media type.
+                    A JSON document is an information resource (series of octets) described by the
+                    application/json media type.
                 </t>
                 <t>
-                    In JSON Schema, the terms "JSON document", "JSON text", and "JSON value" are interchangeable because of the data model it defines.
+                    In JSON Schema, the terms "JSON document", "JSON text", and "JSON value" are
+                    interchangeable because of the data model it defines.
                 </t>
                 <t>
-                    JSON Schema is only defined over JSON documents. However, any document or memory structure that can be parsed into or processed according to the JSON Schema data model can be interpreted against a JSON Schema, including media types like <xref target="RFC7049">CBOR</xref>.
+                    JSON Schema is only defined over JSON documents. However, any document or memory
+                    structure that can be parsed into or processed according to the JSON Schema data
+                    model can be interpreted against a JSON Schema, including media types like
+                    <xref target="RFC7049">CBOR</xref>.
                 </t>
             </section>
 
             <section title="Instance">
                 <t>
-                    JSON Schema interprets documents according to a data model. A JSON value interpreted according to this data model is called an "instance".
+                    JSON Schema interprets documents according to a data model. A JSON value
+                    interpreted according to this data model is called an "instance".
                 </t>
                 <t>
-                    An instance has one of six primitive types, and a range of possible values depending on the type:
+                    An instance has one of six primitive types, and a range of possible values
+                    depending on the type:
 
                     <list style="hanging">
                         <t hangText="null">A JSON "null" production</t>
@@ -166,13 +184,16 @@
                     Whitespace and formatting concerns are thus outside the scope of JSON Schema.
                 </t>
                 <t>
-                    Since an object cannot have two properties with the same key, behavior for a JSON document that tries to define two properties (the "member" production) with the same key (the "string" production) in a single object is undefined.
+                    Since an object cannot have two properties with the same key, behavior for a
+                    JSON document that tries to define two properties (the "member" production) with
+                    the same key (the "string" production) in a single object is undefined.
                 </t>
             </section>
 
             <section title="Instance equality">
                 <t>
-                    Two JSON instances are said to be equal if and only if they are of the same type and have the same value according to the data model. Specifically, this means:
+                    Two JSON instances are said to be equal if and only if they are of the same type
+                    and have the same value according to the data model. Specifically, this means:
 
                     <list>
                         <t>both are null; or</t>
@@ -181,7 +202,9 @@
                         <t>both are strings, and are the same codepoint-for-codepoint; or</t>
                         <t>both are numbers, and have the same mathematical value; or</t>
                         <t>both are arrays, and have an equal value item-for-item; or</t>
-                        <t>both are objects, and each property in one has exactly one property with a key equal to the other's, and that other property has an equal value.</t>
+                        <t>both are objects, and each property in one has exactly one property with
+                            a key equal to the other's, and that other property has an equal
+                            value.</t>
                     </list>
                 </t>
                 <t>
@@ -189,13 +212,15 @@
                     objects must have the same number of members,
                     properties in objects are unordered,
                     there is no way to define multiple properties with the same key,
-                    and mere formatting differences (indentation, placement of commas, trailing zeros) are insignificant.
+                    and mere formatting differences (indentation, placement of commas, trailing
+                    zeros) are insignificant.
                 </t>
             </section>
 
             <section title="JSON Schema documents">
                 <t>
-                    A JSON Schema document, or simply a schema, is a JSON document used to describe an instance.
+                    A JSON Schema document, or simply a schema, is a JSON document used to describe
+                    an instance.
                     A schema is itself interpreted as an instance.
                     A JSON Schema MUST be an object or a boolean.
                 </t>
@@ -207,7 +232,8 @@
                     </list>
                 </t>
                 <t>
-                    Properties that are used to describe the instance are called keywords, or schema keywords.
+                    Properties that are used to describe the instance are called keywords, or schema
+                    keywords.
                     The meaning of properties is specified by the vocabulary that the schema is using.
                 </t>
                 <t>
@@ -216,7 +242,8 @@
                 </t>
                 <t>
                     A schema that itself describes a schema is called a meta-schema.
-                    Meta-schemas are used to validate JSON Schemas and specify which vocabulary it is using.
+                    Meta-schemas are used to validate JSON Schemas and specify which vocabulary it
+                    is using.
                 </t>
                 <t>
                     An empty schema is a JSON Schema with no properties, or only unknown properties.
@@ -291,25 +318,28 @@
             <section title="Range of JSON values">
                 <t>
                     An instance may be any valid JSON value as defined by <xref target="RFC7159">JSON</xref>.
-                    JSON Schema imposes no restrictions on type: JSON Schema can describe any JSON value, including, for example, null.
+                    JSON Schema imposes no restrictions on type: JSON Schema can describe any JSON
+                    value, including, for example, null.
                 </t>
             </section>
 
             <section title="Programming language independence" anchor="language">
                 <t>
-                    JSON Schema is programming language agnostic, and supports the full range of values described in the data model.
-                    Be aware, however, that some languages and JSON parsers may not be able to represent in memory
-                    the full range of values describable by JSON.
+                    JSON Schema is programming language agnostic, and supports the full range of
+                    values described in the data model.
+                    Be aware, however, that some languages and JSON parsers may not be able to
+                    represent in memory the full range of values describable by JSON.
                 </t>
             </section>
 
             <section title="Mathematical integers" anchor="integers">
                 <t>
-                    Some programming languages and parsers use different internal representations for floating
-                    point numbers than they do for integers.
+                    Some programming languages and parsers use different internal representations
+                    for floating point numbers than they do for integers.
                 </t>
                 <t>
-                    For consistency, integer JSON numbers SHOULD NOT be encoded with a fractional part.
+                    For consistency, integer JSON numbers SHOULD NOT be encoded with a fractional
+                    part.
                 </t>
             </section>
 
@@ -321,8 +351,10 @@
                     keywords they do not support.
                 </t>
                 <t>
-                    Authors of extensions to JSON Schema are encouraged to write their own meta-schemas, which extend the existing meta-schemas using "allOf".
-                    This extended meta-schema SHOULD be referenced using the "$schema" keyword, to allow tools to follow the correct behaviour.
+                    Authors of extensions to JSON Schema are encouraged to write their own
+                    meta-schemas, which extend the existing meta-schemas using "allOf".
+                    This extended meta-schema SHOULD be referenced using the "$schema" keyword, to
+                    allow tools to follow the correct behaviour.
                 </t>
             </section>
 
@@ -345,18 +377,23 @@
                 It MUST NOT appear in subschemas.
             </t>
             <t>
-                <cref>While this pattern is likely to remain best practice for schema authoring, implementation behavior is subject to be revised or liberalized in future drafts.</cref>
+                <cref>
+                    While this pattern is likely to remain best practice for schema authoring,
+                    implementation behavior is subject to be revised or liberalized in future
+                    drafts.
+                </cref>
             </t>
             <t>
                 Values for this property are defined in other documents and by other parties.
-                JSON Schema implementations SHOULD implement support for current and previous published drafts
-                of JSON Schema vocabularies as deemed reasonable.
+                JSON Schema implementations SHOULD implement support for current and previous
+                published drafts of JSON Schema vocabularies as deemed reasonable.
             </t>
         </section>
 
         <section title="Schema references with $ref">
             <t>
-                The "$ref" keyword is used to reference a schema, and provides the ability to validate recursive structures through self-reference.
+                The "$ref" keyword is used to reference a schema, and provides the ability to
+                validate recursive structures through self-reference.
             </t>
             <t>
                 An object schema with a "$ref" property MUST be interpreted as a "$ref" reference.
@@ -365,25 +402,30 @@
                 All other properties in a "$ref" object MUST be ignored.
             </t>
             <t>
-                The URI is not a network locator, only an identifier. A schema need not be downloadable from the address
-                if it is a network-addressable URL, and implementations SHOULD NOT assume they should perform a network
-                operation when they encounter a network-addressable URI.
+                The URI is not a network locator, only an identifier. A schema need not be
+                downloadable from the address if it is a network-addressable URL, and
+                implementations SHOULD NOT assume they should perform a network operation when they
+                encounter a network-addressable URI.
             </t>
             <t>
-                A schema MUST NOT be run into an infinite loop against a schema. For example, if two schemas "#alice" and "#bob"
-                both have an "allOf" property that refers to the other, a naive validator might get stuck in an infinite recursive
-                loop trying to validate the instance.
-                Schemas SHOULD NOT make use of infinite recursive nesting like this; the behavior is undefined.
+                A schema MUST NOT be run into an infinite loop against a schema. For example, if two
+                schemas "#alice" and "#bob" both have an "allOf" property that refers to the other,
+                a naive validator might get stuck in an infinite recursive loop trying to validate
+                the instance.
+                Schemas SHOULD NOT make use of infinite recursive nesting like this; the behavior is
+                undefined.
             </t>
         </section>
 
         <section title="Base URI and dereferencing">
             <section title="Initial base URI">
                 <t>
-                    <xref target="RFC3986">RFC3986 Section 5.1</xref> defines how to determine the default base URI of a document.
+                    <xref target="RFC3986">RFC3986 Section 5.1</xref> defines how to determine the
+                    default base URI of a document.
                 </t>
                 <t>
-                    Informatively, the initial base URI of a schema is the URI at which it was found, or a suitable substitute URI if none is known.
+                    Informatively, the initial base URI of a schema is the URI at which it was
+                    found, or a suitable substitute URI if none is known.
                 </t>
             </section>
 
@@ -391,11 +433,14 @@
                 <t>
                     The "$id" keyword defines a URI for the schema,
                     and the base URI that other URI references within the schema are resolved against.
-                    The "$id" keyword itself is resolved against the base URI that the object as a whole appears in.
+                    The "$id" keyword itself is resolved against the base URI that the object as a
+                    whole appears in.
                 </t>
                 <t>
-                    If present, the value for this keyword MUST be a string, and MUST represent a valid <xref target="RFC3986">URI-reference</xref>.
-                    This value SHOULD be normalized, and SHOULD NOT be an empty fragment &lt;#&gt; or an empty string &lt;&gt;.
+                    If present, the value for this keyword MUST be a string, and MUST represent a
+                    valid <xref target="RFC3986">URI-reference</xref>.
+                    This value SHOULD be normalized, and SHOULD NOT be an empty fragment &lt;#&gt;
+                    or an empty string &lt;&gt;.
                 </t>
                 <t>
                     The root schema of a JSON Schema document SHOULD contain an "$id" keyword with
@@ -413,7 +458,8 @@
                     subschemas can use "$id" to give themselves a document-local identifier.
                     This is done by setting "$id" to a URI reference consisting only of a fragment.
                     The fragment identifier MUST begin with a letter ([A-Za-z]), followed by
-                    any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), or periods (".").
+                    any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons
+                    (":"), or periods (".").
                 </t>
                 <t>
                     The effect of defining an "$id" that neither matches the above
@@ -462,12 +508,12 @@
                 </t>
                 <section title="Internal references">
                     <t>
-                        Schemas can be identified by any URI that has been given to them, including a JSON Pointer or
-                        their URI given directly by "$id".
+                        Schemas can be identified by any URI that has been given to them, including
+                        a JSON Pointer or their URI given directly by "$id".
                     </t>
                     <t>
-                        Tools SHOULD take note of the URIs that schemas, including subschemas, provide for themselves using "$id".
-                        This is known as "Internal referencing".
+                        Tools SHOULD take note of the URIs that schemas, including subschemas,
+                        provide for themselves using "$id". This is known as "Internal referencing".
                     </t>
 
                     <t>
@@ -494,28 +540,34 @@
                         </artwork>
                     </figure>
                     <t>
-                        When an implementation encounters the &lt;#/definitions/single&gt; schema, it resolves the "$id" URI reference
-                        against the current base URI to form &lt;http://example.net/root.json#item&gt;.
+                        When an implementation encounters the &lt;#/definitions/single&gt; schema,
+                        it resolves the "$id" URI reference against the current base URI to form
+                        &lt;http://example.net/root.json#item&gt;.
                     </t>
                     <t>
-                        When an implementation then looks inside the &lt;#/items&gt; schema, it encounters the &lt;#item&gt; reference,
-                        and resolves this to &lt;http://example.net/root.json#item&gt; which is understood as the schema defined elsewhere in the same document.
+                        When an implementation then looks inside the &lt;#/items&gt; schema, it
+                        encounters the &lt;#item&gt; reference, and resolves this to
+                        &lt;http://example.net/root.json#item&gt; which is understood as the schema
+                        defined elsewhere in the same document.
                     </t>
                 </section>
                 <section title="External references">
                     <t>
-                        To differentiate schemas between each other in a vast ecosystem, schemas are identified by URI.
-                        As specified above, this does not necessarily mean anything is downloaded, but instead JSON Schema
-                        implementations SHOULD already understand the schemas they will be using, including the URIs that identify them.
+                        To differentiate schemas between each other in a vast ecosystem, schemas are
+                        identified by URI. As specified above, this does not necessarily mean
+                        anything is downloaded, but instead JSON Schema implementations SHOULD
+                        already understand the schemas they will be using, including the URIs that
+                        identify them.
                     </t>
                     <t>
-                        Implementations SHOULD be able to associate arbitrary URIs with an arbitrary schema and/or
-                        automatically associate a schema's "$id"-given URI, depending on the trust that the validator
-                        has in the schema.
+                        Implementations SHOULD be able to associate arbitrary URIs with an arbitrary
+                        schema and/or automatically associate a schema's "$id"-given URI, depending
+                        on the trust that the validator has in the schema.
                     </t>
                     <t>
-                        A schema MAY (and likely will) have multiple URIs, but there is no way for a URI to identify more than one schema.
-                        When multiple schemas try to identify with the same URI, validators SHOULD raise an error condition.
+                        A schema MAY (and likely will) have multiple URIs, but there is no way for a
+                        URI to identify more than one schema. When multiple schemas try to identify
+                        with the same URI, validators SHOULD raise an error condition.
                     </t>
                 </section>
             </section>
@@ -524,18 +576,22 @@
         <section title="Usage for hypermedia">
 
             <t>
-                JSON has been adopted widely by HTTP servers for automated APIs and robots.
-                This section describes how to enhance processing of JSON documents in a more RESTful manner
-                when used with protocols that support media types and <xref target="RFC5988">Web linking</xref>.
+                JSON has been adopted widely by HTTP servers for automated APIs and robots. This
+                section describes how to enhance processing of JSON documents in a more RESTful
+                manner when used with protocols that support media types and
+                <xref target="RFC5988">Web linking</xref>.
             </t>
 
             <section title='Linking to a schema'>
                 <t>
-                    It is RECOMMENDED that instances described by a schema/profile provide a link to a downloadable JSON Schema using the link relation "describedby", as defined by <xref target="W3C.REC-ldp-20150226">Linked Data Protocol 1.0, section 8.1</xref>.
+                    It is RECOMMENDED that instances described by a schema/profile provide a link to
+                    a downloadable JSON Schema using the link relation "describedby", as defined by
+                    <xref target="W3C.REC-ldp-20150226">Linked Data Protocol 1.0, section 8.1</xref>.
                 </t>
 
                 <t>
-                    In HTTP, such links can be attached to any response using the <xref target="RFC5988">Link header</xref>. An example of such a header would be:
+                    In HTTP, such links can be attached to any response using the
+                    <xref target="RFC5988">Link header</xref>. An example of such a header would be:
                 </t>
 
                 <figure>
@@ -551,15 +607,22 @@ Link: <http://example.com/my-hyper-schema#>; rel="describedby"
 
             <section title='Describing a profile of JSON' anchor="profile">
                 <t>
-                    Instances MAY specify a "profile" as described in <xref target="RFC6906">The 'profile' Link Relation</xref>.
-                    When used as a media-type parameter, HTTP servers gain the ability to perform Content-Type Negotiation based on profile.
-                    The media-type parameter MUST be a whitespace-separated list of URIs (i.e. relative references are invalid).
+                    Instances MAY specify a "profile" as described in
+                    <xref target="RFC6906">The 'profile' Link Relation</xref>.
+                    When used as a media-type parameter, HTTP servers gain the ability to perform
+                    Content-Type Negotiation based on profile.
+                    The media-type parameter MUST be a whitespace-separated list of URIs
+                    (i.e. relative references are invalid).
                 </t>
                 <t>
                     The profile URI is opaque and SHOULD NOT automatically be dereferenced.
-                    If the implementation does not understand the semantics of the provided profile, the implementation can instead follow the "describedby" links, if any, which may provide information on how to handle the profile.
-                    Since "profile" doesn't necessarily point to a network location, the "describedby" relation is used for linking to a downloadable schema.
-                    However, for simplicity, schema authors should make these URIs point to the same resource when possible.
+                    If the implementation does not understand the semantics of the provided profile,
+                    the implementation can instead follow the "describedby" links, if any, which may
+                    provide information on how to handle the profile.
+                    Since "profile" doesn't necessarily point to a network location, the
+                    "describedby" relation is used for linking to a downloadable schema.
+                    However, for simplicity, schema authors should make these URIs point to the same
+                    resource when possible.
                 </t>
 
                 <t>
@@ -589,7 +652,9 @@ Content-Type: application/json;
                 </figure>
 
                 <t>
-                    HTTP can also send the "profile" in a Link, though this may impact media-type semantics and Content-Type negotiation if this replaces the media-type parameter entirely:
+                    HTTP can also send the "profile" in a Link, though this may impact media-type
+                    semantics and Content-Type negotiation if this replaces the media-type parameter
+                    entirely:
                 </t>
 
                 <figure>
@@ -604,15 +669,24 @@ Link: </alice>;rel="profile", </bob>;rel="profile"
 
              <section title="Usage over HTTP">
                 <t>
-                    When used for hypermedia systems over a network, <xref target="RFC7231">HTTP</xref> is frequently the protocol of choice for distributing schemas. Misbehaving clients can pose problems for server maintainers if they pull a schema over the network more frequently than necessary, when it's instead possible to cache a schema for a long period of time.
+                    When used for hypermedia systems over a network,
+                    <xref target="RFC7231">HTTP</xref> is frequently the protocol of choice for
+                    distributing schemas. Misbehaving clients can pose problems for server
+                    maintainers if they pull a schema over the network more frequently than
+                    necessary, when it's instead possible to cache a schema for a long period of
+                    time.
                 </t>
                 <t>
                     HTTP servers SHOULD set long-lived caching headers on JSON Schemas.
-                    HTTP clients SHOULD observe caching headers and not re-request documents within their freshness period.
+                    HTTP clients SHOULD observe caching headers and not re-request documents within
+                    their freshness period.
                     Distributed systems SHOULD make use of a shared cache and/or caching proxy.
                 </t>
                 <t>
-                    Clients SHOULD set or prepend a User-Agent header specific to the JSON Schema implementation or software product. Since symbols are listed in decreasing order of significance, the JSON Schema library name/version should precede the more generic HTTP library name (if any). For example:
+                    Clients SHOULD set or prepend a User-Agent header specific to the JSON Schema
+                    implementation or software product. Since symbols are listed in decreasing order
+                    of significance, the JSON Schema library name/version should precede the more
+                    generic HTTP library name (if any). For example:
                     <figure>
                         <artwork>
 <![CDATA[
@@ -622,7 +696,8 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     </figure>
                 </t>
                 <t>
-                    Clients SHOULD be able to make requests with a "From" header so that server operators can contact the owner of a potentially misbehaving script.
+                    Clients SHOULD be able to make requests with a "From" header so that server
+                    operators can contact the owner of a potentially misbehaving script.
                 </t>
             </section>
 
@@ -634,15 +709,19 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                 defined in <xref target="RFC7159">RFC 7159</xref> apply.
             </t>
             <t>
-                Instances and schemas are both frequently written by untrusted third parties, to be deployed on public Internet servers.
-                Validators should take care that the parsing of schemas doesn't consume excessive system resources.
+                Instances and schemas are both frequently written by untrusted third parties, to be
+                deployed on public Internet servers.
+                Validators should take care that the parsing of schemas doesn't consume excessive
+                system resources.
                 Validators MUST NOT fall into an infinite loop.
             </t>
             <t>
-                Servers need to take care that malicious parties can't change the functionality of existing schemas by uploading a schema with an pre-existing or very similar "$id".
+                Servers need to take care that malicious parties can't change the functionality of
+                existing schemas by uploading a schema with an pre-existing or very similar "$id".
             </t>
             <t>
-                Individual JSON Schema vocabularies are liable to also have their own security considerations. Consult the respective specifications for more information.
+                Individual JSON Schema vocabularies are liable to also have their own security
+                considerations. Consult the respective specifications for more information.
             </t>
         </section>
 

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -21,7 +21,9 @@
 <?rfc inline="yes" ?>
 <rfc category="info" docName="draft-wright-json-schema-hyperschema-01" ipr="trust200902">
     <front>
-        <title abbrev="JSON Hyper-Schema">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</title>
+        <title abbrev="JSON Hyper-Schema">
+            JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON
+        </title>
 
         <author fullname="Austin Wright" initials="A" surname="Wright" role="editor">
             <address>
@@ -60,20 +62,23 @@
         <abstract>
             <t>
                 JSON Schema is a JSON based format for defining the structure of JSON data.
-                This document specifies hyperlink- and hypermedia-related keywords of JSON Schema for
-                annotating JSON documents with hyperlinks and instructions for processing and manipulating remote JSON resources
-                through hypermedia environments like HTTP.
+                This document specifies hyperlink- and hypermedia-related keywords of JSON Schema
+                for annotating JSON documents with hyperlinks and instructions for processing and
+                manipulating remote JSON resources through hypermedia environments like HTTP.
             </t>
         </abstract>
         <note title="Note to Readers">
             <t>
-                The issues list for this draft can be found at <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
+                The issues list for this draft can be found at
+                <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
             </t>
             <t>
-                For additional information, see <eref target="http://json-schema.org/"/>.
+                For additional information, see
+                <eref target="http://json-schema.org/"/>.
             </t>
             <t>
-                To provide feedback, use this issue tracker, the communication methods listed on the homepage, or email the document editors.
+                To provide feedback, use this issue tracker, the communication methods listed on the
+                homepage, or email the document editors.
             </t>
         </note>
     </front>
@@ -85,13 +90,14 @@
                 This document specifies hyperlink- and hypermedia-related keywords of JSON Schema.
             </t>
             <t>
-                The term JSON Hyper-Schema is used to refer to a JSON Schema that uses these keywords.
+                The term JSON Hyper-Schema is used to refer to a JSON Schema that uses these
+                keywords.
             </t>
 
             <t>
-                This specification will use the terminology defined by the <xref target="json-schema">JSON Schema core
-                specification</xref>.
-                It is advised that readers have a copy of this specification.
+                This specification will use the terminology defined by the
+                <xref target="json-schema">JSON Schema core specification</xref>. It is advised that
+                readers have a copy of this specification.
             </t>
         </section>
 
@@ -106,21 +112,28 @@
             </t>
 
             <t>
-                The terms "schema" and "instance" are to be interpreted as defined in the <xref target="json-schema">JSON Schema core
-                specification</xref>.
+                The terms "schema" and "instance" are to be interpreted as defined in the
+                <xref target="json-schema">JSON Schema core specification</xref>.
             </t>
         </section>
 
         <section title="Overview">
             <t>
-                This document describes how JSON Schema can be used to define hyperlinks on instance data.
-                It also defines how to provide additional information required to interpret JSON data as rich multimedia documents.
+                This document describes how JSON Schema can be used to define hyperlinks on instance
+                data.
+                It also defines how to provide additional information required to interpret JSON
+                data as rich multimedia documents.
             </t>
             <t>
-                As with all JSON Schema keywords, all the keywords described in the "Schema Keywords" section are optional. The minimal valid JSON Hyper-schema is the blank object.
+                As with all JSON Schema keywords, all the keywords described in the "Schema
+                Keywords" section are optional. The minimal valid JSON Hyper-schema is the blank
+                object.
             </t>
             <figure>
-                <preamble>Here is an example JSON Schema defining hyperlinks, and providing a multimedia interpretation for the "imgData" property:</preamble>
+                <preamble>
+                    Here is an example JSON Schema defining hyperlinks, and providing a multimedia
+                    interpretation for the "imgData" property:
+                </preamble>
                 <artwork>
 <![CDATA[
 {
@@ -163,15 +176,24 @@
 ]]>
                 </artwork>
                 <postamble>
-                    This example schema defines the properties of the instance.
-                    For the "imgData" property, it specifies that that it should be base64-decoded and the resulting binary data treated as a PNG image.
-                    It also defines link relations for the instance, with URIs incorporating values from the instance.
-                    <cref>"id" probably should not normally be a required keyword, since new instances will have an unknown "id" property until is it assigned by the server. However, this property is used in a link, and without it, multiple different instances would be given the same rel=self URI!</cref>
+                    This example schema defines the properties of the instance. For the "imgData"
+                    property, it specifies that that it should be base64-decoded and the resulting
+                    binary data treated as a PNG image.
+                    It also defines link relations for the instance, with URIs incorporating values
+                    from the instance.
+                    <cref>
+                        "id" probably should not normally be a required keyword, since new instances
+                        will have an unknown "id" property until is it assigned by the server.
+                        However, this property is used in a link, and without it, multiple different
+                        instances would be given the same rel=self URI!
+                    </cref>
                 </postamble>
             </figure>
 
             <figure>
-                <preamble>An example of a JSON instance described by the above schema might be:</preamble>
+                <preamble>
+                    An example of a JSON instance described by the above schema might be:
+                </preamble>
                 <artwork>
 <![CDATA[
 {
@@ -182,49 +204,59 @@
 }
 ]]>
                 </artwork>
-                <postamble>The base-64 data has been abbreviated for readability.</postamble>
+                <postamble>
+                    The base-64 data has been abbreviated for readability.
+                </postamble>
             </figure>
 
             <section title="Interaction with validation">
                 <t>
-                    Hyper-schemas MUST NOT be applied to an instance if the instance fails
-                    to validate against the validation keywords within or containing the hyper-schema.
-                    Hyper-schema keywords in branches of an "anyOf" or "oneOf" that do not
-                    validate, or in a "dependencies" subschema that is not relevant
-                    to the instance, MUST be ignored.
+                    Hyper-schemas MUST NOT be applied to an instance if the instance fails to
+                    validate against the validation keywords within or containing the hyper-schema.
+                    Hyper-schema keywords in branches of an "anyOf" or "oneOf" that do not validate,
+                    or in a "dependencies" subschema that is not relevant to the instance, MUST be
+                    ignored.
                 </t>
                 <t>
-                    Hyper-schema keywords in a subschema contained within
-                    a "not", at any depth, including any number of intervening
-                    additional "not" subschemas, MUST be ignored.
+                    Hyper-schema keywords in a subschema contained within a "not", at any depth,
+                    including any number of intervening additional "not" subschemas, MUST be
+                    ignored.
                 </t>
                 <t>
-                    If the subschema for a "contains" keyword contains hyper-schema
-                    keywords they MUST be applied to all array elements that validate
-                    against the schema.  While finding a single validating element
-                    is sufficient to determine the validation outcome, when hyper-schema
-                    keywords are present, the subschema MUST be evaluated against all array elements.
+                    If the subschema for a "contains" keyword contains hyper-schema keywords they
+                    MUST be applied to all array elements that validate against the schema.  While
+                    finding a single validating element is sufficient to determine the validation
+                    outcome, when hyper-schema keywords are present, the subschema MUST be evaluated
+                    against all array elements.
                 </t>
             </section>
         </section>
 
         <section title="Meta-schema">
             <t>
-                The current URI for the JSON Schema Validation is &lt;http://json-schema.org/draft-06/hyper-schema#&gt;.
+                The current URI for the JSON Schema Validation is
+                &lt;http://json-schema.org/draft-06/hyper-schema#&gt;.
             </t>
         </section>
 
         <section title="Schema keywords">
             <section title="base">
                 <t>
-                    If present, this keyword is resolved against the current URI base that the entire instance is found within, and sets the new URI base for URI references within the instance.
-                    It is therefore the first URI Reference resolved, regardless of which order it was found in.
+                    If present, this keyword is resolved against the current URI base that the
+                    entire instance is found within, and sets the new URI base for URI references
+                    within the instance.
+                    It is therefore the first URI Reference resolved, regardless of which order it
+                    was found in.
                 </t>
                 <t>
-                    The URI is computed from the provided URI template using the same process described for the <xref target="href">"href"</xref> property of a Link Description Object.
+                    The URI is computed from the provided URI template using the same process
+                    described for the <xref target="href">"href"</xref> property of a Link
+                    Description Object.
                 </t>
                 <figure>
-                    <preamble>An example of a JSON schema using "base":</preamble>
+                    <preamble>
+                        An example of a JSON schema using "base":
+                    </preamble>
                     <artwork>
 <![CDATA[
 {
@@ -244,7 +276,10 @@
                     </artwork>
                 </figure>
                 <figure>
-                    <preamble>An example of a JSON instance using this schema to produce rel="self" and rel="next" links:</preamble>
+                    <preamble>
+                        An example of a JSON instance using this schema to produce rel="self" and
+                        rel="next" links:
+                    </preamble>
                     <artwork>
 <![CDATA[
 {
@@ -255,10 +290,12 @@
                     </artwork>
                 </figure>
                 <t>
-                    If the document URI is &lt;http://example.com/?id=41&gt;, then the new URI base becomes &lt;http://example.com/object/41&gt;
+                    If the document URI is &lt;http://example.com/?id=41&gt;, then the new URI base
+                    becomes &lt;http://example.com/object/41&gt;
                 </t>
                 <t>
-                    Resolving the two Link Description Objects against this URI base creates two links exactly equivalent to these absolute-form HTTP Link headers:
+                    Resolving the two Link Description Objects against this URI base creates two
+                    links exactly equivalent to these absolute-form HTTP Link headers:
                     <list style="symbols">
                         <t>Link: &lt;http://example.com/object/41&gt;;rel=self</t>
                         <t>Link: &lt;http://example.com/object/42&gt;;rel=next</t>
@@ -268,11 +305,15 @@
 
             <section title="links">
                 <t>
-                    The "links" property of schemas is used to associate Link Description Objects with instances.  The value of this property MUST be an array, and the items in the array must be Link Description Objects, as defined below.
+                    The "links" property of schemas is used to associate Link Description Objects
+                    with instances.  The value of this property MUST be an array, and the items in
+                    the array must be Link Description Objects, as defined below.
                 </t>
 
                 <figure>
-                    <preamble>An example schema using the "links" keyword could be:</preamble>
+                    <preamble>
+                        An example schema using the "links" keyword could be:
+                    </preamble>
                     <artwork>
 <![CDATA[{
     "title": "Schema defining links",
@@ -293,41 +334,53 @@
 
             <section title="media">
                 <t>
-                    The "media" property indicates that this instance contains non-JSON data encoded in a JSON string.
+                    The "media" property indicates that this instance contains non-JSON data encoded
+                    in a JSON string.
                     It describes the type of content and how it is encoded.
                 </t>
                 <t>
                     The value of this property MUST be an object.
-                    The value of this property SHOULD be ignored if the instance described is not a string.
+                    The value of this property SHOULD be ignored if the instance described is not a
+                    string.
                 </t>
 
                 <section title="Properties of &quot;media&quot;">
                     <t>
-                        The value of the "media" keyword MAY contain any of the following properties:
+                        The value of the "media" keyword MAY contain any of the following
+                        properties:
                     </t>
 
                     <section title="binaryEncoding">
                         <t>
-                            If the instance value is a string, this property defines that the string SHOULD be interpreted as binary data and decoded using the encoding named by this property.
-                            <xref target="RFC2045">RFC 2045, Sec 6.1</xref> lists the possible values for this property.
+                            If the instance value is a string, this property defines that the string
+                            SHOULD be interpreted as binary data and decoded using the encoding
+                            named by this property.
+                            <xref target="RFC2045">RFC 2045, Sec 6.1</xref> lists the possible
+                            values for this property.
                         </t>
                     </section>
 
                     <section title="type">
                         <t>
-                            The value of this property must be a media type, as defined by <xref target="RFC2046">RFC 2046</xref>.
-                            This property defines the media type of instances which this schema defines.
+                            The value of this property must be a media type, as defined by
+                            <xref target="RFC2046">RFC 2046</xref>. This property defines the media
+                            type of instances which this schema defines.
                         </t>
 
                         <t>
-                            If the "binaryEncoding" property is not set, but the instance value is a string, then the value of this property SHOULD specify a text document type, and the character set SHOULD be the character set into which the JSON string value was decoded (for which the default is Unicode).
+                            If the "binaryEncoding" property is not set, but the instance value is a
+                            string, then the value of this property SHOULD specify a text document
+                            type, and the character set SHOULD be the character set into which the
+                            JSON string value was decoded (for which the default is Unicode).
                         </t>
                     </section>
                 </section>
 
                 <section title="Example">
                     <figure>
-                        <preamble>Here is an example schema, illustrating the use of "media":</preamble>
+                        <preamble>
+                            Here is an example schema, illustrating the use of "media":
+                        </preamble>
                         <artwork>
 <![CDATA[
 {
@@ -339,11 +392,16 @@
 }
 ]]>
                         </artwork>
-                        <postamble>Instances described by this schema should be strings, and their values should be interpretable as base64-encoded PNG images.</postamble>
+                        <postamble>
+                            Instances described by this schema should be strings, and their values
+                            should be interpretable as base64-encoded PNG images.
+                        </postamble>
                     </figure>
 
                     <figure>
-                        <preamble>Another example:</preamble>
+                        <preamble>
+                            Another example:
+                        </preamble>
                         <artwork>
 <![CDATA[
 {
@@ -354,17 +412,25 @@
 }
 ]]>
                         </artwork>
-                        <postamble>Instances described by this schema should be strings containing HTML, using whatever character set the JSON string was decoded into (default is Unicode).</postamble>
+                        <postamble>
+                            Instances described by this schema should be strings containing HTML,
+                            using whatever character set the JSON string was decoded into (default
+                            is Unicode).
+                        </postamble>
                     </figure>
                 </section>
             </section>
 
             <section title="readOnly">
                 <t>
-                    If it has a value of boolean true, this keyword indicates that the value of the instance is managed exclusively by the server or the owning authority, and attempts by a user agent to modify the value of this property are expected to be ignored or rejected by a server.
+                    If it has a value of boolean true, this keyword indicates that the value of the
+                    instance is managed exclusively by the server or the owning authority, and
+                    attempts by a user agent to modify the value of this property are expected to be
+                    ignored or rejected by a server.
                 </t>
                 <t>
-                    For example, this property would be used to mark a server-generated serial number as read-only.
+                    For example, this property would be used to mark a server-generated serial
+                    number as read-only.
                 </t>
                 <t>
                     The value of this keyword MUST be a boolean.
@@ -375,13 +441,18 @@
 
         <section title="Link Description Object">
             <t>
-                A Link Description Object (LDO) is used to describe a single link relation from the instance to another resource.
+                A Link Description Object (LDO) is used to describe a single link relation from the
+                instance to another resource.
                 A Link Description Object must be an object.
             </t>
 
             <t>
-                The link description format can be used without JSON Schema, and use of this format can be declared by referencing the normative link description schema as the schema for the data structure that uses the links.
-                The URI of the normative link description schema is: <eref target="http://json-schema.org/draft-06/links">http://json-schema.org/draft-06/links</eref> (draft-06 version).
+                The link description format can be used without JSON Schema, and use of this format
+                can be declared by referencing the normative link description schema as the schema
+                for the data structure that uses the links.
+                The URI of the normative link description schema is:
+                <eref target="http://json-schema.org/draft-06/links">http://json-schema.org/draft-06/links</eref>
+                (draft-06 version).
             </t>
 
             <section title="Links, operations, and data">
@@ -409,8 +480,8 @@
                     Link Description Objects do not directly indicate what operations, such
                     as HTTP methods, are supported by the target resource.  Instead, operations
                     should be inferred primarily from link <xref target="rel">relation types</xref>
-                    and URI schemes.  Note, however, that a resource may always decline an operation at
-                    runtime, for instance due to application state that controls the operation's
+                    and URI schemes.  Note, however, that a resource may always decline an operation
+                    at runtime, for instance due to application state that controls the operation's
                     availability.
                 </t>
                 <section title="Resolving templated URIs">
@@ -420,8 +491,8 @@
                         <xref target="hrefSchema">"hrefSchema"</xref> allows a link to specify
                         a schema for resolving template variables from client-supplied data.
                         Regular JSON Schema validation features can be used to require resolution
-                        from user agent data, forbid it, or allow user agent data while falling back to
-                        server-supplied instance data if no user agent data is provided.
+                        from user agent data, forbid it, or allow user agent data while falling back
+                        to server-supplied instance data if no user agent data is provided.
                     </t>
                     <t>
                         The common pattern of resolving a templated path component with
@@ -437,12 +508,12 @@
                 <section title="Manipulating the target resource representation">
                     <t>
                         In JSON Hyper-Schema, <xref target="targetSchema">"targetSchema"</xref>
-                        supplies a non-authoritative description of the target resource's representation.
-                        A client can use "targetSchema" to structure input for replacing or
-                        modifying the representation.  Alternatively, if "targetSchema" is absent
-                        or if the client prefers to only use authoritative information, it can
-                        interact with the target resource to confirm or discover its representation
-                        structure.
+                        supplies a non-authoritative description of the target resource's
+                        representation. A client can use "targetSchema" to structure input for
+                        replacing or modifying the representation.  Alternatively, if "targetSchema"
+                        is absent or if the client prefers to only use authoritative information, it
+                        can interact with the target resource to confirm or discover its
+                        representation structure.
                     </t>
                     <t>
                         "targetSchema" is not intended to describe link operation responses,
@@ -457,9 +528,9 @@
                     <t>
                         The <xref target="submissionSchema">"submissionSchema"</xref> and
                         <xref target="submissionEncType">"submissionEncType"</xref> keywords
-                        describe the domain of the processing function implemented by the target resource.
-                        Otherwise, as noted above, the submission schema and encoding are ignored
-                        for operations to which they are not relevant.
+                        describe the domain of the processing function implemented by the target
+                        resource. Otherwise, as noted above, the submission schema and encoding are
+                        ignored for operations to which they are not relevant.
                     </t>
                 </section>
             </section>
@@ -468,8 +539,11 @@
 
             <section title="href" anchor="href">
                 <t>
-                    The value of the "href" link description property is a template used to determine the target URI of the related resource.
-                    The value of the instance property MUST be resolved as a <xref target="RFC3986">URI-reference</xref> against the base URI of the instance.
+                    The value of the "href" link description property is a template used to
+                    determine the target URI of the related resource.
+                    The value of the instance property MUST be resolved as a
+                    <xref target="RFC3986">URI-reference</xref> against the base URI of the
+                    instance.
                 </t>
                 <t>
                     This property is REQUIRED.
@@ -478,27 +552,44 @@
                 <section title="URI Templating">
                     <t>
                         <cref>
-                            The pre-processing rules present in earlier drafts have been removed due to their complexity and inability to address all limitations with URI templating.  This section is subject to significant change in upcoming drafts to replace the old pre-processing with a comprehensive solution.
+                            The pre-processing rules present in earlier drafts have been removed due
+                            to their complexity and inability to address all limitations with URI
+                            templating.
+                            This section is subject to significant change in upcoming drafts to
+                            replace the old pre-processing with a comprehensive solution.
                         </cref>
                     </t>
                     <t>
-                        The value of "href" is to be used as a URI Template, as defined in <xref target="RFC6570">RFC 6570</xref>.  However, some special considerations apply:
+                        The value of "href" is to be used as a URI Template, as defined in
+                        <xref target="RFC6570">RFC 6570</xref>.
+                        However, some special considerations apply:
                     </t>
 
                     <section title="Values for substitution">
                         <t>
-                            The URI Template is filled out using data from some combination of an external source and the instance.
-                            Where either instance data or user agent data may be used, this section will refer simply to "data" or to a "value".
+                            The URI Template is filled out using data from some combination of an
+                            external source and the instance.
+                            Where either instance data or user agent data may be used, this section
+                            will refer simply to "data" or to a "value".
                             When the source is important, it is specified explicitly.
 
-                            To allow the use of any object property (including the empty string) or array index, the following rules are defined:
+                            To allow the use of any object property (including the empty string) or
+                            array index, the following rules are defined:
                         </t>
 
                         <t>
-                            For a given variable name in the URI Template, the value to use is determined as follows:
+                            For a given variable name in the URI Template, the value to use is
+                            determined as follows:
                             <list>
-                                <t>If the data is an array, and the variable name is a representation of a non-negative integer, then the value at the corresponding array index MUST be used (if it exists).</t>
-                                <t>Otherwise, the variable name should be percent-decoded, and the corresponding object property MUST be used (if it exists).</t>
+                                <t>
+                                    If the data is an array, and the variable name is a
+                                    representation of a non-negative integer, then the value at the
+                                    corresponding array index MUST be used (if it exists).
+                                </t>
+                                <t>
+                                    Otherwise, the variable name should be percent-decoded, and the
+                                    corresponding object property MUST be used (if it exists).
+                                </t>
                             </list>
                         </t>
 
@@ -513,16 +604,30 @@
 
                         <section title="Converting to strings">
                             <t>
-                                When any value referenced by the URI template is null, a boolean or a number, then it should first be converted into a string as follows:
+                                When any value referenced by the URI template is null, a boolean or
+                                a number, then it should first be converted into a string as
+                                follows:
                                 <list>
-                                    <t>null values SHOULD be replaced by the text "null"</t>
-                                    <t>boolean values SHOULD be replaced by their lower-case equivalents: "true" or "false"</t>
-                                    <t>numbers SHOULD be replaced with their original JSON representation.</t>
+                                    <t>
+                                        null values SHOULD be replaced by the text "null"
+                                    </t>
+                                    <t>
+                                        boolean values SHOULD be replaced by their lower-case
+                                        equivalents: "true" or "false"
+                                    </t>
+                                    <t>
+                                        numbers SHOULD be replaced with their original JSON
+                                        representation.
+                                    </t>
                                 </list>
                             </t>
                             <t>
-                                In some software environments the original JSON representation of a number will not be available (there is no way to tell the difference between 1.0 and 1), so any reasonable representation should be used.
-                                Schema and API authors should bear this in mind, and use other types (such as string or boolean) if the exact representation is important.
+                                In some software environments the original JSON representation of a
+                                number will not be available (there is no way to tell the difference
+                                between 1.0 and 1), so any reasonable representation should be used.
+                                Schema and API authors should bear this in mind, and use other types
+                                (such as string or boolean) if the exact representation is
+                                important.
                             </t>
                         </section>
                     </section>
@@ -530,12 +635,17 @@
                     <section title="Missing values">
                         <t>
                             Sometimes, the appropriate values will not be available.
-                            For example, the template might specify the use of object properties, but no such data was provided (or "hrefSchema" is not present), and the instance is an array or a string.
+                            For example, the template might specify the use of object properties,
+                            but no such data was provided (or "hrefSchema" is not present), and the
+                            instance is an array or a string.
                         </t>
 
                         <t>
-                            If any of the values required for the template are neither present in the user agent data (if relevant) nor the JSON instance, then substitute values MAY be provided from another source (such as default values).
-                            Otherwise, the link definition SHOULD be considered not to apply to the instance.
+                            If any of the values required for the template are neither present in
+                            the user agent data (if relevant) nor the JSON instance, then substitute
+                            values MAY be provided from another source (such as default values).
+                            Otherwise, the link definition SHOULD be considered not to apply to the
+                            instance.
                         </t>
                     </section>
                 </section>
@@ -635,19 +745,27 @@
 
             <section title="rel" anchor="rel">
                 <t>
-                    The value of the "rel" property indicates the name of the relation to the target resource. The value MUST be a registered link relation from the <xref target="RFC5988">IANA Link Relation Type Registry established in RFC 5988</xref>, or a normalized URI following the <xref target="RFC3986">URI production of RFC 3986</xref>.
+                    The value of the "rel" property indicates the name of the relation to the target
+                    resource. The value MUST be a registered link relation from the
+                    <xref target="RFC5988">IANA Link Relation Type Registry established in RFC 5988</xref>,
+                    or a normalized URI following the <xref target="RFC3986">URI production of RFC 3986</xref>.
                 </t>
 
                 <t>
-                    The relation to the target is interpreted as from the instance that the schema (or sub-schema) applies to, not any larger document that the instance may have been found in.
+                    The relation to the target is interpreted as from the instance that the schema
+                    (or sub-schema) applies to, not any larger document that the instance may have
+                    been found in.
                 </t>
 
                 <t>
-                    Relationship definitions are not normally media type dependent, and users are encouraged to utilize existing accepted relation definitions.
+                    Relationship definitions are not normally media type dependent, and users are
+                    encouraged to utilize existing accepted relation definitions.
                 </t>
 
                 <figure>
-                    <preamble>For example, if a hyper-schema is defined:</preamble>
+                    <preamble>
+                        For example, if a hyper-schema is defined:
+                    </preamble>
                     <artwork>
 <![CDATA[{
     "type": "array",
@@ -665,7 +783,10 @@
                 </figure>
 
                 <figure>
-                    <preamble>And if a collection of instance resources were retrieved with JSON representation:</preamble>
+                    <preamble>
+                        And if a collection of instance resources were retrieved with JSON
+                        representation:
+                    </preamble>
                     <artwork>
 <![CDATA[GET /Resource/
 
@@ -678,20 +799,30 @@
 }]]]>
                     </artwork>
                     <postamble>
-                        This would indicate that for the first item in the collection, its URI as its own resource would resolve to "/Resource/thing" and the first item's "up" relation SHOULD be resolved to the resource at "/Resource/parent".
+                        This would indicate that for the first item in the collection, its URI as
+                        its own resource would resolve to "/Resource/thing" and the first item's
+                        "up" relation SHOULD be resolved to the resource at "/Resource/parent".
                     </postamble>
                 </figure>
 
                 <t>
-                    Note that these relationship values are case-insensitive, consistent with their use in HTML and the <xref target="RFC5988">HTTP Link header</xref>.
+                    Note that these relationship values are case-insensitive, consistent with their
+                    use in HTML and the <xref target="RFC5988">HTTP Link header</xref>.
                 </t>
 
                 <section title="Security Considerations for &quot;self&quot; links">
                     <t>
-                        When link relation of "self" is used to denote a full representation of an object, the user agent SHOULD NOT consider the representation to be the authoritative representation of the resource denoted by the target URI if the target URI is not equivalent to or a sub-path of the URI used to request the resource representation which contains the target URI with the "self" link.
+                        When link relation of "self" is used to denote a full representation of an
+                        object, the user agent SHOULD NOT consider the representation to be the
+                        authoritative representation of the resource denoted by the target URI if
+                        the target URI is not equivalent to or a sub-path of the URI used to request
+                        the resource representation which contains the target URI with the "self"
+                        link.
 
                         <figure>
-                            <preamble>For example, if a hyper-schema was defined:</preamble>
+                            <preamble>
+                                For example, if a hyper-schema was defined:
+                            </preamble>
                             <artwork>
 <![CDATA[{
     "links": [{
@@ -703,7 +834,9 @@
                         </figure>
 
                         <figure>
-                            <preamble>And a resource was requested from somesite.com:</preamble>
+                            <preamble>
+                                And a resource was requested from somesite.com:
+                            </preamble>
                             <artwork>
 <![CDATA[
 GET /foo/
@@ -712,7 +845,9 @@ GET /foo/
                         </figure>
 
                         <figure>
-                            <preamble>With a response of (with newlines and whitespace added):</preamble>
+                            <preamble>
+                                With a response of (with newlines and whitespace added):
+                            </preamble>
                             <artwork>
 <![CDATA[Content-Type: application/json; profile="http://example.com/alpha"
 
@@ -759,29 +894,32 @@ GET /foo/
                 </t>
                 <section title="&quot;targetSchema&quot; and HTTP" anchor="targetHTTP">
                     <t>
-                        The relationship between a resource's representation and
-                        HTTP requests and responses is determined by
-                        <xref target="RFC7231">RFC 7231, section 4.3.1 - "GET", section 4.3.4 "PUT", and section 3.1.4.2, "Content-Location"</xref>.
-                        In particular, "targetSchema" suggests what a client can expect
-                        for the response to an HTTP GET or any response for which
-                        the "Content-Location" header is equal to the request URI,
-                        and what a client should send if it replaces the resource
-                        in an HTTP PUT request.
-                        Per <xref target="RFC5789">RFC 5789</xref>, the request structure
-                        for an HTTP PATCH is determined by the combination of "targetSchema"
-                        and the request media type.
+                        The relationship between a resource's representation and HTTP requests and
+                        responses is determined by <xref target="RFC7231">RFC 7231, section 4.3.1 -
+                            "GET", section 4.3.4 "PUT", and section 3.1.4.2,
+                            "Content-Location"</xref>. In particular, "targetSchema" suggests what a
+                        client can expect for the response to an HTTP GET or any response for which
+                        the "Content-Location" header is equal to the request URI, and what a client
+                        should send if it replaces the resource in an HTTP PUT request. Per <xref
+                            target="RFC5789">RFC 5789</xref>, the request structure for an HTTP
+                        PATCH is determined by the combination of "targetSchema" and the request
+                        media type.
                     </t>
                 </section>
                 <section title="Security Considerations for &quot;targetSchema&quot;">
                     <t>
                         This property has similar security concerns to that of "mediaType".
-                        Clients MUST NOT use the value of this property to aid in the interpretation of the data received in response to following the link, as this leaves "safe" data open to re-interpretation.
+                        Clients MUST NOT use the value of this property to aid in the interpretation
+                        of the data received in response to following the link, as this leaves
+                        "safe" data open to re-interpretation.
                     </t>
                     <t>
                         <figure>
                             <preamble>
-                                For example, suppose two programmers are having a discussion about web security using a text-only message board.
-                                Here is some data from that conversation, with a URI of: http://forum.example.com/topics/152/comments/13
+                                For example, suppose two programmers are having a discussion about
+                                web security using a text-only message board.
+                                Here is some data from that conversation, with a URI of:
+                                http://forum.example.com/topics/152/comments/13
                             </preamble>
                             <artwork>
 <![CDATA[{
@@ -805,7 +943,8 @@ GET /foo/
                         </figure>
                     </t>
                     <t>
-                        A third party might then provide the following Link Description Object at another location:
+                        A third party might then provide the following Link Description Object at
+                        another location:
                         <figure>
                             <artwork>
 <![CDATA[{
@@ -824,8 +963,10 @@ GET /foo/
 }]]>
                             </artwork>
                             <postamble>
-                                If the client used this "targetSchema" value when interpreting the above data, then it might display the contents of "message" as HTML.
-                                At this point, the JavaScript embedded in the message might be executed (in the context of the "forum.example.com" domain).
+                                If the client used this "targetSchema" value when interpreting the
+                                above data, then it might display the contents of "message" as HTML.
+                                At this point, the JavaScript embedded in the message might be
+                                executed (in the context of the "forum.example.com" domain).
                             </postamble>
                         </figure>
                     </t>
@@ -834,26 +975,42 @@ GET /foo/
 
             <section title="mediaType">
                 <t>
-                    The value of this property is advisory only, and represents the media type <xref target="RFC2046">RFC 2046</xref>, that is expected to be returned when fetching this resource.
-                    This property value MAY be a media range instead, using the same pattern defined in <xref target="RFC7231">RFC 7231, section 5.3.2 - HTTP "Accept" header</xref>.
+                    The value of this property is advisory only, and represents the media type
+                    <xref target="RFC2046">RFC 2046</xref>, that is expected to be returned when
+                    fetching this resource.
+                    This property value MAY be a media range instead, using the same pattern defined
+                    in <xref target="RFC7231">RFC 7231, section 5.3.2 - HTTP "Accept" header</xref>.
                 </t>
 
                 <t>
-                    This property is analogous to the "type" property of &lt;a&gt; elements in HTML (advisory content type), or the "type" parameter in the <xref target="RFC5988">HTTP Link header</xref>.
-                    User agents MAY use this information to inform the interface they present to the user before the link is followed, but this information MUST NOT use this information in the interpretation of the resulting data.
-                    When deciding how to interpret data obtained through following this link, the behaviour of user agents MUST be identical regardless of the value of the this property.
+                    This property is analogous to the "type" property of &lt;a&gt; elements in HTML
+                    (advisory content type), or the "type" parameter in the
+                    <xref target="RFC5988">HTTP Link header</xref>.
+                    User agents MAY use this information to inform the interface they present to the
+                    user before the link is followed, but this information MUST NOT use this
+                    information in the interpretation of the resulting data.
+                    When deciding how to interpret data obtained through following this link, the
+                    behaviour of user agents MUST be identical regardless of the value of the this
+                    property.
                 </t>
 
                 <t>
-                    If this property's value is specified, and the link's target is to be obtained using any protocol that supports the HTTP/1.1 "Accept" header <xref target="RFC7231">RFC 7231, section 5.3.2</xref>, then user agents MAY use the value of this property to aid in the assembly of that header when making the request to the server.
+                    If this property's value is specified, and the link's target is to be obtained
+                    using any protocol that supports the HTTP/1.1 "Accept" header
+                    <xref target="RFC7231">RFC 7231, section 5.3.2</xref>, then user agents MAY use
+                    the value of this property to aid in the assembly of that header when making the
+                    request to the server.
                 </t>
 
                 <t>
-                    If this property's value is not specified, then the value should be taken to be "application/json".
+                    If this property's value is not specified, then the value should be taken to be
+                    "application/json".
                 </t>
 
                 <figure>
-                    <preamble>For example, if a schema is defined:</preamble>
+                    <preamble>
+                        For example, if a schema is defined:
+                    </preamble>
                     <artwork>
 <![CDATA[
 {
@@ -878,35 +1035,53 @@ GET /foo/
                     </artwork>
                     <postamble>
                         A suitable instance described by this schema would have four links defined.
-                        The link with a "rel" value of "self" would have an expected MIME type of "application/json" (the default).
-                        The two links with a "rel" value of "alternate" specify the locations of HTML and RSS versions of the current item.
-                        The link with a "rel" value of "icon" links to an image, but does not specify the exact format.
+                        The link with a "rel" value of "self" would have an expected MIME type of
+                        "application/json" (the default).
+                        The two links with a "rel" value of "alternate" specify the locations of
+                        HTML and RSS versions of the current item.
+                        The link with a "rel" value of "icon" links to an image, but does not
+                        specify the exact format.
                     </postamble>
                 </figure>
 
                 <t>
-                    A visual user agent displaying the item from the above example might present a button representing an RSS feed, which when pressed passes the target URI (calculated "href" value) to an view more suited to displaying it, such as a news feed aggregator tab.
+                    A visual user agent displaying the item from the above example might present a
+                    button representing an RSS feed, which when pressed passes the target URI
+                    (calculated "href" value) to an view more suited to displaying it, such as a
+                    news feed aggregator tab.
                 </t>
 
                 <t>
-                    Note that presenting the link in the above manner, or passing the URI to a news feed aggregator view does not constitute interpretation of the data, but an interpretation of the link.
-                    The interpretation of the data itself is performed by the news feed aggregator, which SHOULD reject any data that would not have also been interpreted as a news feed, had it been displayed in the main view.
+                    Note that presenting the link in the above manner, or passing the URI to a news
+                    feed aggregator view does not constitute interpretation of the data, but an
+                    interpretation of the link.
+                    The interpretation of the data itself is performed by the news feed aggregator,
+                    which SHOULD reject any data that would not have also been interpreted as a news
+                    feed, had it been displayed in the main view.
                 </t>
 
                 <section title="Security concerns for &quot;mediaType&quot;">
                     <t>
-                        The "mediaType" property in link definitions defines the expected format of the link's target.
+                        The "mediaType" property in link definitions defines the expected format of
+                        the link's target.
                         However, this is advisory only, and MUST NOT be considered authoritative.
                     </t>
 
                     <t>
-                        When choosing how to interpret data, the type information provided by the server (or inferred from the filename, or any other usual method) MUST be the only consideration, and the "mediaType" property of the link MUST NOT be used.
-                        User agents MAY use this information to determine how they represent the link or where to display it (for example hover-text, opening in a new tab).
-                        If user agents decide to pass the link to an external program, they SHOULD first verify that the data is of a type that would normally be passed to that external program.
+                        When choosing how to interpret data, the type information provided by the
+                        server (or inferred from the filename, or any other usual method) MUST be
+                        the only consideration, and the "mediaType" property of the link MUST NOT be
+                        used.
+                        User agents MAY use this information to determine how they represent the
+                        link or where to display it (for example hover-text, opening in a new tab).
+                        If user agents decide to pass the link to an external program, they SHOULD
+                        first verify that the data is of a type that would normally be passed to
+                        that external program.
                     </t>
 
                     <t>
-                        This is to guard against re-interpretation of "safe" data, similar to the precautions for "targetSchema".
+                        This is to guard against re-interpretation of "safe" data, similar to the
+                        precautions for "targetSchema".
                     </t>
                 </section>
             </section>
@@ -975,9 +1150,13 @@ GET /foo/
                 </t>
 
                 <t>
-                    This is a separate concept from the <xref target="targetSchema">"targetSchema"</xref> property, which is describing the target information resource (including for replacing the contents of the resource in a PUT request), unlike "submissionSchema" which describes the user-submitted request data to be evaluated by the resource.
-                    "submissionSchema" is intended for use with requests that have payloads that are not
-                    defined in terms of the target representation.
+                    This is a separate concept from the
+                    <xref target="targetSchema">"targetSchema"</xref> property, which is describing
+                    the target information resource (including for replacing the contents of the
+                    resource in a PUT request), unlike "submissionSchema" which describes the
+                    user-submitted request data to be evaluated by the resource. "submissionSchema"
+                    is intended for use with requests that have payloads that are not defined in
+                    terms of the target representation.
                 </t>
                 <t>
                     Omitting "submissionSchema" or setting the entire schema to "false" prevents

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -21,7 +21,9 @@
 <?rfc inline="yes" ?>
 <rfc category="info" docName="draft-wright-json-schema-validation-01" ipr="trust200902">
     <front>
-        <title abbrev="JSON Schema Validation">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</title>
+        <title abbrev="JSON Schema Validation">
+            JSON Schema Validation: A Vocabulary for Structural Validation of JSON
+        </title>
 
         <author fullname="Austin Wright" initials="A" surname="Wright" role="editor">
             <address>
@@ -50,22 +52,25 @@
 
         <abstract>
             <t>
-                JSON Schema (application/schema+json) has several purposes, one of which is JSON instance validation.
-                This document specifies a vocabulary for JSON Schema to describe the meaning of JSON documents,
-                provide hints for user interfaces working with JSON data,
-                and to make assertions about what a valid document must look like.
+                JSON Schema (application/schema+json) has several purposes, one of which is JSON
+                instance validation.
+                This document specifies a vocabulary for JSON Schema to describe the meaning of JSON
+                documents, provide hints for user interfaces working with JSON data, and to make
+                assertions about what a valid document must look like.
             </t>
         </abstract>
 
         <note title="Note to Readers">
             <t>
-                The issues list for this draft can be found at <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
+                The issues list for this draft can be found at
+                <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
             </t>
             <t>
                 For additional information, see <eref target="http://json-schema.org/"/>.
             </t>
             <t>
-                To provide feedback, use this issue tracker, the communication methods listed on the homepage, or email the document editors.
+                To provide feedback, use this issue tracker, the communication methods listed on the
+                homepage, or email the document editors.
             </t>
         </note>
     </front>
@@ -116,7 +121,8 @@
 
             <section title="Validation of numeric instances">
                 <t>
-                    The JSON specification allows numbers with arbitrary precision, and JSON Schema does not add any such bounds.
+                    The JSON specification allows numbers with arbitrary precision, and JSON Schema
+                    does not add any such bounds.
                     This means that numeric instances processed by JSON Schema can be arbitrarily large and/or
                     have an arbitrarily long decimal part, regardless of the ability of the
                     underlying programming language to deal with such data.
@@ -167,8 +173,10 @@
                     validation succeeds.
                 </t>
                 <t>
-                    For example, the "maxLength" keyword will only restrict certain strings (that are too long) from being valid.
-                    If the instance is a number, boolean, null, array, or object, the keyword passes validation.
+                    For example, the "maxLength" keyword will only restrict certain strings (that
+                    are too long) from being valid.
+                    If the instance is a number, boolean, null, array, or object, the keyword passes
+                    validation.
                 </t>
             </section>
 
@@ -204,8 +212,8 @@
                 </t>
                 <t>
                     Validation keywords that are missing never restrict validation.
-                    In some cases, this no-op behavior is identical to a keyword that exists with certain values,
-                    and these values are noted where known.
+                    In some cases, this no-op behavior is identical to a keyword that exists with
+                    certain values, and these values are noted where known.
                 </t>
             </section>
 
@@ -217,8 +225,13 @@
                 <t>
                     For schema author convenience, there are some exceptions:
                     <list>
-                        <t>"additionalProperties", whose behavior is defined in terms of "properties" and "patternProperties"; and</t>
-                        <t>"additionalItems", whose behavior is defined in terms of "items".</t>
+                        <t>
+                            "additionalProperties", whose behavior is defined in terms of
+                            "properties" and "patternProperties"; and
+                        </t>
+                        <t>
+                            "additionalItems", whose behavior is defined in terms of "items".
+                        </t>
                     </list>
                 </t>
             </section>
@@ -227,13 +240,15 @@
 
         <section title="Meta-schema">
             <t>
-                The current URI for the JSON Schema Validation is &lt;http://json-schema.org/draft-06/schema#&gt;.
+                The current URI for the JSON Schema Validation is
+                &lt;http://json-schema.org/draft-06/schema#&gt;.
             </t>
         </section>
 
         <section title="Validation keywords">
             <t>
-                Validation keywords in a schema impose requirements for successful validation of an instance.
+                Validation keywords in a schema impose requirements for successful validation of an
+                instance.
             </t>
 
             <section title="multipleOf">
@@ -241,43 +256,52 @@
                     The value of "multipleOf" MUST be a number, strictly greater than 0.
                 </t>
                 <t>
-                    A numeric instance is valid only if division by this keyword's value results in an integer.
+                    A numeric instance is valid only if division by this keyword's value results in
+                    an integer.
                 </t>
             </section>
 
             <section title="maximum">
                 <t>
-                    The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.
+                    The value of "maximum" MUST be a number, representing an inclusive upper limit
+                    for a numeric instance.
                 </t>
                 <t>
-                    If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".
+                    If the instance is a number, then this keyword validates only if the instance is
+                    less than or exactly equal to "maximum".
                 </t>
             </section>
 
             <section title="exclusiveMaximum">
                 <t>
-                    The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance.
+                    The value of "exclusiveMaximum" MUST be number, representing an exclusive upper
+                    limit for a numeric instance.
                 </t>
                 <t>
-                    If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".
+                    If the instance is a number, then the instance is valid only if it has a value
+                    strictly less than (not equal to) "exclusiveMaximum".
                 </t>
             </section>
 
             <section title="minimum">
                 <t>
-                    The value of "minimum" MUST be a number, representing an inclusive upper limit for a numeric instance.
+                    The value of "minimum" MUST be a number, representing an inclusive upper limit
+                    for a numeric instance.
                 </t>
                 <t>
-                    If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".
+                    If the instance is a number, then this keyword validates only if the instance is
+                    greater than or exactly equal to "minimum".
                 </t>
             </section>
 
             <section title="exclusiveMinimum">
                 <t>
-                    The value of "exclusiveMinimum" MUST be number, representing an exclusive upper limit for a numeric instance.
+                    The value of "exclusiveMinimum" MUST be number, representing an exclusive upper
+                    limit for a numeric instance.
                 </t>
                 <t>
-                    If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".
+                    If the instance is a number, then the instance is valid only if it has a value
+                    strictly greater than (not equal to) "exclusiveMinimum".
                 </t>
             </section>
 
@@ -327,7 +351,8 @@
 
             <section title="items">
                 <t>
-                    The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.
+                    The value of "items" MUST be either a valid JSON Schema or an array of valid
+                    JSON Schemas.
                 </t>
                 <t>
                     This keyword determines how child instances validate for arrays,
@@ -551,8 +576,8 @@
                     The value of "propertyNames" MUST be a valid JSON Schema.
                 </t>
                 <t>
-                    If the instance is an object, this keyword validates if every property name in the instance
-                    validates against the provided schema.
+                    If the instance is an object, this keyword validates if every property name in
+                    the instance validates against the provided schema.
                     Note the property name that the schema is testing will always be a string.
                 </t>
                 <t>
@@ -595,7 +620,8 @@
                     or "integer" which matches any number with a zero fractional part.
                 </t>
                 <t>
-                    An instance validates if and only if the instance is in any of the sets listed for this keyword.
+                    An instance validates if and only if the instance is in any of the sets listed
+                    for this keyword.
                 </t>
             </section>
 
@@ -831,7 +857,8 @@
                         This attribute applies to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid URI Reference (either a URI or a relative-reference),
+                        A string instance is valid against this attribute if it is a valid URI
+                        Reference (either a URI or a relative-reference),
                         according to <xref target="RFC3986"/>.
                     </t>
                 </section>
@@ -860,13 +887,17 @@
 
         <section title="Security considerations">
             <t>
-                JSON Schema validation defines a vocabulary for JSON Schema core and concerns all the security considerations listed there.
+                JSON Schema validation defines a vocabulary for JSON Schema core and concerns all
+                the security considerations listed there.
             </t>
             <t>
-                JSON Schema validation allows the use of Regular Expressions, which have numerous different (often incompatible) implementations.
-                Some implementations allow the embedding of arbitrary code, which is outside the scope of JSON Schema and MUST NOT be permitted.
-                Regular expressions can often also be crafted to be extremely expensive to compute (with so-called "catastrophic backtracking"),
-                resulting in a denial-of-service attack.
+                JSON Schema validation allows the use of Regular Expressions, which have numerous
+                different (often incompatible) implementations.
+                Some implementations allow the embedding of arbitrary code, which is outside the
+                scope of JSON Schema and MUST NOT be permitted.
+                Regular expressions can often also be crafted to be extremely expensive to compute
+                (with so-called "catastrophic backtracking"), resulting in a denial-of-service
+                attack.
             </t>
         </section>
 


### PR DESCRIPTION
As mentioned in https://github.com/json-schema-org/json-schema-spec/issues/206#issuecomment-292872393, to hopefully make future review easier.

I choose 100 columns as a compromise because wrapping to 80 columns would lead to narrow blocks of text for deeply nested elements.

I could not find a tool to automate this that gives satisfactory results so I did that by hand. I occasionally left some text exceed the limit when it looked better not wrapped (e.g. to avoid breaking links).

`git diff --word-diff master` can be used to get a relevant diff.