### PR TITLE
New overview based on applicability and assertions

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -259,7 +259,11 @@
                     A JSON Schema MUST be an object or a boolean.
                 </t>
                 <t>
-                    Boolean values are equivalent to the following behaviors:
+                    JSON Schema vocabularies can include assertions, which return a boolean result
+                    when applied to an instance.  The boolean schema values "true" and "false"
+                    are trivial assertions that always return themselves regardless of the
+                    instance value.  As an example, in terms of the validation vocabulary,
+                    boolean schemas are equivalent to the following behaviors:
                     <list style="hanging">
                         <t hangText="true">Always passes validation, as if the empty schema {}</t>
                         <t hangText="false">Always fails validation, as if the schema { "not":{} }</t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -187,8 +187,8 @@
         <section title="Schema keywords">
             <t>
                 Hyper-schema keywords can be applied when the instance is valid against
-                the schema that includes those keywords, as outlined in
-                <xref target="json-schema-validation">Section 10.1 of JSON Schema validation</xref>.
+                the schema that includes those keywords, as outlined under "Annotations" in
+                <xref target="json-schema-validation">Section 3.3 of JSON Schema validation</xref>.
             </t>
             <t>
                 When multiple subschemas are applicable to a given sub-instance, all "link"

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -172,78 +172,145 @@
 
         </section>
 
-        <section title="General validation considerations">
-
-            <section title="Keywords and instance primitive types">
+        <section title="Overview">
+            <t>
+                JSON Schema validation applies schemas to locations within the instance,
+                and asserts constraints on the structure of the data at each location.
+                An instance location that satisfies all asserted constraints is then
+                annotated with any keywords that contain non-assertion information,
+                such as desciptive metadata and usage hints.  If all locations within
+                the instance satisfy all asserted constraints, then the instance is
+                said to be valid against the schema.
+            </t>
+            <t>
+                Each schema object is independently evaluated against each instance location
+                to which it applies.  This greatly simplifies the implementation requirements
+                for validators by ensuring that they do not need to maintain state across
+                the document-wide validation process.
+            </t>
+            <section title="Applicability">
                 <t>
-                    Most validation keywords only constrain values within a certain primitive type.
-                    When the type of the instance is not of the type targeted by the keyword, the
-                    validation succeeds.
+                    Validation begins by applying the root schema to the complete instance
+                    document.  From there, various keywords are used to determine which additional
+                    subschemas are applied to either the current location, or a child location.
+                    These keywords also define whether and how subschema assertion results are
+                    modified and/or combined.  Such keywords do not assert conditions on their
+                    own.  Rather, they control how assertions are applied and evaluated.
                 </t>
                 <t>
-                    For example, the "maxLength" keyword will only restrict certain strings (that
-                    are too long) from being valid.
-                    If the instance is a number, boolean, null, array, or object, the keyword passes
-                    validation.
+                    The keywords in the <xref target="logic">boolean logic</xref> and
+                    <xref target="conditional">conditional</xref> sections of this specification
+                    apply subschemas to the same location as the parent schema.  The former group
+                    defines boolean operations on the subschema assertion results, while the
+                    latter evaluates one subschema and uses its assertion results to determine
+                    which of two other subschemas to apply as well.
                 </t>
+                <t>
+                    Several keywords determine which subschemas are applied to array items,
+                    object property values, and object property names.  They are:
+                    "items", "additionalItems", "contains", "properties", "patternProperties",
+                    "additionalProperties", and "propertyNames".  The "contains" keyword only
+                    requires its subschema to be valid against at least one child instance, while
+                    the other keywords require that all subschemas are valid against all child
+                    instances to which they apply.
+                </t>
+                <section title="Keyword independence">
+                    <t>
+                        Validation keywords typically operate independently, without
+                        affecting each other's outcomes.
+                    </t>
+                    <t>
+                        For schema author convenience, there are some exceptions among the
+                        keywords that control subschema applicability:
+                        <list>
+                            <t>
+                                "additionalProperties", whose behavior is defined in terms of
+                                "properties" and "patternProperties"; and
+                            </t>
+                            <t>
+                                "additionalItems", whose behavior is defined in terms of "items".
+                            </t>
+                        </list>
+                    </t>
+                </section>
             </section>
