### PR TITLE
Add $vocabularies, clarify $schema and $ref

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,53 +1,63 @@
 {
     "$schema": "http://json-schema.org/draft-06/hyper-schema#",
     "$id": "http://json-schema.org/draft-06/hyper-schema#",
+    "$vocabularies": [
+        "http://json-schema.org/draft-06/schema#",
+        "http://json-schema.org/draft-06/hyper-schema#"
+    ],
     "title": "JSON Hyper-Schema",
     "definitions": {
         "schemaArray": {
             "allOf": [
                 { "$ref": "http://json-schema.org/draft-06/schema#/definitions/schemaArray" },
                 {
-                    "items": { "$ref": "#" }
+                    "items": { "$ref": "#/definitions/subschema" }
                 }
+            ]
+        },
+        "subschema": {
+            "allOf": [
+                { "$ref": "#" },
+                { "properties": { "$schema": false } }
             ]
         }
     },
     "allOf": [ { "$ref": "http://json-schema.org/draft-06/schema#" } ],
     "properties": {
-        "additionalItems": { "$ref": "#" },
-        "additionalProperties": { "$ref": "#"},
+        "additionalItems": { "$ref": "#/definitions/subschema" },
+        "additionalProperties": { "$ref": "#/definitions/subschema"},
         "dependencies": {
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
+                    { "$ref": "#/definitions/subschema" },
                     { "type": "array" }
                 ]
             }
         },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$ref": "#/definitions/subschema" },
                 { "$ref": "#/definitions/schemaArray" }
             ]
         },
         "definitions": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subschema" }
         },
         "patternProperties": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subschema" }
         },
         "properties": {
-            "additionalProperties": { "$ref": "#" }
+            "additionalProperties": { "$ref": "#/definitions/subschema" }
         },
