### PR TITLE
Fix recursion in hyper-schema.json

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -3,14 +3,6 @@
     "$id": "http://json-schema.org/draft-06/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
-        "schemaArray": {
-            "allOf": [
-                { "$ref": "http://json-schema.org/draft-06/schema#/definitions/schemaArray" },
-                {
-                    "items": { "$ref": "#" }
-                }
-            ]
-        },
         "linkDescription": {
             "title": "Link Description Object",
             "type": "object",
@@ -66,47 +58,14 @@
         }
     },
     "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
+    "patternProperties": {
+        "^(additional(Propertie|Item)s|propertyNames|not|contains)$": { "$ref": "#" },
+        "^(any|all|one)Of$": { "items": { "$ref": "#" } },
+        "^(p(atternP)?ropertie|definition)s$": { "additionalProperties": { "$ref": "#" } },
+        "^items$": { "oneOf": [ { "$ref": "#" }, { "type": "array", "items": { "$ref": "#" } } ] },
+        "^dependencies$": { "additionalProperties": { "oneOf": [ { "type": "array" }, { "$ref": "#" } ] } }
+    },
     "properties": {
-        "additionalItems": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
-            ]
-        },
-        "additionalProperties": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
-            ]
-        },
-        "dependencies": {
-            "additionalProperties": {
-                "anyOf": [
-                    { "$ref": "#" },
-                    { "type": "array" }
-                ]
-            }
-        },
-        "items": {
-            "anyOf": [
-                { "$ref": "#" },
-                { "$ref": "#/definitions/schemaArray" }
-            ]
-        },
-        "definitions": {
-            "additionalProperties": { "$ref": "#" }
-        },
-        "patternProperties": {
-            "additionalProperties": { "$ref": "#" }
-        },
-        "properties": {
-            "additionalProperties": { "$ref": "#" }
-        },
-        "allOf": { "$ref": "#/definitions/schemaArray" },
-        "anyOf": { "$ref": "#/definitions/schemaArray" },
-        "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" },
-
         "base": {
             "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
             "type": "string"

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -3,6 +3,10 @@
     "$id": "http://json-schema.org/draft-06/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "items": { "$ref": "#" }
+        },
         "linkDescription": {
             "title": "Link Description Object",
             "type": "object",
@@ -58,14 +62,39 @@
         }
     },
     "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
-    "patternProperties": {
-        "^(additional(Propertie|Item)s|propertyNames|not|contains)$": { "$ref": "#" },
-        "^(any|all|one)Of$": { "items": { "$ref": "#" } },
-        "^(p(atternP)?ropertie|definition)s$": { "additionalProperties": { "$ref": "#" } },
-        "^items$": { "oneOf": [ { "$ref": "#" }, { "type": "array", "items": { "$ref": "#" } } ] },
-        "^dependencies$": { "additionalProperties": { "oneOf": [ { "type": "array" }, { "$ref": "#" } ] } }
-    },
     "properties": {
+        "additionalItems": { "$ref": "#" },
+        "additionalProperties": { "$ref": "#" },		
+        "dependencies": {		
+            "additionalProperties": {		
+                "anyOf": [		
+                    { "$ref": "#" },		
+                    { "type": "array" }		
+                ]		
+            }		
+        },
+        "items": {		
+            "anyOf": [		
+                { "$ref": "#" },		
+                { "$ref": "#/definitions/schemaArray" }
+            ]		
+        },		
+        "definitions": {		
+            "additionalProperties": { "$ref": "#" }		
+        },		
+        "patternProperties": {		
+            "additionalProperties": { "$ref": "#" }		
+        },		
+        "properties": {		
+            "additionalProperties": { "$ref": "#" }		
+        },		
+        "allOf": { "$ref": "#/definitions/schemaArray" },		
+        "anyOf": { "$ref": "#/definitions/schemaArray" },		
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" },
+        "propertyNames": { "$ref": "#" },
+        "contains": { "$ref": "#" },
+        
         "base": {
             "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
             "type": "string"

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -4,8 +4,12 @@
     "title": "JSON Hyper-Schema",
     "definitions": {
         "schemaArray": {
-            "type": "array",
-            "items": { "$ref": "#" }
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-06/schema#/definitions/schemaArray" },
+                {
+                    "items": { "$ref": "#" }
+                }
+            ]
         },
         "linkDescription": {
             "title": "Link Description Object",
@@ -64,37 +68,37 @@
     "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
     "properties": {
         "additionalItems": { "$ref": "#" },
-        "additionalProperties": { "$ref": "#" },		
-        "dependencies": {		
-            "additionalProperties": {		
-                "anyOf": [		
-                    { "$ref": "#" },		
-                    { "type": "array" }		
-                ]		
-            }		
+        "additionalProperties": { "$ref": "#"},
+        "dependencies": {
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "type": "array" }
+                ]
+            }
         },
-        "items": {		
-            "anyOf": [		
-                { "$ref": "#" },		
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
                 { "$ref": "#/definitions/schemaArray" }
-            ]		
-        },		
-        "definitions": {		
-            "additionalProperties": { "$ref": "#" }		
-        },		
-        "patternProperties": {		
-            "additionalProperties": { "$ref": "#" }		
-        },		
-        "properties": {		
-            "additionalProperties": { "$ref": "#" }		
-        },		
-        "allOf": { "$ref": "#/definitions/schemaArray" },		
-        "anyOf": { "$ref": "#/definitions/schemaArray" },		
+            ]
+        },
+        "definitions": {
+            "additionalProperties": { "$ref": "#" }
+        },
+        "patternProperties": {
+            "additionalProperties": { "$ref": "#" }
+        },
+        "properties": {
+            "additionalProperties": { "$ref": "#" }
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" },
-        "propertyNames": { "$ref": "#" },
         "contains": { "$ref": "#" },
-        
+        "propertyNames": { "$ref": "#" },
+
         "base": {
             "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
             "type": "string"


### PR DESCRIPTION
- Fix recursion to cover `contains` (specifically mentioned in section 3.1 of the hyper-schema spec), and `propertyNames` (probably irrelevant, since none of the hyper-schema fields would apply, but feels like a better practise since the core spec refers to the hyper-schema definition for guidance on recursion when extending schemas (see also #86)) 
- Much more concise definition of recursion. 