### PR TITLE
Internationalized formats

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -7,6 +7,7 @@
 <!ENTITY RFC2673 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2673.xml">
 <!ENTITY RFC3339 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3339.xml">
 <!ENTITY RFC3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
+<!ENTITY RFC3987 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3987.xml">
 <!ENTITY RFC4291 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4291.xml">
 <!ENTITY RFC5322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5322.xml">
 <!ENTITY RFC6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
@@ -994,24 +995,33 @@
                     </t>
                 </section>
 
-                <section title="uri">
+                <section title="Resource identifiers">
                     <t>
-                        This attribute applies to string instances.
+                        These attributes apply to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid URI,
-                        according to <xref target="RFC3986"/>.
-                    </t>
-                </section>
-
-                <section title="uri-reference">
-                    <t>
-                        This attribute applies to string instances.
-                    </t>
-                    <t>
-                        A string instance is valid against this attribute if it is a valid URI
-                        Reference (either a URI or a relative-reference),
-                        according to <xref target="RFC3986"/>.
+                        <list style="hanging">
+                            <t hangText="uri">
+                                A string instance is valid against this attribute if it is
+                                a valid URI, according to <xref target="RFC3986"/>.
+                            </t>
+                            <t hangText="uri-reference">
+                                A string instance is valid against this attribute if it is a valid URI
+                                Reference (either a URI or a relative-reference),
+                                according to <xref target="RFC3986"/>.
+                            </t>
+                            <t hangText="iri">
+                                A string instance is valid against this attribute if it is
+                                a valid IRI, according to <xref target="RFC3987"/>.
+                            </t>
+                            <t hangText="iri-reference">
+                                A string instance is valid against this attribute if it is a valid IRI
+                                Reference (either an IRI or a relative-reference),
+                                according to <xref target="RFC3987"/>.
+                            </t>
+                        </list>
+                        Note that all valid URIs are valid IRIs, and all valid URI References are
+                        also valid IRI References.
                     </t>
                 </section>
 
@@ -1022,6 +1032,10 @@
                     <t>
                         A string instance is valid against this attribute if it is a valid URI Template
                         (of any level), according to <xref target="RFC6570"/>.
+                    </t>
+                    <t>
+                        Note that URI Templates may be used for IRIs; there is no separate
+                        IRI Template specification.
                     </t>
                 </section>
 
@@ -1209,6 +1223,7 @@
             &RFC2673;
             &RFC3339;
             &RFC3986;
+            &RFC3987;
             &RFC4291;
             &RFC6570;
             &RFC6901;

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -973,25 +973,27 @@
                         valid against the "idn-email" attribute.
                     </t>
                 </section>
-                <section title="Host and domain names">
+                <section title="Hostnames">
                     <t>
                         These attributes apply to string instances.
                     </t>
                     <t>
                         A string instance is valid against these attributes if it is a valid
-                        representation for an Internet host name as follows:
+                        representation for an Internet hostname as follows:
                         <list style="hanging">
                             <t hangText="hostname">
                                 As defined by <xref target="RFC1034">RFC 1034, section 3.1</xref>,
                                 including host names produced using the Punycode algorithm
                                 specified in <xref target="RFC5891">RFC 5891, section 4.4</xref>.
                             </t>
-                            <t hangText="idn">
+                            <t hangText="idn-hostname">
                                 As defined by either RFC 1034 as for hostname, or an
-                                internationalized domain name as defined by
+                                internationalized hostname as defined by
                                 <xref target="RFC5890">RFC 5890, section 2.3.2.3</xref>.
                             </t>
                         </list>
+                        Note that all strings valid against the "hostname" attribute are also
+                        valid against the "idn-hostname" attribute.
                     </t>
                 </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -995,26 +995,24 @@
                     </t>
                 </section>
 
-                <section title="ipv4">
+                <section title="IP addresses">
                     <t>
