### PR TITLE
Define "applicability" and "attachment"

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -175,32 +175,6 @@
                     relations for the instance, with URIs incorporating values from the instance.
                 </postamble>
             </figure>
-
-            <section title="Interaction with validation">
-                <t>
-                    Hyper-schema keywords can be applied when the instance is valid against
-                    the schema that includes those keywords.
-                </t>
-                <t>
-                    Hyper-schemas MUST NOT be applied to an instance if the instance fails to
-                    validate against the validation keywords within or containing the hyper-schema.
-                    Hyper-schema keywords in branches of an "anyOf", "oneOf", or "if"/"then"/"else"
-                    that do not validate, or in a "dependencies" subschema that is not relevant
-                    to the instance, MUST be ignored.
-                </t>
-                <t>
-                    Hyper-schema keywords in a subschema contained within a "not", at any depth,
-                    including any number of intervening additional "not" subschemas, MUST be
-                    ignored.
-                </t>
-                <t>
-                    If the subschema for a "contains" keyword contains hyper-schema keywords they
-                    MUST be applied to all array elements that validate against the schema.  While
-                    finding a single validating element is sufficient to determine the validation
-                    outcome, when hyper-schema keywords are present, the subschema MUST be evaluated
-                    against all array elements.
-                </t>
-            </section>
         </section>
 
         <section title="Meta-schema">
@@ -211,6 +185,17 @@
         </section>
 
         <section title="Schema keywords">
+            <t>
+                Hyper-schema keywords can be applied when the instance is valid against
+                the schema that includes those keywords, as outlined in
+                <xref target="json-schema-validation">Section 10.1 of JSON Schema validation</xref>.
+            </t>
+            <t>
+                When multiple subschemas are applicable to a given sub-instance, all "link"
+                arrays MUST be concatenated, in any order, into a single array.  Each object
+                in the resulting array MUST retain its own list of applicable "base" values,
+                in resolution order, from the same schema and any parent schemas.
+            </t>
             <section title="base">
                 <t>
                     If present, this keyword is resolved against the current URI base that the

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1160,7 +1160,7 @@
                     keywords.  Implementation of this feature MAY instead be done separately.
                 </t>
                 <t>
-                    Since many subschemas can be applicable to any single sub-isntance, each
+                    Since many subschemas can be applicable to any single sub-instance, each
                     annotation keyword or vocabulary needs to specify how to handle multiple
                     occurrences with different values.  In the absence of keyword-specific
                     handling rules, an implementation MUST collect all values and make them
@@ -1217,7 +1217,9 @@
 
                 <section title='"default"'>
                     <t>
-                        There are no restrictions placed on the value of this keyword.
+                        There are no restrictions placed on the value of this keyword.  When
+                        multiple occurrences of this keyword are applicable to a single
+                        sub-instance, implementations SHOULD remove duplicates.
                     </t>
                     <t>
                         This keyword can be used to supply a default JSON value associated with a
@@ -1228,13 +1230,16 @@
 
                 <section title='"readOnly"'>
                     <t>
-                        The value of this keyword MUST be a boolean.
+                        The value of this keyword MUST be a boolean.  When multiple occurrences
+                        of this keyword are applicable to a single sub-instance, the resulting
+                        value MUST be true if any occurrence specifies a true value, and MUST
+                        be false otherwise.
                     </t>
                     <t>
-                        If it has a value of boolean true, this keyword indicates that the value of the
-                        instance is managed exclusively by the owning authority, and attempts by an
-                        application to modify the value of this property are expected to be ignored or
-                        rejected by that owning authority.
+                        If it has a value of boolean true, this keyword indicates that the value
+                        of the instance is managed exclusively by the owning authority, and
+                        attempts by an application to modify the value of this property are
+                        expected to be ignored or rejected by that owning authority.
                     </t>
                     <t>
                         For example, this property would be used to mark a database-generated serial
@@ -1252,6 +1257,9 @@
                     <t>
                         The value of this keyword MUST be an array.
                         There are no restrictions placed on the values within the array.
+                        When multiple occurrences of this keyword are applicable to a single
+                        sub-instance, implementations MUST provide a flat array of all
+                        values rather than an array of arrays.
                     </t>
                     <t>
                         This keyword can be used to provide sample JSON values associated with a
