### PR TITLE
Make "rel" required.

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -645,6 +645,7 @@
                     resource. The value MUST be a registered link relation from the
                     <xref target="RFC5988">IANA Link Relation Type Registry established in RFC 5988</xref>,
                     or a normalized URI following the <xref target="RFC3986">URI production of RFC 3986</xref>.
+                    This property is required.
                 </t>
 
                 <t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -3,6 +3,7 @@
 <!ENTITY rfc2046 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2046.xml">
 <!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY rfc3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
+<!ENTITY rfc4151 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4151.xml">
 <!--<!ENTITY rfc4287 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4287.xml">-->
 <!--<!ENTITY rfc5226 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5226.xml">-->
 <!ENTITY rfc5789 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5789.xml">
@@ -669,13 +670,24 @@
 
                 <t>
                     Relationship definitions are not normally media type
-                    dependent, and users are encouraged to utilize existing
-                    accepted relation definitions.
+                    dependent, and users are encouraged to utilize the most
+                    suitable existing accepted relation definitions.
                 </t>
 
+                <t>
+                    When no registered relation (aside from "related") applies, users are
+                    encouraged to mint their own extension relation types, as described in
+                    <xref target="RFC5988">section 4.2 of RFC 5988</xref>.  The simplest
+                    approaches for choosing link relation type URIs are to either use
+                    a URI scheme that is already in use to identify the system's primary
+                    resources, or to use a human-readable, non-dereferenceable URI scheme
+                    such as <xref target="RFC4151">"tag", defined by RFC 4151</xref>.
+                    Extension relation type URIs need not be dereferenceable, even when
+                    using a scheme that allows it.
+                </t>
                 <figure>
                     <preamble>
-                        For example, if a hyper-schema is defined:
+                        As an example of registered relation types, if a hyper-schema is defined:
                     </preamble>
                     <artwork>
 <![CDATA[{
@@ -1216,6 +1228,7 @@ GET /foo/
         <references title="Informative References">
             &rfc2046;
             <!--&rfc5226;-->
+            &rfc4151;
             &rfc5789;
             &rfc5988;
             &rfc7231;


### PR DESCRIPTION
Addresses #297 

There are two commits here: the first simply makes "rel" required, while
the second attempts to address concerns over having to create new URIs
for custom link relations by pointing out two simple approaches.

The `"rel"` section is getting large, but I will address that when I address
#377 in which I have suggested a new outline to more clearly organize
the spec.

RFC 5988bis lists the link relation type as one of the three
required aspects of a link.

Since we do not need to support the deprecated "rev" mechanisms
for specifying relation types, we can make "rel" required.

This will encourage hyper-schema authors to think more about
choosing relation types.