-
-            <section title="Validation of primitive types and child values">
+            <section title="Assertions">
                 <t>
-                    Two of the primitive types, array and object, allow for child values.
-                    The validation of the primitive type is considered separately from
-                    the validation of child instances.
+                    Validation is a process of checking assertions.  Each assertion adds
+                    constraints that an instance must satisfy in order to successfully validate.
                 </t>
                 <t>
-                    For arrays, primitive type validation consists of validating
-                    restrictions on length with "minItems" and "maxItems", while
-                    "items" and "additionalItems" determine which subschemas apply
-                    to which elements of the array.  In addition, "uniqueItems"
-                    and "contains" validate array contents as a whole.
-                </t>
-                <t>
-                    For objects, primitive type validation consists of validating
-                    restrictions on which and how many properties appear with
-                    "required", "minProperties", "maxProperties", "propertyNames",
-                    and the string array form of "dependencies", while "properties",
-                    "patternProperties", and "additionalProperties" determine which
-                    subschemas apply to which object property values.
-                    In addition, the schema form of "dependencies" validates the
-                    object as a whole based on the presence of specific property names.
-                </t>
-            </section>
-
-            <section title="Constraints and missing keywords">
-                <t>
-                    Each JSON Schema validation keyword adds constraints that
-                    an instance must satisfy in order to successfully validate.
-                </t>
-                <t>
-                    Validation keywords that are missing never restrict validation.
+                    Assertion keywords that are absent never restrict validation.
                     In some cases, this no-op behavior is identical to a keyword that exists with
                     certain values, and these values are noted where known.
                 </t>
-            </section>
-
-            <section title="Keyword independence">
                 <t>
-                    Validation keywords typically operate independently, without
-                    affecting each other's outcomes.
+                    All of the keywords in the <xref target="general">general</xref>,
+                    <xref target="numeric">numeric</xref>, and <xref target="string">string</xref>
+                    sections are assertions, as well as "minItems", "maxItems", "uniqueItems",
+                    "minProperties", "maxProperties", and "required".  Additionally, "dependencies"
+                    is shorthand for a combination of conditional and assertion keywords.
                 </t>
                 <t>
-                    For schema author convenience, there are some exceptions:
-                    <list>
-                        <t>
-                            "additionalProperties", whose behavior is defined in terms of
-                            "properties" and "patternProperties"; and
-                        </t>
-                        <t>
-                            "additionalItems", whose behavior is defined in terms of "items".
-                        </t>
-                    </list>
+                    The "format", "contentType", and "contentEncoding" keywords can also be
+                    implemented as assertions, although that functionality is an optional part
+                    of this specification, and the keywords convey additional non-assertion
+                    information.
                 </t>
+                <section title="Assertions and instance primitive types">
+                    <t>
+                        Most validation assertions only constrain values within a certain
+                        primitive type.  When the type of the instance is not of the type
+                        targeted by the keyword, the instance is considered to conform
+                        to the assertion.
+                    </t>
+                    <t>
+                        For example, the "maxLength" keyword will only restrict certain strings
+                        (that are too long) from being valid.  If the instance is a number,
+                        boolean, null, array, or object, then it is valid against this assertion.
+                    </t>
+                </section>
             </section>
-
+            <section title="Annotations">
+                <t>
+                    In addition to assertions, this specification provides a small vocabulary
+                    of metadata keywords that can be used to annotate the JSON instance with
+                    useful information.  The <xref target="format" /> and <xref target="content" />
+                    keywords are also useful as annotations as well as being optional assertions,
+                    as they convey additional usage guidance for the instance data.
+                </t>
+                <t>
+                    A schema that is applicable to a particular location in the instance, against
+                    which the instance location is valid, attaches its annotations to that location
+                    in the instance.  Since many subschemas can be applicable to any single
+                    location, annotation keywords need to specify any unusual handling of
+                    multiple applicable occurrences of the keyword with different values.
+                    The default behavior is simply to collect all values.
+                </t>
+                <t>
+                    Additional vocabularies SHOULD make use of this mechanism for applying
+                    their own annotations to instances.
+                </t>
+                <section title="Negated schemas">
+                    <t>
+                        Annotations in a subschema contained within a "not", at any depth,
+                        including any number of intervening additional "not" subschemas, MUST be
+                        ignored.  Similarly, annotations within a failing branch of a "oneOf",
+                        "anyOf", "then", or "else" MUST be ignored.
+                    </t>
+                </section>
+                <section title="Annotations and short-circuit validation">
+                    <t>
+                        Annotation keywords MUST be applied to all possible sub-instances.
+                        even if such application can be short-circuited when only assertion
+                        evaluation is needed.  For instance, the "contains" keyword need only
+                        be checked for assertions until at least one array item proves valid.
+                        However, when working with annotations, all items in the array must
+                        be evaluated to determine all items with which the annotations should
+                        be associated.
+                    </t>
+                </section>
+            </section>
         </section>
 
         <section title="Meta-schema">
