### PR TITLE
Add "hrefPointers" for adjusting resolution

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -588,7 +588,7 @@
     "links": [
         {
             "rel": "self",
-            "href": "/trees{/root,parent,id}"
+            "href": "/trees{/root,parent,id}",
             "hrefPointers": {
                 "root": "/id",
                 "parent": "2/id"
@@ -597,17 +597,27 @@
     ]
 }]]>
                     </artwork>
-                    <postamble>
-                        The self links here should always include the root node id,
-                        followed by an immediate parent id if one exists, and always ending
-                        with the id of the node that is the context of the self link.
-                        The context node's id resolves with the standard process and
-                        does not appear in "hrefPointers".  The root id is located
-                        using an absolute JSON Pointer, while the parent node
-                        uses a Relative JSON Pointer, going up two levels (one level up
-                        is the array of children, two levels up is the whole parent node).
-                    </postamble>
                 </figure>
+                <t>
+                    The self links here should always include the root node id,
+                    followed by an immediate parent id if one exists, and always ending
+                    with the id of the node that is the context of the self link.
+                </t>
+                <t>
+                    The context node's id resolves with the standard process and
+                    does not appear in "hrefPointers".  The root id is located
+                    using an absolute JSON Pointer, while the parent node
+                    uses a Relative JSON Pointer, going up two levels (one level up
+                    is the array of children, two levels up is the whole parent node).
+                </t>
+                <t>
+                    This design never has more than three ids in the URI.  Nodes
+                    along the path between the root and the immediate parent,
+                    if any, are omitted.  This illustrates a limitation of JSON Schema:
+                    Producing a variable-length path URI to any arbitrary depth is
+                    not possible without redesigning the representation to make an
+                    array of path ids available in each node.
+                </t>
                 <figure>
                     <preamble>
                         Given the following instance:
@@ -621,7 +631,10 @@
       "id": 2,
       "children": [ {
         "id": 3
-} ] } ] } ] }]]>
+      } ]
+    } ]
+  } ]
+}]]>
                     </artwork>
                 </figure>
                 <t>
@@ -629,13 +642,15 @@
                     by JSON Pointers:
                     <list style="hanging">
                         <t hangText='"" (the root node)'>/trees/0/0</t>
-                        <t hangText='"/children/0/children/0"'>/trees/0/0/1</t>
-                        <t hangText='"/children/0/children/0/children/0"'>/trees/0/1/2</t>
-                        <t hangText='"/children/0/children/0/children/0/children/0"'>/trees/0/2/3</t>
+                        <t hangText='"/children/0"'>/trees/0/0/1</t>
+                        <t hangText='"/children/0/children/0"'>/trees/0/1/2</t>
+                        <t hangText='"/children/0/children/0/children/0"'>/trees/0/2/3</t>
                     </list>
                     This shows the use of an absolute JSON Pointer to always resolve
                     the root node from any depth, and a Relative JSON Pointer to always resolve
                     the immediate parent, which cannot be identified with an absolute pointer.
+                </t>
+                <t>
                     For the root node, there is no defined parent, so per URI Template resolution
                     rules, that variable and the path component that it would produce are simply
                     omitted, giving us the desired URI with two components after "/trees".

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -537,7 +537,7 @@
                         </section>
                     </section>
 
-                    <section title="Missing values">
+                    <section title="Missing values" anchor="missingValues">
                         <t>
                             Sometimes, the appropriate values will not be available.
                             For example, the template might specify the use of object properties,
@@ -574,8 +574,13 @@
                 </t>
                 <figure>
                     <preamble>