@@ -1259,12 +1267,11 @@
                         RECOMMENDED that these values be valid against the associated schema.
                     </t>
                     <t>
-                        Implementations MAY use the value of "default", if present, as
+                        Implementations MAY use the value(s) of "default", if present, as
                         an additional example.  If "examples" is absent, "default"
                         MAY still be used in this manner.
                     </t>
                 </section>
-
             </section>
         </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1196,68 +1196,76 @@
                 </section>
             </section>
 
-            <section title='"title" and "description"'>
+            <section title="Basic annotation keywords">
                 <t>
-                    The value of both of these keywords MUST be a string.
+                    These general-purpose annotation keywords provide commonly used information
+                    for documentation and user interface display purposes.  They are not intended
+                    to form a comprehensive set of features.  Rather, additional vocabularies
+                    can be defined for more complex annotation-based applications.
                 </t>
-                <t>
-                    Both of these keywords can be used to decorate a user interface with
-                    information about the data produced by this user interface. A title will
-                    preferably be short, whereas a description will provide explanation about
-                    the purpose of the instance described by this schema.
-                </t>
-            </section>
+                <section title='"title" and "description"'>
+                    <t>
+                        The value of both of these keywords MUST be a string.
+                    </t>
+                    <t>
+                        Both of these keywords can be used to decorate a user interface with
+                        information about the data produced by this user interface. A title will
+                        preferably be short, whereas a description will provide explanation about
+                        the purpose of the instance described by this schema.
+                    </t>
+                </section>
 
-            <section title='"default"'>
-                <t>
-                    There are no restrictions placed on the value of this keyword.
-                </t>
-                <t>
-                    This keyword can be used to supply a default JSON value associated with a
-                    particular schema. It is RECOMMENDED that a default value be valid against
-                    the associated schema.
-                </t>
-            </section>
+                <section title='"default"'>
+                    <t>
+                        There are no restrictions placed on the value of this keyword.
+                    </t>
+                    <t>
+                        This keyword can be used to supply a default JSON value associated with a
+                        particular schema. It is RECOMMENDED that a default value be valid against
+                        the associated schema.
+                    </t>
+                </section>
 
-            <section title='"readOnly"'>
-                <t>
-                    The value of this keyword MUST be a boolean.
-                </t>
-                <t>
-                    If it has a value of boolean true, this keyword indicates that the value of the
-                    instance is managed exclusively by the owning authority, and attempts by an
-                    application to modify the value of this property are expected to be ignored or
-                    rejected by that owning authority.
-                </t>
-                <t>
-                    For example, this property would be used to mark a database-generated serial
-                    number as read-only.
-                </t>
-                <t>
-                    This keyword can be used to assist in user interface instance generation.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as a value of false.
-                </t>
-            </section>
+                <section title='"readOnly"'>
+                    <t>
+                        The value of this keyword MUST be a boolean.
+                    </t>
+                    <t>
+                        If it has a value of boolean true, this keyword indicates that the value of the
+                        instance is managed exclusively by the owning authority, and attempts by an
+                        application to modify the value of this property are expected to be ignored or
+                        rejected by that owning authority.
+                    </t>
+                    <t>
+                        For example, this property would be used to mark a database-generated serial
+                        number as read-only.
+                    </t>
+                    <t>
+                        This keyword can be used to assist in user interface instance generation.
+                    </t>
+                    <t>
+                        Omitting this keyword has the same behavior as a value of false.
+                    </t>
+                </section>
 
-            <section title='"examples"'>
-                <t>
-                    The value of this keyword MUST be an array.
-                    There are no restrictions placed on the values within the array.
-                </t>
-                <t>
-                    This keyword can be used to provide sample JSON values associated with a
-                    particular schema, for the purpose of illustrating usage.  It is
-                    RECOMMENDED that these values be valid against the associated schema.
-                </t>
-                <t>
-                    Implementations MAY use the value of "default", if present, as
-                    an additional example.  If "examples" is absent, "default"
-                    MAY still be used in this manner.
-                </t>
-            </section>
+                <section title='"examples"'>
+                    <t>
+                        The value of this keyword MUST be an array.
+                        There are no restrictions placed on the values within the array.
+                    </t>
+                    <t>
+                        This keyword can be used to provide sample JSON values associated with a
+                        particular schema, for the purpose of illustrating usage.  It is
+                        RECOMMENDED that these values be valid against the associated schema.
+                    </t>
+                    <t>
+                        Implementations MAY use the value of "default", if present, as
+                        an additional example.  If "examples" is absent, "default"
+                        MAY still be used in this manner.
+                    </t>
+                </section>
 