@@ -259,7 +326,7 @@
                 instance.
             </t>
 
-            <section title="Validation keywords for any instance type">
+            <section title="Validation keywords for any instance type" anchor="general">
                 <section title="type">
                     <t>
                         The value of this keyword MUST be either a string or an array. If it is
@@ -301,7 +368,8 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for numeric instances (number and integer)">
+            <section title="Validation keywords for numeric instances (number and integer)"
+                     anchor="numeric">
                 <section title="multipleOf">
                     <t>
                         The value of "multipleOf" MUST be a number, strictly greater than 0.
@@ -357,7 +425,7 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for strings">
+            <section title="Validation keywords for strings" anchor="string">
                 <section title="maxLength">
                     <t>
                         The value of this keyword MUST be a non-negative integer.</t>
@@ -655,7 +723,7 @@
                 </section>
             </section>
 
-            <section title="Keywords for applying subschemas conditionally">
+            <section title="Keywords for applying subschemas conditionally" anchor="conditional">
                 <t>
                     These keywords work together to implement conditional
                     application of a subschema based on the outcome of
@@ -727,7 +795,7 @@
                 </section>
             </section>
 
-            <section title="Keywords for applying subschemas with boolean logic">
+            <section title="Keywords for applying subschemas with boolean logic" anchor="logic">
                 <section title="allOf">
                     <t>
                         This keyword's value MUST be a non-empty array.
@@ -773,7 +841,7 @@
             </section>
         </section>
 
-        <section title='Semantic validation with "format"'>
+        <section title='Semantic validation with "format"' anchor="format">
 
             <section title="Foreword">
                 <t>
@@ -1003,7 +1071,7 @@
             </section>
         </section>
 
-        <section title='String-encoding non-JSON data'>
+        <section title='String-encoding non-JSON data' anchor="content">
 
             <section title="Foreword">
                 <t>
@@ -1147,75 +1215,19 @@
             </t>
         </section>
 
-        <section title="Schema annotations and extension vocabularies">
+        <section title="Schema annotations">
             <t>
                 Schema validation is a useful mechanism for annotating instance data
-                with additional information.  This section describes the rules for
-                determining when and how annotations apply to an instance, and specifies
-                a small general-purpose annotation vocabulary.
+                with additional information.  The rules for determining when and how
+                annotations are associated with an instance are outlined in this specification's
+                overview.
             </t>
             <t>
-                Additional vocabularies SHOULD make use of this mechanism for applying
-                their keywords to instances.
+                These general-purpose annotation keywords provide commonly used information
+                for documentation and user interface display purposes.  They are not intended
+                to form a comprehensive set of features.  Rather, additional vocabularies
+                can be defined for more complex annotation-based applications.
             </t>