-                        Consider the following schema for an n-ary tree using the path expansion
-                        URI Template syntax:
+                        Recall that a Relative JSON Pointer which is not also a regular
+                        JSON Pointer begins with a number indicating how many levels
+                        up to move before applying the remainder of the pointer, if any, in the
+                        same manner as a regular JSON Pointer.  Consider the following schema
+                        for n-ary tree nodes, where a node is identified by its own id as well
+                        as the tree's root node id, and links are given for the IANA-registered
+                        "self" and "up" link relation types.
                     </preamble>
                     <artwork>
 <![CDATA[{
@@ -588,10 +593,17 @@
     "links": [
         {
             "rel": "self",
-            "href": "/trees{/root,parent,id}",
+            "href": "/trees/{rootId}/nodes/{id}",
             "hrefPointers": {
-                "root": "/id",
-                "parent": "2/id"
+                "rootId": "/id"
+            }
+        },
+        {
+            "rel": "up",
+            "href": "/trees/{rootId}/nodes/{parentId}",
+            "hrefPointers": {
+                "rootId": "/id",
+                "parentId": "2/id"
             }
         }
     ]
@@ -599,24 +611,12 @@
                     </artwork>
                 </figure>
                 <t>
-                    The self links here should always include the root node id,
-                    followed by an immediate parent id if one exists, and always ending
-                    with the id of the node that is the context of the self link.
-                </t>
-                <t>
                     The context node's id resolves with the standard process and
-                    does not appear in "hrefPointers".  The root id is located
+                    therefore does not appear in "hrefPointers".  The root id is located
                     using an absolute JSON Pointer, while the parent node
                     uses a Relative JSON Pointer, going up two levels (one level up
-                    is the array of children, two levels up is the whole parent node).
-                </t>
-                <t>
-                    This design never has more than three ids in the URI.  Nodes
-                    along the path between the root and the immediate parent,
-                    if any, are omitted.  This illustrates a limitation of JSON Schema:
-                    Producing a variable-length path URI to any arbitrary depth is
-                    not possible without redesigning the representation to make an
-                    array of path ids available in each node.
+                    is the array of children, two levels up is the whole parent node),
+                    and then looking at the "id" field from that point.
                 </t>
                 <figure>
                     <preamble>
@@ -638,22 +638,32 @@
                     </artwork>
                 </figure>
                 <t>
-                    We get the following self links for each node in the instance as identifed
-                    by JSON Pointers:
+                    For each node (as identified by JSON Pointers), we get these "self" links:
                     <list style="hanging">
-                        <t hangText='"" (the root node)'>/trees/0/0</t>
-                        <t hangText='"/children/0"'>/trees/0/0/1</t>
-                        <t hangText='"/children/0/children/0"'>/trees/0/1/2</t>
-                        <t hangText='"/children/0/children/0/children/0"'>/trees/0/2/3</t>
+                        <t hangText='"" (the root node)'>/trees/0/nodes/0</t>
+                        <t hangText='"/children/0"'>/trees/0/nodes/1</t>
+                        <t hangText='"/children/0/children/0"'>/trees/0/nodes/2</t>
+                        <t hangText='"/children/0/children/0/children/0"'>/trees/0/nodes/3</t>
                     </list>
-                    This shows the use of an absolute JSON Pointer to always resolve
-                    the root node from any depth, and a Relative JSON Pointer to always resolve
-                    the immediate parent, which cannot be identified with an absolute pointer.
                 </t>
                 <t>
-                    For the root node, there is no defined parent, so per URI Template resolution
-                    rules, that variable and the path component that it would produce are simply
-                    omitted, giving us the desired URI with two components after "/trees".
+                    and these "up" links:
+                    <list style="hanging">
+                        <t hangText='"/children/0"'>/trees/0/nodes/0</t>
+                        <t hangText='"/children/0/children/0"'>/trees/0/nodes/1</t>
+                        <t hangText='"/children/0/children/0/children/0"'>/trees/0/nodes/2</t>
+                    </list>
+                </t>
+                <t>
+                    For the root node, the relative pointer for the parent doesn't point
+                    to anything.  As noted under
+                    <xref target="missingValues">missing values</xref>, such a link should
+                    simply be ignored.
+                    <cref>
+                        GitHub issue #49 tracks the question of distinguishing this situation
+                        of a missing required variable (common in path components) from
+                        missing optional variables (common in query string parameters).
+                    </cref>
                 </t>
             </section>
 

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -611,12 +611,12 @@
                     </artwork>
                 </figure>
                 <t>
-                    The context node's id resolves with the standard process and
-                    therefore does not appear in "hrefPointers".  The root id is located
-                    using an absolute JSON Pointer, while the parent node
-                    uses a Relative JSON Pointer, going up two levels (one level up
-                    is the array of children, two levels up is the whole parent node),
-                    and then looking at the "id" field from that point.
+                    In "self" link, the context node's id resolves with the standard process and
+                    therefore does not appear in "hrefPointers".  In both "self" and "up" links,
+                    the root id is located using an absolute JSON Pointer. Finally, in "up" link,
+                    the parent node uses a Relative JSON Pointer, going up two levels (one level up
+                    is the array of children, two levels up is the whole parent node), and then
+                    looking at the "id" field from that point.
                 </t>
                 <figure>
                     <preamble>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -9,6 +9,7 @@
 <!ENTITY rfc5988 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml">
 <!ENTITY rfc6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
 <!ENTITY rfc7231 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml">
+<!ENTITY I-D.luff-relative-json-pointer SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-luff-relative-json-pointer-00.xml">
 <!ENTITY I-D.reschke-http-jfv SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-reschke-http-jfv-06.xml">
 ]>
 <?rfc toc="yes"?>
@@ -358,7 +359,15 @@
                 <section title="Resolving templated URIs">
                     <t>
                         URI Template variables in <xref target="href">"href"</xref> resolve from
-                        server-supplied instance data by default.
+                        server-supplied instance data by default.  This data is drawn from the
+                        sub-instance that validated against the schema containing the LDO.
+                    </t>
+                    <t>
+                        <xref target="hrefPointers">"hrefPointers"</xref> allows adjusting
+                        the location from which instance data is resolved on a per-variable
+                        basis.
+                    </t>
+                    <t>
                         <xref target="hrefSchema">"hrefSchema"</xref> allows a link to specify
                         a schema for resolving template variables from client-supplied data.
                         Regular JSON Schema validation features can be used to require resolution
@@ -546,6 +555,84 @@
                     </section>
                 </section>
 
+            </section>
+
+            <section title="hrefPointers" anchor="hrefPointers">
+                <t>
+                    The value of the "hrefPointers" link description property MUST be
+                    an object.  Each property value in the object MUST be a valid
+                    <xref target="I-D.luff-relative-json-pointer">Relative JSON Pointer</xref>,
+                    which is evaluated relative to the position in the instance from which
+                    <xref target="href">"href"</xref> template variable resolution would
+                    normolly begin.
+                </t>
+                <t>
+                    For each property name in the object that matches a variable name in the
+                    "href" URI Template, the value of that property adjusts the starting position
+                    of variable resolution for that variable.  Properties which do not match
+                    "href" template variable names MUST be ignored.
+                </t>
+                <figure>
+                    <preamble>
+                        Consider the following schema for an n-ary tree using the path expansion
+                        URI Template syntax:
+                    </preamble>
+                    <artwork>
+<![CDATA[{
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {"type": "integer", "minimum": 0},
+        "children": {"type": "array", "items": {"$ref": "#"}}
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "/trees{/root,parent,id}"
+            "hrefPointers": {
+        }
+    ]
+}]]>
+                    </artwork>
+                    <postamble>
+                        The self links here should always include the root node id,
+                        followed by an immediate parent id if one exists, and always ending
+                        with the id of the node that is the context of the self link.
+                    </postamble>
+                </figure>
+                <figure>
+                    <preamble>
+                        Given the following instance:
+                    </preamble>
+                    <artwork>
+<![CDATA[{
+  "id": 0,
+  "children": [ {
+    "id": 1,
+    "children": [ {
+      "id": 2,
+      "children": [ {
+        "id": 3
+} ] } ] } ] }]]>
+                    </artwork>
+                </figure>
+                <t>
+                    We get the following self links for each node in the instance as identifed
+                    by JSON Pointers:
+                    <list style="hanging">
+                        <t hangText='"" (the root node)'>/trees/0/0</t>
+                        <t hangText='"/children/0/children/0"'>/trees/0/0/1</t>
+                        <t hangText='"/children/0/children/0/children/0"'>/trees/0/1/2</t>
+                        <t hangText='"/children/0/children/0/children/0/children/0"'>/trees/2/3</t>
+                    </list>
+                    omitted, giving us the desired URI with two components after "/trees".  The
+                    This shows the use of an absolute JSON Pointer to always resolve
+                    the root node from any depth, and a Relative JSON Pointer to always resolve
+                    the immediate parent, which cannot be identified with an absolute pointer.
+                    For the root node, there is no defined parent, so per URI Template resolution
+                    rules, that variable and the path component that it would produce are simply
+                    omitted, giving us the desired URI with two components after "/trees".
+                </t>
             </section>
 
             <section title="hrefSchema" anchor="hrefSchema">
