### PR TITLE
Support date and time, and allow for more RFC 3339

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -827,7 +827,7 @@
                     </t>
                     <t>
                         Implementations MAY support additional attributes using the other
-                        production names defined in that section.  If "full-date" or "full-time",
+                        production names defined in that section.  If "full-date" or "full-time"
                         are implemented, the corresponding short form ("date" or "time"
                         respectively) MUST be implemented, and MUST behave identically.
                         Implementations SHOULD NOT define extension attributes

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -799,14 +799,48 @@
 
             <section title="Defined formats">
 
-                <section title="date-time">
+                <section title="Dates and times">
                     <t>
-                        This attribute applies to string instances.
+                        These attributes apply to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid date
-                        representation as defined by <xref target="RFC3339">RFC 3339, section
-                        5.6</xref>.
+                        Date and time format names are derived from
+                        <xref target="RFC3339">RFC 3339, section 5.6</xref>.
+                    </t>
+                    <t>
+                        Implementations supporting formats SHOULD implement support for
+                        the following attributes:
+                        <list style="hanging">
+                            <t hangText="date-time">
+                                A string instance is valid against this attribute if it is
+                                a valid representation according to the "date-time" production.
+                            </t>
+                            <t hangText="date">
+                                A string instance is valid against this attribute if it is
+                                a valid representation according to the "full-date" production.
+                            </t>
+                            <t hangText="time">
+                                A string instance is valid against this attribute if it is
+                                a valid representation according to the "full-time" production.
+                            </t>
+                        </list>
+                    </t>
+                    <t>
+                        Implementations MAY support additional attributes using the other
+                        production names defined in that section.  If implementing
+                        "full-date" or "full-time", the corresponding short form ("date"
+                        or "time" respectively) MUST be implemented, and MUST behave
+                        identically.  Implementations SHOULD NOT define extension attributes
+                        with any name matching an RFC 3339 production unless it validates
+                        according to the rules of that production.
+                        <cref>
+                            There is not currently consensus on the need for supporting
+                            all RFC 3339 formats, so this approach of reserving the
+                            namespace will encourage experimentation without committing
+                            to the entire set.  Either the format implementation requirements
+                            will become more flexible in general, or these will likely
+                            either be promoted to fully specified attributes or dropped.
+                        </cref>
                     </t>
                 </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -827,10 +827,10 @@
                     </t>
                     <t>
                         Implementations MAY support additional attributes using the other
-                        production names defined in that section.  If implementing
-                        "full-date" or "full-time", the corresponding short form ("date"
-                        or "time" respectively) MUST be implemented, and MUST behave
-                        identically.  Implementations SHOULD NOT define extension attributes
+                        production names defined in that section.  If "full-date" or "full-time",
+                        are implemented, the corresponding short form ("date" or "time"
+                        respectively) MUST be implemented, and MUST behave identically.
+                        Implementations SHOULD NOT define extension attributes
                         with any name matching an RFC 3339 production unless it validates
                         according to the rules of that production.
                         <cref>


### PR DESCRIPTION
This addresses #199 by supporting the two least controversial and
most requested addtional date/time formats, and reserving the
remaining namespace while we decide whether or how to specify
additional RFC 3339 formats.