### PR TITLE
Fix readOnly default in draft-06 meta-schema

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -119,7 +119,7 @@
         "readOnly": {
             "description": "If true, indicates that the value of this property is controlled by the server.",
             "type": "boolean",
-            "default": "false"
+            "default": false
         }
     },
     "links": [


### PR DESCRIPTION
It was the string "false" instead of the literal false

Addresses part of #430 