@@ -1190,6 +1277,7 @@ GET /foo/
             &rfc3986;
             <!--&rfc4287;-->
             &rfc6570;
+            &I-D.luff-relative-json-pointer;
             &I-D.reschke-http-jfv;
             <reference anchor="json-schema">
                 <front>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -564,7 +564,7 @@
                     <xref target="I-D.luff-relative-json-pointer">Relative JSON Pointer</xref>,
                     which is evaluated relative to the position in the instance from which
                     <xref target="href">"href"</xref> template variable resolution would
-                    normolly begin.
+                    normally begin.
                 </t>
                 <t>
                     For each property name in the object that matches a variable name in the
@@ -590,6 +590,9 @@
             "rel": "self",
             "href": "/trees{/root,parent,id}"
             "hrefPointers": {
+                "root": "/id",
+                "parent": "2/id"
+            }
         }
     ]
 }]]>
@@ -598,6 +601,11 @@
                         The self links here should always include the root node id,
                         followed by an immediate parent id if one exists, and always ending
                         with the id of the node that is the context of the self link.
+                        The context node's id resolves with the standard process and
+                        does not appear in "hrefPointers".  The root id is located
+                        using an absolute JSON Pointer, while the parent node
+                        uses a Relative JSON Pointer, going up two levels (one level up
+                        is the array of children, two levels up is the whole parent node).
                     </postamble>
                 </figure>
                 <figure>
