### PR TITLE
Set up a blank change log for the next draft.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -20,7 +20,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-wright-json-schema-01" ipr="trust200902">
+<rfc category="info" docName="draft-wright-json-schema-02" ipr="trust200902">
     <front>
         <title abbrev="JSON Schema">JSON Schema: A Media Type for Describing JSON Documents</title>
 
@@ -832,6 +832,11 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-wright-json-schema-02">
+                        <list style="symbols">
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-wright-json-schema-01">
                         <list style="symbols">
                             <t>Updated intro</t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -19,7 +19,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-wright-json-schema-hyperschema-01" ipr="trust200902">
+<rfc category="info" docName="draft-wright-json-schema-hyperschema-02" ipr="trust200902">
     <front>
         <title abbrev="JSON Hyper-Schema">
             JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON
@@ -1230,6 +1230,11 @@ GET /foo/
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-wright-json-schema-hyperschema-02">
+                        <list style="symbols">
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-wright-json-schema-hyperschema-01">
                         <list style="symbols">
                             <t>Fixed examples</t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -19,7 +19,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-wright-json-schema-validation-01" ipr="trust200902">
+<rfc category="info" docName="draft-wright-json-schema-validation-02" ipr="trust200902">
     <front>
         <title abbrev="JSON Schema Validation">
             JSON Schema Validation: A Vocabulary for Structural Validation of JSON
@@ -974,6 +974,11 @@
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-wright-json-schema-validation-02">
+                        <list style="symbols">
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-wright-json-schema-validation-01">
                         <list style="symbols">
                             <t>Standardized on hyphenated format names ("uriref" becomes "uri-ref")</t>


### PR DESCRIPTION
None of the open PRs have a change log, because they would
all conflict with each other.  This initializes empty change
logs and updates the draft numbering accordingly.

Note that there must be at least an empty <t></t> in the list
or the XML won't validate against its DTD.

Ensuring that the entire changelog is filled out is part of
the pre-publication checklist.