+            </section>
         </section>
 
         <section title="Security considerations">

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1100,25 +1100,23 @@
 
         </section>
 
-        <section title="Metadata keywords">
-            <section title="definitions">
-                <t>
-                    This keyword's value MUST be an object.
-                    Each member value of this object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    This keyword plays no role in validation per se. Its role is to provide
-                    a standardized location for schema authors to inline JSON Schemas into a
-                    more general schema.
-                </t>
+        <section title='Schema re-use with "definitions"'>
+            <t>
+                The "definitions" keywords provides a standardized location for schema
+                authors to inline re-usable JSON Schemas into a more general schema.
+                The keyword does not directly affect the validation result.
+            </t>
+            <t>
+                This keyword's value MUST be an object.
+                Each member value of this object MUST be a valid JSON Schema.
+            </t>
+            <t>
+                As an example, here is a schema describing an array of positive
+                integers, where the positive integer constraint is a subschema in
+                "definitions":
 
-                <t>
-                    As an example, here is a schema describing an array of positive
-                    integers, where the positive integer constraint is a subschema in
-                    "definitions":
-
-                    <figure>
-                        <artwork>
+                <figure>
+                    <artwork>
 <![CDATA[
 {
     "type": "array",
@@ -1131,10 +1129,12 @@
     }
 }
 ]]>
-                        </artwork>
-                    </figure>
-                </t>
-            </section>
+                    </artwork>
+                </figure>
+            </t>
+        </section>
+
+        <section title="Schema annotations and extension vocabularies">
 
             <section title='"title" and "description"'>
                 <t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1135,6 +1135,66 @@
         </section>
 
         <section title="Schema annotations and extension vocabularies">
+            <t>
+                Schema validation is a useful mechanism for annotating instance data
+                with additional information.  This section describes the rules for
+                determining when and how annotations apply to an instance, and specifies
+                a small general-purpose annotation vocabulary.
+            </t>
+            <t>
+                Additional vocabularies SHOULD make use of this mechanism for applying
+                their keywords to instances.
+            </t>
+            <section title="Applicability and attachment">
+                <t>
+                    Annotations can be applied to an instance when it is valid against
+                    the schema that includes the annotation keywords.  For any given location
+                    in the instance (referred to as a sub-instance), each (sub)schema against
+                    which it successfully validates is considered to be <spanx>applicable</spanx>
+                    to that sub-instance.  The (sub)schema is said to be <spanx>attached</spanx>
+                    to each sub-instance to which it applies.
+                </t>
+                <t>
+                    A validation implementation MAY choose to implement determining subschema
+                    applicability and providing access to the value(s) of applicable annotation
+                    keywords.  Implementation of this feature MAY instead be done separately.
+                </t>
+                <t>
+                    Since many subschemas can be applicable to any single sub-isntance, each
+                    annotation keyword or vocabulary needs to specify how to handle multiple
+                    occurrences with different values.  In the absence of keyword-specific
+                    handling rules, an implementation MUST collect all values and make them
+                    available as a data structure in which order is not significant and items
+                    need not be unique.
+                </t>
+                <section title="Combinatoric and conditional schemas">
+                    <t>
+                        Annotations in branches of an "anyOf", "oneOf", or "if"/"then"/"else"
+                        that do not validate, or in a "dependencies" subschema that is not relevant
+                        to the instance, MUST be ignored.
+                    </t>
+                    <t>
+                        Annotations in a subschema contained within a "not", at any depth,
+                        including any number of intervening additional "not" subschemas, MUST be
+                        ignored.
+                    </t>
+                </section>
+                <section title="Annotations and short-circuit validation">
+                    <t>
+                        Schema keywords MUST be applied to all possible sub-instances when
+                        considering annotations, even if such application can be short-circuited
+                        when only the overall validation result is needed.
+                    </t>
+                    <t>
+                        An example of this is the "contains" keyword, which need only be evaluated
+                        against array elements until it produces at least one successful outcome
+                        in order to be implemented.  However, when annotations are considered,
+                        it must be checked against every array element, and the annotations MUST
+                        be applied to every element that successfully validates against the
+                        "contains" susbschema.
+                    </t>
+                </section>
+            </section>
 
             <section title='"title" and "description"'>
                 <t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -769,106 +769,6 @@
             </section>
         </section>
 
