### PR TITLE
Move "readOnly" from Hyper-Schema to Validation

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -127,11 +127,6 @@
                     "type": "string"
                 }
             }
-        },
-        "readOnly": {
-            "description": "If true, indicates that the value of this property is controlled by the server.",
-            "type": "boolean",
-            "default": "false"
         }
     },
     "links": [

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -425,23 +425,6 @@
                     </figure>
                 </section>
             </section>
-
-            <section title="readOnly">
-                <t>
-                    If it has a value of boolean true, this keyword indicates that the value of the
-                    instance is managed exclusively by the server or the owning authority, and
-                    attempts by a user agent to modify the value of this property are expected to be
-                    ignored or rejected by a server.
-                </t>
-                <t>
-                    For example, this property would be used to mark a server-generated serial
-                    number as read-only.
-                </t>
-                <t>
-                    The value of this keyword MUST be a boolean.
-                    The default value is false.
-                </t>
-            </section>
         </section>
 
         <section title="Link Description Object">

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -740,6 +740,23 @@
                 </t>
             </section>
 
+            <section title='"readOnly"'>
+                <t>
+                    If it has a value of boolean true, this keyword indicates that the value of the
+                    instance is managed exclusively by the server or the owning authority, and
+                    attempts by a user agent to modify the value of this property are expected to be
+                    ignored or rejected by a server.
+                </t>
+                <t>
+                    For example, this property would be used to mark a server-generated serial
+                    number as read-only.
+                </t>
+                <t>
+                    The value of this keyword MUST be a boolean.
+                    The default value is false.
+                </t>
+            </section>
+
             <section title='"examples"'>
                 <t>
                     The value of this keyword MUST be an array.

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -755,6 +755,9 @@
                     number as read-only.
                 </t>
                 <t>
+                    This keyword can be used to assist in user interface instance generation.
+                </t>
+                <t>
                     Omitting this keyword has the same behavior as a value of false.
                 </t>
             </section>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -751,7 +751,7 @@
                     rejected by that owning authority.
                 </t>
                 <t>
-                    For example, this property would be used to mark a server-generated serial
+                    For example, this property would be used to mark a database-generated serial
                     number as read-only.
                 </t>
                 <t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -742,6 +742,9 @@
 
             <section title='"readOnly"'>
                 <t>
+                    The value of this keyword MUST be a boolean.
+                </t>
+                <t>
                     If it has a value of boolean true, this keyword indicates that the value of the
                     instance is managed exclusively by the owning authority, and attempts by a user
                     agent to modify the value of this property are expected to be ignored or
@@ -752,7 +755,6 @@
                     number as read-only.
                 </t>
                 <t>
-                    The value of this keyword MUST be a boolean.
                     Omitting this keyword has the same behavior as a value of false.
                 </t>
             </section>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -746,8 +746,8 @@
                 </t>
                 <t>
                     If it has a value of boolean true, this keyword indicates that the value of the
-                    instance is managed exclusively by the owning authority, and attempts by a user
-                    agent to modify the value of this property are expected to be ignored or
+                    instance is managed exclusively by the owning authority, and attempts by an
+                    application to modify the value of this property are expected to be ignored or
                     rejected by that owning authority.
                 </t>
                 <t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -753,7 +753,7 @@
                 </t>
                 <t>
                     The value of this keyword MUST be a boolean.
-                    The default value is false.
+                    Omitting this keyword has the same behavior as a value of false.
                 </t>
             </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -743,9 +743,9 @@
             <section title='"readOnly"'>
                 <t>
                     If it has a value of boolean true, this keyword indicates that the value of the
-                    instance is managed exclusively by the server or the owning authority, and
-                    attempts by a user agent to modify the value of this property are expected to be
-                    ignored or rejected by a server.
+                    instance is managed exclusively by the owning authority, and attempts by a user
+                    agent to modify the value of this property are expected to be ignored or
+                    rejected by that owning authority.
                 </t>
                 <t>
                     For example, this property would be used to mark a server-generated serial

--- a/schema.json
+++ b/schema.json
@@ -63,7 +63,7 @@
         "readOnly": {
             "description": "If true, indicates that the value of this property is controlled by the server.",
             "type": "boolean",
-            "default": "false"
+            "default": false
         },
         "examples": {
             "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -61,7 +61,6 @@
         },
         "default": {},
         "readOnly": {
-            "description": "If true, indicates that the value of this property is controlled by the server.",
             "type": "boolean",
             "default": false
         },

--- a/schema.json
+++ b/schema.json
@@ -60,6 +60,11 @@
             "type": "string"
         },
         "default": {},
+        "readOnly": {
+            "description": "If true, indicates that the value of this property is controlled by the server.",
+            "type": "boolean",
+            "default": "false"
+        },
         "examples": {
             "type": "array",
             "items": {}


### PR DESCRIPTION
This addresses part of #363, which states that some keywords historically in the Hyper-Schema specification would be better in the Validation document. The main argument for moving keywords such as "readOnly" is that the Hyper-Schema document could then only focus on describing the hypermedia linking model.

The second commit fixes the default value of `readOnly` (wrong type).