-            <section title="Applicability and attachment">
-                <t>
-                    Annotations can be applied to an instance when it is valid against
-                    the schema that includes the annotation keywords.  For any given location
-                    in the instance (referred to as a sub-instance), each (sub)schema against
-                    which it successfully validates is considered to be <spanx>applicable</spanx>
-                    to that sub-instance.  The (sub)schema is said to be <spanx>attached</spanx>
-                    to each sub-instance to which it applies.
-                </t>
-                <t>
-                    A validation implementation MAY choose to implement determining subschema
-                    applicability and providing access to the value(s) of applicable annotation
-                    keywords.  Implementation of this feature MAY instead be done separately.
-                </t>
-                <t>
-                    Since many subschemas can be applicable to any single sub-instance, each
-                    annotation keyword or vocabulary needs to specify how to handle multiple
-                    occurrences with different values.  In the absence of keyword-specific
-                    handling rules, an implementation MUST collect all values and make them
-                    available as a data structure in which order is not significant and items
-                    need not be unique.
-                </t>
-                <section title="Combinatoric and conditional schemas">
-                    <t>
-                        Annotations in branches of an "anyOf", "oneOf", or "if"/"then"/"else"
-                        that do not validate, or in a "dependencies" subschema that is not relevant
-                        to the instance, MUST be ignored.
-                    </t>
-                    <t>
-                        Annotations in a subschema contained within a "not", at any depth,
-                        including any number of intervening additional "not" subschemas, MUST be
-                        ignored.
-                    </t>
-                </section>
-                <section title="Annotations and short-circuit validation">
-                    <t>
-                        Schema keywords MUST be applied to all possible sub-instances when
-                        considering annotations, even if such application can be short-circuited
-                        when only the overall validation result is needed.
-                    </t>
-                    <t>
-                        An example of this is the "contains" keyword, which need only be evaluated
-                        against array elements until it produces at least one successful outcome
-                        in order to be implemented.  However, when annotations are considered,
-                        it must be checked against every array element, and the annotations MUST
-                        be applied to every element that successfully validates against the
-                        "contains" susbschema.
-                    </t>
-                </section>
-            </section>
-
-            <section title="Basic annotation keywords">
-                <t>
-                    These general-purpose annotation keywords provide commonly used information
-                    for documentation and user interface display purposes.  They are not intended
-                    to form a comprehensive set of features.  Rather, additional vocabularies
-                    can be defined for more complex annotation-based applications.
-                </t>
                 <section title='"title" and "description"'>
                     <t>
                         The value of both of these keywords MUST be a string.
@@ -1306,7 +1318,6 @@
                         MAY still be used in this manner.
                     </t>
                 </section>
-            </section>
         </section>
 
         <section title="Security considerations">

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1228,96 +1228,96 @@
                 to form a comprehensive set of features.  Rather, additional vocabularies
                 can be defined for more complex annotation-based applications.
             </t>
-                <section title='"title" and "description"'>
-                    <t>
-                        The value of both of these keywords MUST be a string.
-                    </t>
-                    <t>
-                        Both of these keywords can be used to decorate a user interface with
-                        information about the data produced by this user interface. A title will
-                        preferably be short, whereas a description will provide explanation about
-                        the purpose of the instance described by this schema.
-                    </t>
-                </section>
+            <section title='"title" and "description"'>
+                <t>
+                    The value of both of these keywords MUST be a string.
+                </t>
+                <t>
+                    Both of these keywords can be used to decorate a user interface with
+                    information about the data produced by this user interface. A title will
+                    preferably be short, whereas a description will provide explanation about
+                    the purpose of the instance described by this schema.
+                </t>
+            </section>
 
-                <section title='"default"'>
-                    <t>
-                        There are no restrictions placed on the value of this keyword.  When
-                        multiple occurrences of this keyword are applicable to a single
-                        sub-instance, implementations SHOULD remove duplicates.
-                    </t>
-                    <t>
-                        This keyword can be used to supply a default JSON value associated with a
-                        particular schema. It is RECOMMENDED that a default value be valid against
-                        the associated schema.
-                    </t>
-                </section>
+            <section title='"default"'>
+                <t>
+                    There are no restrictions placed on the value of this keyword.  When
+                    multiple occurrences of this keyword are applicable to a single
+                    sub-instance, implementations SHOULD remove duplicates.
+                </t>
+                <t>
+                    This keyword can be used to supply a default JSON value associated with a
+                    particular schema. It is RECOMMENDED that a default value be valid against
+                    the associated schema.
+                </t>
+            </section>
 