@@ -623,9 +631,8 @@
                         <t hangText='"" (the root node)'>/trees/0/0</t>
                         <t hangText='"/children/0/children/0"'>/trees/0/0/1</t>
                         <t hangText='"/children/0/children/0/children/0"'>/trees/0/1/2</t>
-                        <t hangText='"/children/0/children/0/children/0/children/0"'>/trees/2/3</t>
+                        <t hangText='"/children/0/children/0/children/0/children/0"'>/trees/0/2/3</t>
                     </list>
-                    omitted, giving us the desired URI with two components after "/trees".  The
                     This shows the use of an absolute JSON Pointer to always resolve
                     the root node from any depth, and a Relative JSON Pointer to always resolve
                     the immediate parent, which cannot be identified with an absolute pointer.

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -8,6 +8,7 @@
 <!ENTITY rfc5789 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5789.xml">
 <!ENTITY rfc5988 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml">
 <!ENTITY rfc6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
+<!ENTITY rfc6906 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6906.xml">
 <!ENTITY rfc7231 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml">
 <!ENTITY I-D.luff-relative-json-pointer SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-luff-relative-json-pointer-00.xml">
 <!ENTITY I-D.reschke-http-jfv SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-reschke-http-jfv-06.xml">
@@ -561,7 +562,8 @@
                 <t>
                     The value of the "hrefPointers" link description property MUST be
                     an object.  Each property value in the object MUST be a valid
-                    <xref target="I-D.luff-relative-json-pointer">Relative JSON Pointer</xref>,
+                    <xref target="RFC6906">JSON Pointer</xref>, or a valid
+                    <xref target="I-D.luff-relative-json-pointer">Relative JSON Pointer</xref>
                     which is evaluated relative to the position in the instance from which
                     <xref target="href">"href"</xref> template variable resolution would
                     normally begin.
@@ -574,13 +576,12 @@
                 </t>
                 <figure>
                     <preamble>
-                        Recall that a Relative JSON Pointer which is not also a regular
-                        JSON Pointer begins with a number indicating how many levels
-                        up to move before applying the remainder of the pointer, if any, in the
-                        same manner as a regular JSON Pointer.  Consider the following schema
-                        for n-ary tree nodes, where a node is identified by its own id as well
-                        as the tree's root node id, and links are given for the IANA-registered
-                        "self" and "up" link relation types.
+                        Recall that a Relative JSON Pointer begins with a number indicating
+                        how many levels up to move before applying the remainder of the pointer,
+                        if any, in the same manner as a regular JSON Pointer.  Consider the
+                        following schema for n-ary tree nodes, where a node is identified by
+                        its own id as well as the tree's root node id, and links are given for
+                        the IANA-registered "self" and "up" link relation types.
                     </preamble>
                     <artwork>
 <![CDATA[{
@@ -1309,6 +1310,7 @@ GET /foo/
             &rfc3986;
             <!--&rfc4287;-->
             &rfc6570;
+            &rfc6906;
             &I-D.luff-relative-json-pointer;
             &I-D.reschke-http-jfv;
             <reference anchor="json-schema">

--- a/links.json
+++ b/links.json
@@ -9,6 +9,9 @@
             "type": "string",
             "format": "uri-template"
         },
+        "hrefPointers": {
+            "description": "a map of variable names to relative instance JSON Pointers, which adjust the instance location from which template variable resolution begins"
+        },
         "hrefSchema": {
             "allOf": [
                 { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }

--- a/links.json
+++ b/links.json
@@ -10,7 +10,14 @@
             "format": "uri-template"
         },
         "hrefPointers": {
-            "description": "a map of variable names to relative instance JSON Pointers, which adjust the instance location from which template variable resolution begins"
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "anyOf": [
+                    { "format": "json-pointer" },
+                    { "pattern": "^[0-9]" }
+                ]
+            }
         },
         "hrefSchema": {
             "allOf": [


### PR DESCRIPTION
This is a companion to "anchorPointer" (#385), as they use the same
mechanism for adjusting locations within the instance.  While
"anchorPointer" adjusts the context, "hrefPointers" adjust
how template variables are resolved.

"hrefPointers" replaces and is much more functional than the
preprocessing rules that were removed in draft wright-01.
Those rules only allowed adjusting to use the sub-instance
as a whole intead of individual properties or elements.
"hrefPointers" supports that as well as using data from
any containg or sub-instance.