### PR TITLE
Minimal change from "profile" to "schema"

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -5,7 +5,6 @@
 <!ENTITY RFC5988 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml">
 <!ENTITY RFC6839 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6839.xml">
 <!ENTITY RFC6901 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6901.xml">
-<!ENTITY RFC6906 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6906.xml">
 <!ENTITY RFC7049 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7049.xml">
 <!ENTITY RFC7159 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7159.xml">
 <!ENTITY RFC7231 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml">
@@ -675,7 +674,7 @@
 
             <section title='Linking to a schema'>
                 <t>
-                    It is RECOMMENDED that instances described by a schema/profile provide a link to
+                    It is RECOMMENDED that instances described by a schema provide a link to
                     a downloadable JSON Schema using the link relation "describedby", as defined by
                     <xref target="W3C.REC-ldp-20150226">Linked Data Protocol 1.0, section 8.1</xref>.
                 </t>
@@ -696,21 +695,23 @@ Link: <http://example.com/my-hyper-schema#>; rel="describedby"
             </section>
 
 
-            <section title='Describing a profile of JSON' anchor="profile">
+            <section title='Identifying a schema via a media type parameter' anchor="parameter">
                 <t>
-                    Instances MAY specify a "profile" as described in
-                    <xref target="RFC6906">The 'profile' Link Relation</xref>.
-                    When used as a media-type parameter, HTTP servers gain the ability to perform
-                    Content-Type Negotiation based on profile.
+                    Media types MAY allow for a "schema" media type parameter, which gives
+                    HTTP servers the ability to perform Content-Type Negotiation based on schema.
                     The media-type parameter MUST be a whitespace-separated list of URIs
                     (i.e. relative references are invalid).
                 </t>
                 <t>
-                    The profile URI is opaque and SHOULD NOT automatically be dereferenced.
-                    If the implementation does not understand the semantics of the provided profile,
+                    When using the media type application/schema-instance+json, the "schema"
+                    parameter MUST be supplied.
+                </t>
+                <t>
+                    The schema URI is opaque and SHOULD NOT automatically be dereferenced.
+                    If the implementation does not understand the semantics of the provided schema,
                     the implementation can instead follow the "describedby" links, if any, which may
-                    provide information on how to handle the profile.
-                    Since "profile" doesn't necessarily point to a network location, the
+                    provide information on how to handle the schema.
+                    Since "schema" doesn't necessarily point to a network location, the
                     "describedby" relation is used for linking to a downloadable schema.
                     However, for simplicity, schema authors should make these URIs point to the same
                     resource when possible.
@@ -724,26 +725,31 @@ Link: <http://example.com/my-hyper-schema#>; rel="describedby"
                     <artwork>
 <![CDATA[
 Content-Type: application/json;
-          profile="http://example.com/my-hyper-schema#"
+          schema="http://example.com/my-hyper-schema#"
 ]]>
                     </artwork>
                 </figure>
 
                 <t>
-                    Multiple profiles are whitespace separated:
+                    Multiple schemas are whitespace separated:
                 </t>
 
                 <figure>
                     <artwork>
 <![CDATA[
 Content-Type: application/json;
-          profile="http://example.com/alice http://example.com/bob"
+          schema="http://example.com/alice http://example.com/bob"
 ]]>
                     </artwork>
                 </figure>
 
                 <t>
-                    HTTP can also send the "profile" in a Link, though this may impact media-type
+                    <cref>
+                        This paragraph assumes that we can register a "schema" link relation.
+                        Should we instead specify something like "tag:json-schema.org,2017:schema"
+                        for now?
+                    </cref>
+                    HTTP can also send the "schema" in a Link, though this may impact media-type
                     semantics and Content-Type negotiation if this replaces the media-type parameter
                     entirely:
                 </t>
@@ -751,7 +757,7 @@ Content-Type: application/json;
                 <figure>
                     <artwork>
 <![CDATA[
-Link: </alice>;rel="profile", </bob>;rel="profile"
+Link: </alice>;rel="schema", </bob>;rel="schema"
 ]]>
                     </artwork>
                 </figure>
@@ -915,7 +921,6 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
 
         <references title="Informative References">
             &RFC5988;
-            &RFC6906;
             &RFC7049;
             &RFC7231;
             &fragid-best-practices;


### PR DESCRIPTION
This change removes "profile", since as noted in issue #222 the
usage is not correct.  It replaces it with "schema", with the
minimal possible change.

We may wish to also remove the "describedby" link relation and
instead mandate using "schema", or a similarly named
extension relation, and allow downloading schemas based on the
parameter.  That is outside of the scope of this change.

This also continues to address #351 `application/schema-instance+json`