-        <section title="Metadata keywords">
-            <section title="definitions">
-                <t>
-                    This keyword's value MUST be an object.
-                    Each member value of this object MUST be a valid JSON Schema.
-                </t>
-                <t>
-                    This keyword plays no role in validation per se. Its role is to provide
-                    a standardized location for schema authors to inline JSON Schemas into a
-                    more general schema.
-                </t>
-
-                <t>
-                    As an example, here is a schema describing an array of positive
-                    integers, where the positive integer constraint is a subschema in
-                    "definitions":
-
-                    <figure>
-                        <artwork>
-<![CDATA[
-{
-    "type": "array",
-    "items": { "$ref": "#/definitions/positiveInteger" },
-    "definitions": {
-        "positiveInteger": {
-            "type": "integer",
-            "exclusiveMinimum": 0
-        }
-    }
-}
-]]>
-                        </artwork>
-                    </figure>
-                </t>
-            </section>
-
-            <section title='"title" and "description"'>
-                <t>
-                    The value of both of these keywords MUST be a string.
-                </t>
-                <t>
-                    Both of these keywords can be used to decorate a user interface with
-                    information about the data produced by this user interface. A title will
-                    preferably be short, whereas a description will provide explanation about
-                    the purpose of the instance described by this schema.
-                </t>
-            </section>
-
-            <section title='"default"'>
-                <t>
-                    There are no restrictions placed on the value of this keyword.
-                </t>
-                <t>
-                    This keyword can be used to supply a default JSON value associated with a
-                    particular schema. It is RECOMMENDED that a default value be valid against
-                    the associated schema.
-                </t>
-            </section>
-
-            <section title='"readOnly"'>
-                <t>
-                    The value of this keyword MUST be a boolean.
-                </t>
-                <t>
-                    If it has a value of boolean true, this keyword indicates that the value of the
-                    instance is managed exclusively by the owning authority, and attempts by an
-                    application to modify the value of this property are expected to be ignored or
-                    rejected by that owning authority.
-                </t>
-                <t>
-                    For example, this property would be used to mark a database-generated serial
-                    number as read-only.
-                </t>
-                <t>
-                    This keyword can be used to assist in user interface instance generation.
-                </t>
-                <t>
-                    Omitting this keyword has the same behavior as a value of false.
-                </t>
-            </section>
-
-            <section title='"examples"'>
-                <t>
-                    The value of this keyword MUST be an array.
-                    There are no restrictions placed on the values within the array.
-                </t>
-                <t>
-                    This keyword can be used to provide sample JSON values associated with a
-                    particular schema, for the purpose of illustrating usage.  It is
-                    RECOMMENDED that these values be valid against the associated schema.
-                </t>
-                <t>
-                    Implementations MAY use the value of "default", if present, as
-                    an additional example.  If "examples" is absent, "default"
-                    MAY still be used in this manner.
-                </t>
-            </section>
-
-        </section>
-
         <section title='Semantic validation with "format"'>
 
             <section title="Foreword">
@@ -1196,6 +1096,106 @@
                         Unicode).
                     </postamble>
                 </figure>
