### PR TITLE
Update ipv6 RFC reference.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 <!ENTITY RFC1034 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1034.xml">
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
-<!ENTITY RFC2373 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2373.xml">
 <!ENTITY RFC2673 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2673.xml">
 <!ENTITY RFC3339 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3339.xml">
 <!ENTITY RFC3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
+<!ENTITY RFC4291 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4291.xml">
 <!ENTITY RFC5322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5322.xml">
 <!ENTITY RFC6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
 <!ENTITY RFC6901 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6901.xml">
@@ -849,8 +849,8 @@
                     </t>
                     <t>
                         A string instance is valid against this attribute if it is a valid
-                        representation of an IPv6 address as defined in <xref
-                        target="RFC2373">RFC 2373, section 2.2</xref>.
+                        representation of an IPv6 address as defined in
+                        <xref target="RFC4291">RFC 4291, section 2.2</xref>.
                     </t>
                 </section>
 
@@ -940,10 +940,10 @@
 
         <references title="Informative References">
             &RFC1034;
-            &RFC2373;
             &RFC2673;
             &RFC3339;
             &RFC3986;
+            &RFC4291;
             &RFC6570;
             &RFC6901;
             &RFC7159;


### PR DESCRIPTION
RFC 2373 has long since been obsoleted, and its replacement has
likewise been obsoleted.  RFC 4291 is the current RFC.  While there
is a further RFC providing recommendations for consistent formatting
of ipv6 addresses, it includes the requirement that all implementations
MUST support the full syntax laid out in RFC 4291, so that is what
we give as the reference.