-                <section title='"readOnly" and "writeOnly"'>
-                    <t>
-                        The value of these keywords MUST be a boolean.  When multiple occurrences
-                        of these keywords are applicable to a single sub-instance, the resulting
-                        value MUST be true if any occurrence specifies a true value, and MUST
-                        be false otherwise.
-                    </t>
-                    <t>
-                        If "readOnly" has a value of boolean true, it indicates that the value
-                        of the instance is managed exclusively by the owning authority, and
-                        attempts by an application to modify the value of this property are
-                        expected to be ignored or rejected by that owning authority.
-                    </t>
-                    <t>
-                        An instance document that is marked as "readOnly for the entire document
-                        MAY be ignored if sent to the owning authority, or MAY result in an
-                        error, at the authority's discretion.
-                    </t>
-                    <t>
-                        If "writeOnly" has a value of boolean true, it indicates that the value
-                        is never present when the instance is retrieved from the owning authority.
-                        It can be present when sent to the owning authority to update or create
-                        the document (or the resource it represents), but it will not be included
-                        in any updated or newly created version of the instance.
-                    </t>
-                    <t>
-                        An instance document that is marked as "writeOnly" for the entire document
-                        MAY be returned as a blank document of some sort, or MAY produce an error
-                        upon retrieval, or have the retrieval request ignored, at the authority's
-                        discretion.
-                    </t>
-                    <t>
-                        For example, "readOnly" would be used to mark a database-generated serial
-                        number as read-only, while "writeOnly" would be used to mark a password
-                        input field.
-                    </t>
-                    <t>
-                        These keywords can be used to assist in user interface instance generation.
-                        In particular, an application MAY choose to use a widget that hides
-                        input values as they are typed for write-only fields.
-                    </t>
-                    <t>
-                        Omitting these keywords has the same behavior as values of false.
-                    </t>
-                </section>
+            <section title='"readOnly" and "writeOnly"'>
+                <t>
+                    The value of these keywords MUST be a boolean.  When multiple occurrences
+                    of these keywords are applicable to a single sub-instance, the resulting
+                    value MUST be true if any occurrence specifies a true value, and MUST
+                    be false otherwise.
+                </t>
+                <t>
+                    If "readOnly" has a value of boolean true, it indicates that the value
+                    of the instance is managed exclusively by the owning authority, and
+                    attempts by an application to modify the value of this property are
+                    expected to be ignored or rejected by that owning authority.
+                </t>
+                <t>
+                    An instance document that is marked as "readOnly for the entire document
+                    MAY be ignored if sent to the owning authority, or MAY result in an
+                    error, at the authority's discretion.
+                </t>
+                <t>
+                    If "writeOnly" has a value of boolean true, it indicates that the value
+                    is never present when the instance is retrieved from the owning authority.
+                    It can be present when sent to the owning authority to update or create
+                    the document (or the resource it represents), but it will not be included
+                    in any updated or newly created version of the instance.
+                </t>
+                <t>
+                    An instance document that is marked as "writeOnly" for the entire document
+                    MAY be returned as a blank document of some sort, or MAY produce an error
+                    upon retrieval, or have the retrieval request ignored, at the authority's
+                    discretion.
+                </t>
+                <t>
+                    For example, "readOnly" would be used to mark a database-generated serial
+                    number as read-only, while "writeOnly" would be used to mark a password
+                    input field.
+                </t>
+                <t>
+                    These keywords can be used to assist in user interface instance generation.
+                    In particular, an application MAY choose to use a widget that hides
+                    input values as they are typed for write-only fields.
+                </t>
+                <t>
+                    Omitting these keywords has the same behavior as values of false.
+                </t>
+            </section>
 
-                <section title='"examples"'>
-                    <t>
-                        The value of this keyword MUST be an array.
-                        There are no restrictions placed on the values within the array.
-                        When multiple occurrences of this keyword are applicable to a single
-                        sub-instance, implementations MUST provide a flat array of all
-                        values rather than an array of arrays.
-                    </t>
-                    <t>
-                        This keyword can be used to provide sample JSON values associated with a
-                        particular schema, for the purpose of illustrating usage.  It is
-                        RECOMMENDED that these values be valid against the associated schema.
-                    </t>
-                    <t>
-                        Implementations MAY use the value(s) of "default", if present, as
-                        an additional example.  If "examples" is absent, "default"
-                        MAY still be used in this manner.
-                    </t>
-                </section>
+            <section title='"examples"'>
+                <t>
+                    The value of this keyword MUST be an array.
+                    There are no restrictions placed on the values within the array.
+                    When multiple occurrences of this keyword are applicable to a single
+                    sub-instance, implementations MUST provide a flat array of all
+                    values rather than an array of arrays.
+                </t>
+                <t>
+                    This keyword can be used to provide sample JSON values associated with a
+                    particular schema, for the purpose of illustrating usage.  It is
+                    RECOMMENDED that these values be valid against the associated schema.
+                </t>
+                <t>
+                    Implementations MAY use the value(s) of "default", if present, as
+                    an additional example.  If "examples" is absent, "default"
+                    MAY still be used in this manner.
+                </t>
+            </section>
         </section>
 
         <section title="Security considerations">

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -178,7 +178,7 @@
                     </t>
                 </section>
             </section>