-        "if": {"$ref": "#"},
-        "then": {"$ref": "#"},
-        "else": {"$ref": "#"},
+        "if": {"$ref": "#/definitions/subschema"},
+        "then": {"$ref": "#/definitions/subschema"},
+        "else": {"$ref": "#/definitions/subschema"},
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" },
-        "contains": { "$ref": "#" },
-        "propertyNames": { "$ref": "#" },
+        "not": { "$ref": "#/definitions/subschema" },
+        "contains": { "$ref": "#/definitions/subschema" },
+        "propertyNames": { "$ref": "#/definitions/subschema" },
 
         "base": {
             "type": "string"

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -365,36 +365,113 @@
 
         </section>
 
-        <section title='The "$schema" keyword'>
-            <!-- TODO a custom $schema keyword might also be used to enforce minimum required functionality of a validator -->
+        <section title="Schema vocabularies">
             <t>
-                The "$schema" keyword is both used as a JSON Schema version identifier and the
-                location of a resource which is itself a JSON Schema, which describes any schema
-                written for this particular version.
+                JSON Schema is a media type, and as described by this specification offers
+                minimal functionality.  Schema authors will need to use at least one vocabulary,
+                such as 
+                <xref target="json-schema-validation">validation</xref> or
+                <xref target="json-hyper-schema">hyper-schema</xref>, to create meaningful
+                schema documents.
             </t>
             <t>
-                The value of this keyword MUST be a <xref target="RFC3986">URI</xref>
-                (containing a scheme) and this URI MUST be normalized.
-                The current schema MUST be valid against the meta-schema identified by this URI.
+                Schemas can themselves be described by a schema, referred to as a meta-schema.
+                This process, as with other instance documents, applies a single meta-schema
+                across the entire schema document.  A meta-schema is declared with "$schema".
             </t>
             <t>
-                The "$schema" keyword SHOULD be used in a root schema.
-                It MUST NOT appear in subschemas.
+                Schema vocabularies, however, can be mixed within a single document, at the
+                schema object level.  While a schema vocabulary is identified by a meta-schema,
+                vocabularies used within a schema document are not necessarily capable of
+                validating the entire document.  Vocabularies are declared with "$vocabularies".
             </t>
             <t>
-                <cref>
-                    While this pattern is likely to remain best practice for schema authoring,
-                    implementation behavior is subject to be revised or liberalized in future
-                    drafts.
-                </cref>
+                Either the "$schema" or "$vocabularies" keyword SHOULD be present in a non-empty root
+                schema, or else the interpretation of the schema is undefined.  Implementations MAY
+                make assumptions based on other input or on the schema's contents, but MUST NOT assume
+                identical behavior in peer implementations.
             </t>
             <t>
-                Values for this property are defined in other documents and by other parties.
+                Values for these properties are defined in other documents and by other parties.
                 JSON Schema implementations SHOULD implement support for current and previous
                 published drafts of JSON Schema vocabularies as deemed reasonable.
             </t>
-        </section>
+            <section title='The "$schema" keyword'>
+                <t>
+                    The "$schema" keyword is used to identify another schema which is used to
+                    validate the schema.  This other schema is referred to as a meta-schema.
+                </t>
+                <t>
+                    The value of this keyword MUST be a <xref target="RFC3986">URI</xref>
+                    (containing a scheme) and this URI MUST be normalized.
+                    The current schema MUST be valid against the meta-schema identified by this URI.
+                </t>
+                <t>
+                    The "$schema" keyword SHOULD be used in a root schema.
+                    It MUST NOT appear in subschemas, as the schema validation process applies
+                    at a whole-document granularity.  Note that "$vocabularies" can be used
+                    for more fine-grained control indication of purpose within a document,
+                    as long as the vocabularies declared do not contradict the meta-schema
+                    declared by "$schema".
+                </t>
+                <t>
+                    <cref>
+                        Note that if "$vocabularies" is present in the root schema, and if
+                        a meta-schema is associated with the schema using one of the mechanisms
+                        avaialble to associate schemas with non-schema instance documents, "$schema"
+                        is not strictly necessary.  However, it remains a best practice to include one.
+                        This recommendation is subject to be revised or liberalized in future drafts.
+                    </cref>
+                </t>
+                <t>
+                    Implementations SHOULD NOT make processing decisions other than meta-schema
+                    validation based on this keyword, although in the absence of the "$vocabularies"
+                    keyword, it's default is based on "$schema", if present.
+                </t>
+            </section>
 
+            <section title='The "$vocabularies" keyword'>
+                <t>
+                    The value of this keyword MUST be an array.  Each element in the array
+                    MUST be a URI (containing a scheme) and this URI MUST be normalized.
+                    Vocabulary identifiers SHOULD also be usable as meta-schema identifiers.
+                    However, as vocabularies are declared per schema object, while meta-schemas
+                    are declared per schema document, implementations MUST NOT attempt to
+                    validate the entire document against individual vocabularies.
+                </t>
+                <t>
+                    Implementations SHOULD examine this keyword before any others to determine
+                    if a recognized vocabulary is in use.
+                    <cref>
+                        It is not clear what, if anything, implementations should do with
+                        unrecognized URIs.  Ignore, warn, or error out?  Ignore seems the
+                        safest, but offering the ability to warn or error also seems useful.
+                        Also, could unrecognized vocabulary URIs introduce any kind of
+                        security concern?
+                    </cref>
+                </t>
+                <t>
+                    Each vocabulary SHOULD be listed separately.  For example, the validation
+                    vocabulary should be listed whenever the hyper-schema vocabulary is in use,
+                    as hyper-schema depends on validation.  This avoids the need for implementations
+                    to understand dependencies among vocabularies, and allows a validator to
+                    recognize the validation vocabulary without understanding hyper-schema.
+                </t>
+                <t>
+                    This keyword SHOULD be used in root schemas, and MAY be used in subschemas.
+                    Omitting this keyword in a subschema has the same effect as re-declaring
+                    the parent schema's vocabularies.  Omitting this keyword in a root schema
+                    has the same effect as specifying a one-element array with the same value
+                    as the value of "$schema", if any.
+                </t>
+                <t>
+                    For historical reasons, when "$vocabularies" is omitted from a root schema
+                    and the value of "$schema" is a hyper-schema identifier, then the behavior
+                    of "$vocabularies" is identical to a two-element array containing both the
+                    value of "$schema" and the URI of the corresponding validation vocabulary.
+                </t>
+            </section>
+        </section>
         <section title='Schema references with "$ref"'>
             <t>
                 The "$ref" keyword is used to reference a schema, and provides the ability to
@@ -405,6 +482,12 @@
                 The value of the "$ref" property MUST be a URI Reference.
                 Resolved against the current URI base, it identifies the URI of a schema to use.
                 All other properties in a "$ref" object MUST be ignored.
+            </t>
+            <t>
+                For the purpose of meta-schema validation, when a reference target is in a different
+                schema document than the reference context, validation MUST be processed on
+                each document independently.  The reference target MUST NOT be processed as if
+                it were included in the context document.
             </t>
             <t>
                 The URI is not a network locator, only an identifier. A schema need not be

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -205,8 +205,14 @@
 
         <section title="Meta-schema">
             <t>
-                The current URI for the JSON Hyper-Schema meta-schema is
+                The current URI for the JSON Hyper-Schema meta-schema , intended
+                for use with "$schema" and "$vocabularies", is
                 &lt;http://json-schema.org/draft-06/hyper-schema#&gt;.
+            </t>
+            <t>
+                Schemas that declare the hyper-schema vocabulary in "$vocabularies" SHOULD
+                also declare the corresponding version of the
+                <xref target="json-schema-validation">validation</xref> vocabulary.
             </t>
         </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -247,8 +247,9 @@
 
         <section title="Meta-schema">
             <t>
-                The current URI for the JSON Schema Validation is
-                &lt;http://json-schema.org/draft-06/schema#&gt;.
+                The current URI for the JSON Schema Validation meta-schema, intended
+                for use with "$schema" and "$vocabularies", is
+                &lt;http://json-schema.org/draft-06/schema#&gt;.  This URI 
             </t>
         </section>
 

--- a/links.json
+++ b/links.json
@@ -1,6 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-06/hyper-schema#",
     "$id": "http://json-schema.org/draft-06/links#",
+    "$vocabularies": [
+        "http://json-schema.org/draft-06/schema#",
+        "http://json-schema.org/draft-06/hyper-schema#"
+    ],
     "title": "Link Description Object",
     "type": "object",
     "required": [ "href" ],
@@ -21,7 +25,7 @@
         },
         "hrefSchema": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#/definitions/subschema" }
             ]
         },
         "hrefRequired": {
@@ -53,7 +57,7 @@
         },
         "targetSchema": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#/definitions/subschema" }
             ]
         },
         "targetHints": { },
