### PR TITLE
Clarify the use of plain name fragments.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -456,10 +456,16 @@
                 <t>
                     To name subschemas in a JSON Schema document,
                     subschemas can use "$id" to give themselves a document-local identifier.
-                    This is done by setting "$id" to a URI reference consisting only of a fragment.
+                    This is done by setting "$id" to a URI reference consisting
+                    only of a plain name fragment (not a JSON Pointer fragment).
                     The fragment identifier MUST begin with a letter ([A-Za-z]), followed by
                     any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons
                     (":"), or periods (".").
+                </t>
+                <t>
+                    Providing a plain name fragment enables a subschema to be
+                    relocated within a schema without requiring that JSON
+                    Pointer references are updated.
                 </t>
                 <t>
                     The effect of defining an "$id" that neither matches the above
@@ -548,7 +554,8 @@
                         When an implementation then looks inside the &lt;#/items&gt; schema, it
                         encounters the &lt;#item&gt; reference, and resolves this to
                         &lt;http://example.net/root.json#item&gt; which is understood as the schema
-                        defined elsewhere in the same document.
+                        defined elsewhere in the same document without needing to
+                        resolve the fragment against the base URI.
                     </t>
                 </section>
                 <section title="External references">


### PR DESCRIPTION
Also clarify that internal referencing allows skipping the process
of resolving URI references.

Addresses issue #318.

@reece, I ended up changing your suggestion a bit and putting some up in the "how to define an `$id`" section and some in the section you noted about how internal reference resolution works.  Please let me know if that still makes sense.