-            <section title="Assertions">
+            <section title="Assertions" anchor="assertions">
                 <t>
                     Validation is a process of checking assertions.  Each assertion adds
                     constraints that an instance must satisfy in order to successfully validate.
@@ -215,7 +215,7 @@
                     </t>
                 </section>
             </section>
-            <section title="Annotations">
+            <section title="Annotations" anchor="annotations">
                 <t>
                     In addition to assertions, this specification provides a small vocabulary
                     of metadata keywords that can be used to annotate the JSON instance with
@@ -863,7 +863,15 @@
 
             <section title="Implementation requirements">
                 <t>
-                    Implementations MAY support the "format" keyword. Should they choose to do so:
+                    The "format" keyword functions as both an annotation
+                    (<xref target="annotations" />) and as an assertion
+                    (<xref target="assertions" />).  While no special effort is required to
+                    implement it as an annotation convenying semantic meaning, implementing
+                    validation is non-trivial.
+                </t>
+                <t>
+                    Implementations MAY support the "format" keyword as a validation assertion.
+                    Should they choose to do so:
 
                     <list>
                         <t>they SHOULD implement validation for attributes defined below;</t>
@@ -1087,7 +1095,16 @@
 
             <section title="Implementation requirements">
                 <t>
-                    Implementations MAY support keywords defined in this section.
+                    The content keywords function as both annotations
+                    (<xref target="annotations" />) and as assertions
+                    (<xref target="assertions" />).
+                    While no special effort is required to implement them as annotations convenying
+                    how applications can interpret the data in the string, implementing
+                    validation of conformance to the media type and encoding is non-trivial.
+                </t>
+                <t>
+                    Implementations MAY support the "contentMediaType" and "contentEncoding"
+                    keywords as validation assertions.
                     Should they choose to do so, they SHOULD offer an option to disable validation
                     for these keywords.
                 </t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -116,62 +116,6 @@
             </t>
         </section>
 
-        <section title="Interoperability considerations">
-
-            <section title="Validation of string instances">
-                <t>
-                    It should be noted that the nul character (\u0000) is valid in a JSON string. An
-                    instance to validate may contain a string value with this character, regardless
-                    of the ability of the underlying programming language to deal with such data.
-                </t>
-            </section>
-
-            <section title="Validation of numeric instances">
-                <t>
-                    The JSON specification allows numbers with arbitrary precision, and JSON Schema
-                    does not add any such bounds.
-                    This means that numeric instances processed by JSON Schema can be arbitrarily large and/or
-                    have an arbitrarily long decimal part, regardless of the ability of the
-                    underlying programming language to deal with such data.
-                </t>
-            </section>
-
-            <section title="Regular expressions" anchor="regexInterop">
-                <t>
-                    Two validation keywords, "pattern" and "patternProperties", use regular
-                    expressions to express constraints, and the "regex" value for the
-                    "format" keyword constrains the instance value to be a regular expression.
-                     These regular expressions SHOULD be valid according to the
-                    <xref target="ecma262">ECMA 262</xref> regular expression dialect.
-                </t>
-                <t>
-                    Furthermore, given the high disparity in regular expression constructs support,
-                    schema authors SHOULD limit themselves to the following regular expression
-                    tokens:
-
-                    <list>
-                        <t>individual Unicode characters, as defined by the <xref
-                        target="RFC7159">JSON specification</xref>;</t>
-                        <t>simple character classes ([abc]), range character classes ([a-z]);</t>
-                        <t>complemented character classes ([^abc], [^a-z]);</t>
-                        <t>simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or
-                        one), and their lazy versions ("+?", "*?", "??");</t>
-                        <t>range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at
-                        most y, occurrences), {x,} (x occurrences or more), and their lazy
-                        versions;</t>
-                        <t>the beginning-of-input ("^") and end-of-input ("$") anchors;</t>
-                        <t>simple grouping ("(...)") and alternation ("|").</t>
-                    </list>
-                </t>
-                <t>
-                    Finally, implementations MUST NOT take regular expressions to be
-                    anchored, neither at the beginning nor at the end. This means, for instance,
-                    the pattern "es" matches "expression".
-                </t>
-            </section>
-
-        </section>
-
         <section title="Overview">
             <t>
                 JSON Schema validation applies schemas to locations within the instance,
