### PR TITLE
Clarify what is meant by JSON Pointer format.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -878,8 +878,10 @@
                         This attribute applies to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid JSON Pointer,
-                        according to <xref target="RFC6901"/>
+                        A string instance is valid against this attribute if it
+                        is a valid JSON string representation of a JSON Pointer,
+                        according to
+                        <xref target="RFC6901">RFC 6901, section 5</xref>
                     </t>
                 </section>
             </section>


### PR DESCRIPTION
Addresses issue #328.  URI fragment-encoded JSON Pointers are
already handled by the "uri-reference" format, plus "pattern"
if the media type supports multiple fragment types that would
need to be disambiguated.

Guidance on using "uri-reference" plus "pattern" belongs on
the web site, so I did not add it to the spec.