### PR TITLE
Add "targetHints"

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -1076,6 +1076,9 @@ GET /foo/
                 </t>
                 <section title='"targetHints" for HTTP'>
                     <t>
+                        <cref>It would be good to also include a section with CoAP examples.</cref>
+                    </t>
+                    <t>
                         JSON serializations of HTTP response header information SHOULD follow the
                         guidelines established by the work in progress
                         <xref target="I-D.reschke-http-jfv">"A JSON Encoding for HTTP Header Field Values"</xref>.
@@ -1101,11 +1104,6 @@ GET /foo/
 }]]>
                         </artwork>
                     </figure>
-                </section>
-                <section title='"targetHints for CoAP"'>
-                    <t>
-                        <cref>TBD</cref>
-                    </t>
                 </section>
             </section>
 

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -10,6 +10,7 @@
 <!ENTITY rfc5988 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml">
 <!ENTITY rfc6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
 <!ENTITY rfc7231 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml">
+<!ENTITY I-D.reschke-http-jfv SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-reschke-http-jfv-06.xml">
 ]>
 <?rfc toc="yes"?>
 <?rfc symrefs="yes"?>
@@ -1028,6 +1029,86 @@ GET /foo/
                 </section>
             </section>
 
+            <section title="targetHints" anchor="targetHints">
+                <t>
+                    <cref>
+                        This section attempts to strike a balance between comprehensiveness
+                        and flexibility by deferring most of its structure to the protocol
+                        indicated by the URI scheme.  Note that a resource can be identified
+                        by a URI with a dereferenceable scheme, yet not be accessible over
+                        that protocol.  While currently very loose, this section is expected
+                        to become more well-defined based on draft feedback, and may change
+                        significantly in future drafts.
+                    </cref>
+                </t>
+                <t>
+                    The value of this property is advisory only.  It represents information that
+                    is expected to be discoverable through interacting with the target resource,
+                    typically in the form of protocol-specific control information or meta-data
+                    such as headers returned in response to an HTTP HEAD or OPTIONS request.
+                    The protocol is determined by the "href" URI scheme, although note that
+                    resources are not guaranteed to be accessible over such a protocol.
+                </t>
+                <t>
+                    The value of this property SHOULD be an object.  The keys to this object
+                    SHOULD be lower-cased forms of the control data field names.  Each value
+                    SHOULD be an array, in order to uniformly handle multi-valued fields.
+                    Multiple values MUST be presented as an array, and not as a single string.
+                </t>
+                <t>
+                    Protocols with control information not suitable for representation as
+                    a JSON object MAY be represented by another data type, such as an array.
+                </t>
+                <t>
+                    Values that cannot be understood as part of the indicated protocol MUST
+                    be ignored by a JSON Hyper-Schema implementation.  Applications MAY make
+                    use of such values, but MUST NOT assume interoperability with other
+                    implementations.
+                </t>
+                <t>
+                    Implementations MUST NOT assume that all discoverable information is
+                    accounted for in this object.  Clients MUST properly handle run-time responses
+                    that contradict this property's values.
+                </t>
+                <t>
+                    Clients MUST NOT assume that an implementation will automatically take any
+                    action based on the value of this property.
+                </t>
+                <section title='"targetHints" for HTTP'>
+                    <t>
+                        JSON serializations of HTTP response header information SHOULD follow the
+                        guidelines established by the work in progress
+                        <xref target="I-D.reschke-http-jfv">"A JSON Encoding for HTTP Header Field Values"</xref>.
+                        Approaches shown in that document's examples SHOULD be applied to other
+                        similarly structured headers wherever possible.
+                    </t>
+                    <t>
+                        No distinction is made between headers that may appear in responses to
+                        different methods, such as HEAD vs OPTIONS.
+                    </t>
+                    <figure>
+                        <preamble>
+                            This examples shows several hints that are useful for clients
+                            when determining what requests to make and how to make them.
+                        </preamble>
+                        <artwork>
+<![CDATA[{
+    "targetHints": {
+        "allow": ["GET", "PUT"],
+        "accept-patch": ["application/merge-patch+json"],
+        "accept-ranges": ["none"]
+    }
+}]]>
+                        </artwork>
+                    </figure>
+                </section>
+                <section title='"targetHints for CoAP"'>
+                    <t>
+                        <cref>TBD</cref>
+                    </t>
+                </section>
+            </section>
+
             <section title="mediaType">
                 <t>
                     The value of this property is advisory only, and represents the media type
@@ -1059,7 +1140,8 @@ GET /foo/
 
                 <t>
                     If this property's value is not specified, then the value should be taken to be
-                    "application/json".
+                    "application/json".  Hyper-Schema authors SHOULD NOT use a protocol-specific
+                    value in <xref target="targetHints">"targetHints"</xref> for this purpose.
                 </t>
 
                 <figure>
@@ -1235,6 +1317,7 @@ GET /foo/
             &rfc3986;
             <!--&rfc4287;-->
             &rfc6570;
+            &I-D.reschke-http-jfv;
             <reference anchor="json-schema">
                 <front>
                     <title>JSON Schema: A Media Type for Describing JSON Documents</title>

--- a/links.json
+++ b/links.json
@@ -32,6 +32,9 @@
                 { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
             ]
         },
+        "targetHints": {
+            "description": "JSON representation of likely metadata such as response headers, with a protocol-dependent format"
+        },
         "mediaType": {
             "type": "string"
         },


### PR DESCRIPTION
This is a very tentative first pass to get the discussion started.

This addresses half of #296, specifically advertising information
about the target that would likely be discovered through mechanism
such as the headers of an HTTP HEAD and/or OPTIONS response.
The half for describing request header (or analogous) data will
be posted separately after we see how this goes.

The goal for this draft is to specify this well enough to get
real-world implementations and feedback.  It seems best to
approach that goal by providing loose guidelines and encouraging
experimentation.

The lack of a standard way to advertise HTTP method support,
for instance, is a ***major barrier to adoption for many who have
expressed interest in Hyper-Schema***.

This draft needs to include an approach that will at least
easily fulfill that need while encouraging feedback on what
further guidance is needed for more comprehensive use.
Waiting for the next draft to work up a more detailed
proposal that might not hold up in the wild anyway will
only delay adoption and feedback.

This will be more useful for feedback than simply providing
an "allow" keyword, as it will encourage exploring other
use cases, which a narrowly targeted "allow" keyword would not.