### PR TITLE
Add "description" as an LDO keyword.

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -33,6 +33,10 @@
                     "description": "a title for the link",
                     "type": "string"
                 },
+                "description": {
+                    "description": "additional information about the purpose or usage of the link",
+                    "type": "string"
+                },
                 "targetSchema": {
                     "description": "JSON Schema describing the link target",
                     "allOf": [ { "$ref": "#" } ]

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -877,11 +877,26 @@ GET /foo/
             <section title="title">
                 <t>
                     This property defines a title for the link.
-                    The value must be a string.
+                    The value MUST be a string.
                 </t>
 
                 <t>
                     User agents MAY use this title when presenting the link to the user.
+                </t>
+            </section>
+
+            <section title="description">
+                <t>
+                    This property provides additional information beyond what
+                    is present in the title.  The value MUST be a string.
+                    While a title is preferably short, a description can be
+                    used to go into more detail about the purpose and usage
+                    of the link.
+                </t>
+
+                <t>
+                    User agents MAY use this description when presenting
+                    the link to the user.
                 </t>
             </section>
 


### PR DESCRIPTION
This addresses issue #325.  It adds the description keyword,
analogous to "description" in validation schemas.  In RFC 5988bis
parlance, "description" is an extension target attribute.