### PR TITLE
Start a contributing guide from the wiki contents.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# JSON Schema
+
+## Issues
+
+Issues should identify an problem, enhancement, or use case; and propose some course of action for the draft. For alternate support channels, [see the json-schema.org website](http://json-schema.org/).
+
+Issues waiting for user feedback will be tagged "Feedback". Up to two weeks will be given for feedback to be provided.
+
+If there seems to be consensus around an issue, the issue will be taken up (and tagged with a milestone) or closed.
+
+## Pull requests
+
+We welcome pull requests, both for editorial suggestions and to resolve open issues.
+
+If the pull request would solve a particular issue, reference the issue in the pull request description.
+
+Changes that would affect implementation behavior should typically be opened as an issue first.
+
+Pull requests should be made to master.
+
+## Writing guidelines
+
+An Internet-Draft publication replaces previous documents in their entirety. Behavorial changes to the document should be reverse-compatible with existing written schemas, or allow for implementations to implement old and removed behavior.
+
+The meta-schema URI is used to differentiate between different vocabularies (Validation and Hyper-schema). The authority on JSON Schema behavior is the respective specification document, not the JSON meta-schema; the JSON version of the meta-schema is maintained in an informative capacity only. However, the meta-schema URI referred to in the document should desginate a fixed JSON document, and updates to this document should be publised at a new URI. Updates should be made to the meta-schema and published at a time when it becomes desirable for new behaviors and features to be described in this fashion.
+
+The "master" branch should always be Internet-Draft ready. The document editor is responsible for ensuring that the writing meets best practices for an I-D. An I-D will be published from "master" branch when wider review is desired, at the editor's discretion.
+
+## Conduct
+
+All official channels including the mailing list, GitHub organization, and Freenode channel, follow the IETF Guidelines for Conduct as specified in [RFC7154](https://tools.ietf.org/html/rfc7154).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# JSON Schema
+# Guidelines for contributing to the JSON Schema project
 
 ## Issues
 


### PR DESCRIPTION
**NOTE:  Since this wording is identical to our existing policy on the wiki, commentary on the contents will be ignored.  This is just about moving things into the file unchanged.  We can debate changing contents with additional PRs.  That is part of the point of moving this into the repo instead of the wiki.**

This file has exactly the contents of the front wiki page, except
for the I-D and meta-schema publishing processes which are not
relevant to most contributors.

I'm moving it into a CONTRIBUTING.md as it integrates with
GitHub's tools (e.g. auto-linking it to the create PR screen)
and will allow us to discuss changes as PRs.

I will change the front wiki page to link to this (but retain
the sections that have not been moved here).