-                        This attribute applies to string instances.
+                        These attributes apply to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid
-                        representation of an IPv4 address according to the "dotted-quad" ABNF
-                        syntax as defined in <xref target="RFC2673">RFC 2673, section
-                        3.2</xref>.
-                    </t>
-                </section>
-
-                <section title="ipv6">
-                    <t>
-                        This attribute applies to string instances.
-                    </t>
-                    <t>
-                        A string instance is valid against this attribute if it is a valid
-                        representation of an IPv6 address as defined in
-                        <xref target="RFC4291">RFC 4291, section 2.2</xref>.
+                        A string instance is valid against these attributes if it is a valid
+                        representation of an IP address as follows:
+                        <list style="hanging">
+                            <t hangText="ipv4">
+                                An IPv4 address according to the "dotted-quad" ABNF
+                                syntax as defined in
+                                <xref target="RFC2673">RFC 2673, section 3.2</xref>.
+                            </t>
+                            <t hangText="ipv6">
+                                An IPv6 address as defined in
+                                <xref target="RFC4291">RFC 4291, section 2.2</xref>.
+                            </t>
+                        </list>
                     </t>
                 </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -12,6 +12,7 @@
 <!ENTITY RFC5322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5322.xml">
 <!ENTITY RFC5890 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5890.xml">
 <!ENTITY RFC5891 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5891.xml">
+<!ENTITY RFC6531 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6531.xml">
 <!ENTITY RFC6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
 <!ENTITY RFC6901 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6901.xml">
 <!ENTITY RFC7159 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7159.xml">
@@ -953,14 +954,23 @@
                     </t>
                 </section>
 
-                <section title="email">
+                <section title="Email addresses">
                     <t>
-                        This attribute applies to string instances.
+                        These attributes apply to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid
-                        Internet email address as defined by <xref target="RFC5322">RFC 5322,
-                        section 3.4.1</xref>.
+                        A string instance is valid against these attributes if it is a valid
+                        Internet email address as follows:
+                        <list style="hanging">
+                            <t hangText="email">
+                                As defined by <xref target="RFC5322">RFC 5322, section 3.4.1</xref>.
+                            </t>
+                            <t hangText="idn-email">
+                                As defined by <xref target="RFC6531">RFC 6531</xref>
+                            </t>
+                        </list>
+                        Note that all strings valid against the "email" attribute are also
+                        valid against the "idn-email" attribute.
                     </t>
                 </section>
                 <section title="Host and domain names">
@@ -1241,6 +1251,7 @@
             &RFC5890;
             &RFC5891;
             &RFC6570;
+            &RFC6531;
             &RFC6901;
             &RFC7159;
             &RFC5322;

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -10,6 +10,8 @@
 <!ENTITY RFC3987 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3987.xml">
 <!ENTITY RFC4291 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4291.xml">
 <!ENTITY RFC5322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5322.xml">
+<!ENTITY RFC5890 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5890.xml">
+<!ENTITY RFC5891 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5891.xml">
 <!ENTITY RFC6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
 <!ENTITY RFC6901 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6901.xml">
 <!ENTITY RFC7159 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7159.xml">
@@ -961,14 +963,25 @@
                         section 3.4.1</xref>.
                     </t>
                 </section>
-                <section title="hostname">
+                <section title="Host and domain names">
                     <t>
-                        This attribute applies to string instances.
+                        These attributes apply to string instances.
                     </t>
                     <t>
-                        A string instance is valid against this attribute if it is a valid
-                        representation for an Internet host name, as defined by <xref
-                        target="RFC1034">RFC 1034, section 3.1</xref>.
+                        A string instance is valid against these attributes if it is a valid
+                        representation for an Internet host name as follows:
+                        <list style="hanging">
+                            <t hangText="hostname">
+                                As defined by <xref target="RFC1034">RFC 1034, section 3.1</xref>,
+                                including host names produced using the Punycode algorithm
+                                specified in <xref target="RFC5891">RFC 5891, section 4.4</xref>.
+                            </t>
+                            <t hangText="idn">
+                                As defined by either RFC 1034 as for hostname, or an
+                                internationalized domain name as defined by
+                                <xref target="RFC5890">RFC 5890, section 2.3.2.3</xref>.
+                            </t>
+                        </list>
                     </t>
                 </section>
 
@@ -1225,6 +1238,8 @@
             &RFC3986;
             &RFC3987;
             &RFC4291;
+            &RFC5890;
+            &RFC5891;
             &RFC6570;
             &RFC6901;
             &RFC7159;


### PR DESCRIPTION
This addresses #305 (email) and #355 (IRIs), and also adds internationalized domain/host names as they are what the internationalized email addresses are based on.

It's a multi-commit omnibus but if any are controversial they can be split.

I also put ipv4 and ipv6 together in a section as it just reads better like that.  Alongside the "Dates and times" section introduced in PR #399, these changes result in most of the formats being grouped into sections by topic.  Only `uri-template`, `json-pointer`, and `regex` are on their own (the latter of those being introduced in PR #392).