### PR TITLE
Note that we may remove "dependencies"

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -598,6 +598,15 @@
 
                 <section title="dependencies">
                     <t>
+                        <cref>
+                            Now that "if", "then", and "else" are keywords, it is not clear whether
+                            there is any benefit in keeping dependencies.  It is frequently
+                            misunderstood and seems to be rarely used.  Depending on feedback
+                            with "if", "then", and "else", this keyword may well be removed in a
+                            future draft.
+                        </cref>
+                    </t>
+                    <t>
                         This keyword specifies rules that are evaluated if the instance is an object and
                         contains a certain property.
                     </t>


### PR DESCRIPTION
This was discussed in the if/then/else issue.  There was significant
support for removing "dependencies" as it is more straightforward,
although sometimes more verbose, to implement the same funcitonality
with if/then/else.

Rather than going straight to ripping it out, let's give if/then/else
a bit of time to gather feedback.  Make a note of it to warn that
"dependencies" may be removed, which will hopefully provoke some
feedback on that idea as well.