@@ -62,7 +66,7 @@
         },
         "headerSchema": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#/definitions/subschema" }
             ]
         },
         "submissionEncType": {
@@ -71,7 +75,7 @@
         },
         "submissionSchema": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-06/hyper-schema#" }
+                { "$ref": "http://json-schema.org/draft-06/hyper-schema#/definitions/subschema" }
             ]
         },
         "$comment": {

--- a/schema.json
+++ b/schema.json
@@ -1,12 +1,15 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://json-schema.org/draft-06/schema#",
+    "$vocabularies": [
+        "http://json-schema.org/draft-06/schema#"
+    ],
     "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "#" }
+            "items": { "$ref": "#/definitions/subschema" }
         },
         "nonNegativeInteger": {
             "type": "integer",
@@ -34,6 +37,12 @@
             "items": { "type": "string" },
             "uniqueItems": true,
             "default": []
+        },
+        "subschema": {
+            "allOf": [
+                { "$ref": "#" },
+                { "properties": { "$schema": false } }
+            ]
         }
     },
     "type": ["object", "boolean"],
@@ -45,6 +54,13 @@
         "$schema": {
             "type": "string",
             "format": "uri"
+        },
+        "$vocabularies": {
+            "type": "array",
+            "items": {
+                  "type": "string",
+                  "format": "uri"
+            }
         },
         "$ref": {
             "type": "string",
@@ -90,10 +106,10 @@
             "type": "string",
             "format": "regex"
         },
-        "additionalItems": { "$ref": "#" },
+        "additionalItems": { "$ref": "#/definitions/subschema" },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$ref": "#/definitions/subschema" },
                 { "$ref": "#/definitions/schemaArray" }
             ],
             "default": {}
@@ -104,24 +120,24 @@
             "type": "boolean",
             "default": false
         },
-        "contains": { "$ref": "#" },
+        "contains": { "$ref": "#/definitions/subschema" },
         "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
         "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
         "required": { "$ref": "#/definitions/stringArray" },
-        "additionalProperties": { "$ref": "#" },
+        "additionalProperties": { "$ref": "#/definitions/subschema" },
         "definitions": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subschema" },
             "default": {}
         },
         "properties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subschema" },
             "default": {}
         },
         "patternProperties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$ref": "#/definitions/subschema" },
             "propertyNames": { "format": "regex" },
             "default": {}
         },
@@ -129,12 +145,12 @@
             "type": "object",
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
+                    { "$ref": "#/definitions/subschema" },
                     { "$ref": "#/definitions/stringArray" }
                 ]
             }
         },
-        "propertyNames": { "$ref": "#" },
+        "propertyNames": { "$ref": "#/definitions/subschema" },
         "const": {},
         "enum": {
             "type": "array",
@@ -155,13 +171,13 @@
         "format": { "type": "string" },
         "contentMediaType": { "type": "string" },
         "contentEncoding": { "type": "string" },
-        "if": {"$ref": "#"},
-        "then": {"$ref": "#"},
-        "else": {"$ref": "#"},
+        "if": {"$ref": "#/definitions/subschema"},
+        "then": {"$ref": "#/definitions/subschema"},
+        "else": {"$ref": "#/definitions/subschema"},
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" }
+        "not": { "$ref": "#/definitions/subschema" }
     },
     "default": {}
 }


### PR DESCRIPTION
This addresses issues #314 and #431.

`"$schema"` is now explicitly intended for meta-schema declaration.
An explanation for why it MUST only be present in root schemas
has been added so we (I) don't forget about it and freak out (again).

The concept of vocabularies is now introduced explicitly, and
the `"$vocabularies"` keyword is introduced to declare vocabulary
support.  For compatibility (and simplicity in the case of
a single standard meta-schema conveying sufficient information),
omitting `"$vocabularies"` in the root schema causes it to behave
as if the `"$schema"` value is listed as a vocabulary.  This preserves
all existing behavior.

Finally, a paragraph is added to `"$ref"` clarifying the conceptual
model, specifically with respect to `"$schema"` and meta-schema
validation.