+            </section>
+
+        </section>
+
+        <section title="Metadata keywords">
+            <section title="definitions">
+                <t>
+                    This keyword's value MUST be an object.
+                    Each member value of this object MUST be a valid JSON Schema.
+                </t>
+                <t>
+                    This keyword plays no role in validation per se. Its role is to provide
+                    a standardized location for schema authors to inline JSON Schemas into a
+                    more general schema.
+                </t>
+
+                <t>
+                    As an example, here is a schema describing an array of positive
+                    integers, where the positive integer constraint is a subschema in
+                    "definitions":
+
+                    <figure>
+                        <artwork>
+<![CDATA[
+{
+    "type": "array",
+    "items": { "$ref": "#/definitions/positiveInteger" },
+    "definitions": {
+        "positiveInteger": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+        }
+    }
+}
+]]>
+                        </artwork>
+                    </figure>
+                </t>
+            </section>
+
+            <section title='"title" and "description"'>
+                <t>
+                    The value of both of these keywords MUST be a string.
+                </t>
+                <t>
+                    Both of these keywords can be used to decorate a user interface with
+                    information about the data produced by this user interface. A title will
+                    preferably be short, whereas a description will provide explanation about
+                    the purpose of the instance described by this schema.
+                </t>
+            </section>
+
+            <section title='"default"'>
+                <t>
+                    There are no restrictions placed on the value of this keyword.
+                </t>
+                <t>
+                    This keyword can be used to supply a default JSON value associated with a
+                    particular schema. It is RECOMMENDED that a default value be valid against
+                    the associated schema.
+                </t>
+            </section>
+
+            <section title='"readOnly"'>
+                <t>
+                    The value of this keyword MUST be a boolean.
+                </t>
+                <t>
+                    If it has a value of boolean true, this keyword indicates that the value of the
+                    instance is managed exclusively by the owning authority, and attempts by an
+                    application to modify the value of this property are expected to be ignored or
+                    rejected by that owning authority.
+                </t>
+                <t>
+                    For example, this property would be used to mark a database-generated serial
+                    number as read-only.
+                </t>
+                <t>
+                    This keyword can be used to assist in user interface instance generation.
+                </t>
+                <t>
+                    Omitting this keyword has the same behavior as a value of false.
+                </t>
+            </section>
+
+            <section title='"examples"'>
+                <t>
+                    The value of this keyword MUST be an array.
+                    There are no restrictions placed on the values within the array.
+                </t>
+                <t>
+                    This keyword can be used to provide sample JSON values associated with a
+                    particular schema, for the purpose of illustrating usage.  It is
+                    RECOMMENDED that these values be valid against the associated schema.
+                </t>
+                <t>
+                    Implementations MAY use the value of "default", if present, as
+                    an additional example.  If "examples" is absent, "default"
+                    MAY still be used in this manner.
+                </t>
             </section>
 
         </section>


### PR DESCRIPTION
This is a bit more groundwork for the rewrite, and is relevant
to issue #423.

***NOTE:** This has been updated from its original approach to move the concept into the validation specification!*

The commits have been broken up with individual messages into useful chunks:

1. [Just move the metadata section](https://github.com/json-schema-org/json-schema-spec/pull/424/commits/dd0b873a0227e5a7a5bafbe35ae3302fa5c6ba8a)
1. [Split out and re-word "definitions"](https://github.com/json-schema-org/json-schema-spec/pull/424/commits/4f9e4e3ccdd110e054899592ff88f40de56c77b9)
1. [Generalize and move applicability from hyper-schema to validation/annotation](https://github.com/json-schema-org/json-schema-spec/pull/424/commits/c55678a7e8845ba7eb9ee334d56bc1dbaeb7c376)
1. [Group annotation keywords & re-indent without changing](https://github.com/json-schema-org/json-schema-spec/pull/424/commits/c2eccf96355eb7797f628ddbd76fcddf5c2a9ef5)
1. [Update annotation keywords with multi-value behavior](https://github.com/json-schema-org/json-schema-spec/pull/424/commits/d9c913a98a6b8589c4f2bb1e1868261c39ef3be2)
 
-----

Rework the whole applicability/attachement concept from the 
hyper-schema specification into the validations specification,
and establish it as the basis for working with annotation keywords.

Update the annotation kewyords with clarifications on how to
handle values across multiple applicable schemas.

Update the hyper-schema specification to reference the now more
generic description of validation interaction in the validation
spec itself, with additional clarifications about how to handle
combinign keywords from multiple applicable schemas.

Split the "Metadata" section into a re-use section for just the 
"definitions" keyword, and a section on annotation and extensibility
which defines applicability/attachement and defines the simple
annotation vocabulary that was already present in the validation
spec.

Move all of that after "format" and "String-encoding non-JSON data"
as those sections are both more closely aligned with validation
than with either re-use or annotations.


