### PR TITLE
Restore "regex" to the list of formats.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -129,12 +129,13 @@
                 </t>
             </section>
 
-            <section title="Regular expressions">
+            <section title="Regular expressions" anchor="regexInterop">
                 <t>
                     Two validation keywords, "pattern" and "patternProperties", use regular
-                    expressions to express constraints. These regular expressions SHOULD
-                    be valid according to the <xref target="ecma262">ECMA 262</xref> regular
-                    expression dialect.
+                    expressions to express constraints, and the "regex" value for the
+                    "format" keyword constrains the instance value to be a regular expression.
+                     These regular expressions SHOULD be valid according to the
+                    <xref target="ecma262">ECMA 262</xref> regular expression dialect.
                 </t>
                 <t>
                     Furthermore, given the high disparity in regular expression constructs support,
@@ -903,6 +904,11 @@
                     <t>
                         A regular expression, which SHOULD be valid according to the
                         <xref target="ecma262">ECMA 262</xref> regular expression dialect.
+                    </t>
+                    <t>
+                        Implementations that validate formats MUST accept at least the subset of
+                        ECMA 262 defined in the <xref target="regexInterop">Regular Expressions</xref>
+                        section of this specification, and SHOULD accept all validECMA 262 expressions.
                     </t>
                 </section>
             </section>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -908,7 +908,7 @@
                     <t>
                         Implementations that validate formats MUST accept at least the subset of
                         ECMA 262 defined in the <xref target="regexInterop">Regular Expressions</xref>
-                        section of this specification, and SHOULD accept all validECMA 262 expressions.
+                        section of this specification, and SHOULD accept all valid ECMA 262 expressions.
                     </t>
                 </section>
             </section>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -896,6 +896,15 @@
                         <xref target="RFC6901">RFC 6901, section 5</xref>
                     </t>
                 </section>
+                <section title="regex">
+                    <t>
+                        This attribute applies to string instances.
+                    </t>
+                    <t>
+                        A regular expression, which SHOULD be valid according to the
+                        <xref target="ecma262">ECMA 262</xref> regular expression dialect.
+                    </t>
+                </section>
             </section>
         </section>
 

--- a/schema.json
+++ b/schema.json
@@ -118,6 +118,7 @@
         "patternProperties": {
             "type": "object",
             "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
             "default": {}
         },
         "dependencies": {


### PR DESCRIPTION
Addresses #392.  It's come up several times that removing
this format did not make sense and was quite possibly an accident.

The "regex" format was actually still in use in the meta-schema
for "pattern".  I've added it to "patternProperties" as well
using "propertyNames".

Regular expressions are a fundamental programming tool, and
play a part in JSON Schema's specification.  It seems incorrect
to not offer semantic documentation / optional validation of them.