@@ -311,6 +255,62 @@
                     </t>
                 </section>
             </section>
+        </section>
+
+        <section title="Interoperability considerations">
+
+            <section title="Validation of string instances">
+                <t>
+                    It should be noted that the nul character (\u0000) is valid in a JSON string. An
+                    instance to validate may contain a string value with this character, regardless
+                    of the ability of the underlying programming language to deal with such data.
+                </t>
+            </section>
+
+            <section title="Validation of numeric instances">
+                <t>
+                    The JSON specification allows numbers with arbitrary precision, and JSON Schema
+                    does not add any such bounds.
+                    This means that numeric instances processed by JSON Schema can be arbitrarily large and/or
+                    have an arbitrarily long decimal part, regardless of the ability of the
+                    underlying programming language to deal with such data.
+                </t>
+            </section>
+
+            <section title="Regular expressions" anchor="regexInterop">
+                <t>
+                    Two validation keywords, "pattern" and "patternProperties", use regular
+                    expressions to express constraints, and the "regex" value for the
+                    "format" keyword constrains the instance value to be a regular expression.
+                     These regular expressions SHOULD be valid according to the
+                    <xref target="ecma262">ECMA 262</xref> regular expression dialect.
+                </t>
+                <t>
+                    Furthermore, given the high disparity in regular expression constructs support,
+                    schema authors SHOULD limit themselves to the following regular expression
+                    tokens:
+
+                    <list>
+                        <t>individual Unicode characters, as defined by the <xref
+                        target="RFC7159">JSON specification</xref>;</t>
+                        <t>simple character classes ([abc]), range character classes ([a-z]);</t>
+                        <t>complemented character classes ([^abc], [^a-z]);</t>
+                        <t>simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or
+                        one), and their lazy versions ("+?", "*?", "??");</t>
+                        <t>range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at
+                        most y, occurrences), {x,} (x occurrences or more), and their lazy
+                        versions;</t>
+                        <t>the beginning-of-input ("^") and end-of-input ("$") anchors;</t>
+                        <t>simple grouping ("(...)") and alternation ("|").</t>
+                    </list>
+                </t>
+                <t>
+                    Finally, implementations MUST NOT take regular expressions to be
+                    anchored, neither at the beginning nor at the end. This means, for instance,
+                    the pattern "es" matches "expression".
+                </t>
+            </section>
+
         </section>
 
         <section title="Meta-schema">


### PR DESCRIPTION
***NOTE:*** _No implementation requirements are changed by this PR!_

This reworks the "General validation considerations" section into
an overview that incorporates the applicability concept that was
recently added to the annotation section.  Some of the content
from that section was removed as it became duplicate content
with the new Overview.

The new Overview also talks about assertions, which is a word
used in the existing Abstract and Introduction sections.  It
helps by providing a name for the non-annotation keyword behavior,
other than "validation" which is used for the complete
specification.

The very awkward "Validation of primitive types and child values"
is covered much more clearly when written in terms of applicability
vs assertions.  These concepts map naturally to the distinction
that was being made in that section, and make it less of a weird
exception that needs explaining.

The other old sections are also covered in the new wording,
but are less dramatically affected.  And in some cases, kept
nearly word-for-word in new locations.

Also, move Interop after Overview.  It is too much low-level technical
detail to be that early in the document.