### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+install:
+- pip install xml2rfc
+before_script:
+- TAG=$(git tag -l --points-at HEAD)
+script:
+- xml2rfc jsonschema-core.xml --basename=jsonschema-core-$TAG --text --html
+- xml2rfc jsonschema-validation.xml --basename=jsonschema-validation-$TAG --text --html
+- xml2rfc jsonschema-hyperschema.xml --basename=jsonschema-hyperschema-$TAG --text --html


### PR DESCRIPTION
This adds automatic running of `xml2rfc` on the spec files.  When a tag is pushed it has CD functionality to publish the build HTML and text files to GitHub Releases.

**IMPORTANT:** The `api_key` will need to be changed by someone that can generate a key for this repository.  The one there is for my fork, which I used for testing.  Additionally, a project member will need to enable this repository on Travis CI for this to do anything at all :-)