### PR TITLE
"anchor" is a URI Template

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -922,9 +922,15 @@ GET /foo/
             <section title="anchor" anchor="anchor">
                 <t>
                     This property sets the context URI of the link.
-                    The value of the property MUST be resolved as a
-                    <xref target="RFC3986">URI-reference</xref> against
-                    the base URI of the instance.
+                    The value of the property is a <xref target="RFC6570">URI Template</xref>,
+                    and the resulting <xref target="RFC3986">URI-reference</xref> MUST be resolved
+                    against the base URI of the instance.
+                </t>
+                <t>
+                    The URI is computed from the provided URI template using the same process
+                    described for the <xref target="href">"href"</xref> property, with the
+                    exception that <xref target="hrefSchema">"hrefSchema"</xref> MUST NOT
+                    be applied.  Unlike target URIs, context URIs do not accept user input.
                 </t>
             </section>
 

--- a/links.json
+++ b/links.json
@@ -29,7 +29,7 @@
         },
         "anchor": {
             "type": "string",
-            "format": "uri-reference"
+            "format": "uri-template"
         },
         "anchorPointer": {
             "type": "string",


### PR DESCRIPTION
Addresses the main point of #416.  "anchor" needs to be a URI
template as the context URI will often share characteristics
of the "self" link.

***NOTE:*** Please assume this will get covered by an example
in the rewrite.  It doesn't seem worth the effort to figure one
out here.