### PR TITLE
meta schemas cleanup: remove descriptions, use and update "links.json"

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -10,59 +10,6 @@
                     "items": { "$ref": "#" }
                 }
             ]
-        },
-        "linkDescription": {
-            "title": "Link Description Object",
-            "type": "object",
-            "required": [ "href" ],
-            "properties": {
-                "href": {
-                    "description": "a URI template, as defined by RFC 6570",
-                    "type": "string",
-                    "format": "uri-template"
-                },
-                "hrefSchema": {
-                    "description": "a schema for validating user input to the URI template, where the input is in the form of a JSON object with property names matching variable names in \"href\"",
-                    "allOf": [ {"$ref": "#"} ]
-                },
-                "rel": {
-                    "description": "relation to the target resource of the link",
-                    "type": "string"
-                },
-                "anchor": {
-                    "description": "the URI of the context resource",
-                    "type": "string",
-                    "format": "uri-reference"
-                },
-                "title": {
-                    "description": "a title for the link",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "additional information about the purpose or usage of the link",
-                    "type": "string"
-                },
-                "targetSchema": {
-                    "description": "JSON Schema describing the link target",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "mediaType": {
-                    "description": "media type (as defined by RFC 2046) describing the link target",
-                    "type": "string"
-                },
-                "submissionEncType": {
-                    "description": "The media type in which to submit data along with the request",
-                    "type": "string",
-                    "default": "application/json"
-                },
-                "submissionSchema": {
-                    "description": "Schema describing the data to submit along with the request",
-                    "allOf": [ { "$ref": "#" } ]
-                },
-                "$comment": {
-                    "type": "string"
-                }
-            }
         }
     },
     "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
@@ -108,7 +55,9 @@
         },
         "links": {
             "type": "array",
-            "items": { "$ref": "#/definitions/linkDescription" }
+            "items": {
+                "$ref": "http://json-schema.org/draft-06/links#"
+            }
         },
         "media": {
             "type": "object",

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -50,7 +50,6 @@
         "propertyNames": { "$ref": "#" },
 
         "base": {
-            "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
             "type": "string"
         },
         "links": {
@@ -63,11 +62,9 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "description": "A media type, as described in RFC 2046",
                     "type": "string"
                 },
                 "binaryEncoding": {
-                    "description": "A content encoding scheme, as described in RFC 2045",
                     "type": "string"
                 }
             }

--- a/links.json
+++ b/links.json
@@ -17,7 +17,14 @@
         "rel": {
             "type": "string"
         },
+        "anchor": {
+            "type": "string",
+            "format": "uri-reference"
+        },
         "title": {
+            "type": "string"
+        },
+        "description": {
             "type": "string"
         },
         "targetSchema": {
@@ -36,6 +43,9 @@
             "allOf": [
                 { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
             ]
+        },
+        "$comment": {
+            "type": "string"
         }
     }
 }

--- a/links.json
+++ b/links.json
@@ -6,37 +6,29 @@
     "required": [ "href" ],
     "properties": {
         "href": {
-            "description": "a URI template, as defined by RFC 6570",
             "type": "string",
             "format": "uri-template"
         },
         "hrefSchema": {
-            "description": "a schema for validating user input to the URI template, where the input is in the form of a JSON object with property names matching variable names in \"href\"",
             "allOf": [ {"$ref": "#"} ]
         },
         "rel": {
-            "description": "relation to the target resource of the link",
             "type": "string"
         },
         "title": {
-            "description": "a title for the link",
             "type": "string"
         },
         "targetSchema": {
-            "description": "JSON Schema describing the link target",
             "allOf": [ { "$ref": "hyper-schema#" } ]
         },
         "mediaType": {
-            "description": "media type (as defined by RFC 2046) describing the link target",
             "type": "string"
         },
         "submissionEncType": {
-            "description": "The media type in which to submit data along with the request",
             "type": "string",
             "default": "application/json"
         },
         "submissionSchema": {
-            "description": "Schema describing the data to submit along with the request",
             "allOf": [ { "$ref": "hyper-schema#" } ]
         }
     }

--- a/links.json
+++ b/links.json
@@ -10,7 +10,9 @@
             "format": "uri-template"
         },
         "hrefSchema": {
-            "allOf": [ {"$ref": "#"} ]
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+            ]
         },
         "rel": {
             "type": "string"
@@ -19,7 +21,9 @@
             "type": "string"
         },
         "targetSchema": {
-            "allOf": [ { "$ref": "hyper-schema#" } ]
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+            ]
         },
         "mediaType": {
             "type": "string"
@@ -29,7 +33,9 @@
             "default": "application/json"
         },
         "submissionSchema": {
-            "allOf": [ { "$ref": "hyper-schema#" } ]
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+            ]
         }
     }
 }


### PR DESCRIPTION
Reboot of #402 splitted into atomic commits.

* use "links" meta-schema in hyper-schema;
* remove all descriptions (addressing #175);
* updates in "links" to fix "$ref" and add missing keywords.