### PR TITLE
Drop "description" of targetHints in links.json

### DIFF
--- a/links.json
+++ b/links.json
@@ -32,9 +32,7 @@
                 { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
             ]
         },
-        "targetHints": {
-            "description": "JSON representation of likely metadata such as response headers, with a protocol-dependent format"
-        },
+        "targetHints": { },
         "mediaType": {
             "type": "string"
         },


### PR DESCRIPTION
We just removed all descriptions in 0b0681c; that one slipped in when
PR #383 got rebased (and merged).