### PR TITLE
Remove duplication and descriptions.

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -12,57 +12,6 @@
             ]
         },
         "linkDescription": {
-            "title": "Link Description Object",
-            "type": "object",
-            "required": [ "href" ],
-            "properties": {
-                "href": {
-                    "description": "a URI template, as defined by RFC 6570",
-                    "type": "string",
-                    "format": "uri-template"
-                },
-                "hrefSchema": {
-                    "description": "a schema for validating user input to the URI template, where the input is in the form of a JSON object with property names matching variable names in \"href\"",
-                    "allOf": [ {"$ref": "#"} ]
-                },
-                "rel": {
-                    "description": "relation to the target resource of the link",
-                    "type": "string"
-                },
-                "anchor": {
-                    "description": "the URI of the context resource",
-                    "type": "string",
-                    "format": "uri-reference"
-                },
-                "title": {
-                    "description": "a title for the link",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "additional information about the purpose or usage of the link",
-                    "type": "string"
-                },
-                "targetSchema": {
-                    "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "mediaType": {
-                    "description": "media type (as defined by RFC 2046) describing the link target",
-                    "type": "string"
-                },
-                "submissionEncType": {
-                    "description": "The media type in which to submit data along with the request",
-                    "type": "string",
-                    "default": "application/json"
-                },
-                "submissionSchema": {
-                    "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "$comment": {
-                    "type": "string"
-                }
-            }
         }
     },
     "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
@@ -103,22 +52,21 @@
         "propertyNames": { "$ref": "#" },
 
         "base": {
-            "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
             "type": "string"
         },
         "links": {
             "type": "array",
-            "items": { "$ref": "#/definitions/linkDescription" }
+            "items": {
+                "$ref": "http://json-schema.org/draft-06/links#"
+            }
         },
         "media": {
             "type": "object",
             "properties": {
                 "type": {
-                    "description": "A media type, as described in RFC 2046",
                     "type": "string"
                 },
                 "binaryEncoding": {
-                    "description": "A content encoding scheme, as described in RFC 2045",
                     "type": "string"
                 }
             }

--- a/links.json
+++ b/links.json
@@ -6,38 +6,46 @@
     "required": [ "href" ],
     "properties": {
         "href": {
-            "description": "a URI template, as defined by RFC 6570",
             "type": "string",
             "format": "uri-template"
         },
         "hrefSchema": {
-            "description": "a schema for validating user input to the URI template, where the input is in the form of a JSON object with property names matching variable names in \"href\"",
-            "allOf": [ {"$ref": "#"} ]
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+            ]
         },
         "rel": {
-            "description": "relation to the target resource of the link",
             "type": "string"
         },
+        "anchor": {
+            "type": "string",
+            "format": "uri-reference"
+        },
         "title": {
-            "description": "a title for the link",
+            "type": "string"
+        },
+        "description": {
             "type": "string"
         },
         "targetSchema": {
-            "description": "JSON Schema describing the link target",
-            "allOf": [ { "$ref": "hyper-schema#" } ]
+            "allOf": [
+               { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+            ]
         },
         "mediaType": {
-            "description": "media type (as defined by RFC 2046) describing the link target",
             "type": "string"
         },
         "submissionEncType": {
-            "description": "The media type in which to submit data along with the request",
             "type": "string",
             "default": "application/json"
         },
         "submissionSchema": {
-            "description": "Schema describing the data to submit along with the request",
-            "allOf": [ { "$ref": "hyper-schema#" } ]
+            "allOf": [
+               { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+            ]
+        },
+        "$comment": {
+            "type": "string"
         }
     }
 }


### PR DESCRIPTION
We regularly forget about links.json.  Let's use $ref and prevent
that.

Also, remove all of the descriptions.  They are not present in the
core/validation schema and have gotten out of sync several times.
The descriptions tend to be either trivial or inadequate as the
more complex features aren't easily described in a readable amount
of JSON text.

This addresses #175