### PR TITLE
Clarify dependencies deprecation

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -608,10 +608,13 @@
                     <t>
                         <cref>
                             Now that "if", "then", and "else" are keywords, it is not clear whether
-                            there is any benefit in keeping dependencies.  It is frequently
-                            misunderstood and seems to be rarely used.  Depending on feedback
-                            with "if", "then", and "else", this keyword may well be removed in a
-                            future draft.
+                            there is any benefit in keeping the schema form of "dependencies".
+                            It is frequently misunderstood, and having a form that takes a subschema
+                            as well as a form that takes a primitive value is particularly
+                            confusing.  And it seems to be rarely used.  Depending on feedback
+                            with "if", "then", and "else", the schema form of this keyword may
+                            well be removed in a future draft.  Current thought is that the string
+                            form (giving property names in an array) is a useful shortcut.
                         </cref>
                     </t>
                     <t>


### PR DESCRIPTION
It is focused on the subschema form, not the string array form.

This addresses #442.
