### PR TITLE
Relative JSON Pointer does not include JSON Pointer, but fits with it separately

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -82,7 +82,7 @@
             </t>
             <t>
                 The separation between the integer prefix and the JSON Pointer will
-                always be unambigious, because a JSON Pointer must be either zero-
+                always be unambiguous, because a JSON Pointer must be either zero-
                 length or start with a '/' (%x2F).  Similarly, a JSON Pointer will
                 never be ambiguous with the '#'.
             </t>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -254,6 +254,10 @@
                 The language and structure of this specification are based heavily on
                 <xref target="RFC6901"/>, sometimes quoting it outright.
             </t>
+            <t>
+                This draft remains primarily as written and published by Geraint Luff,
+                with only minor subsequent alterations under new editorship.
+            </t>
         </section>
 
         <section title="Security Considerations">
@@ -287,5 +291,26 @@
         <references title="Informative References">
             &RFC4627;
         </references>
+
+        <section title="ChangeLog">
+            <t>
+                <cref>This section to be removed before leaving Internet-Draft status.</cref>
+            </t>
+            <t>
+                <list style="hanging">
+                    <t hangText="draft-handrews-relative-json-pointer-00">
+                        <list style="symbols">
+                            <t>Revived draft with identical wording and structure.</t>
+                            <t>Clarified how to use alongside JSON Pointer.</t>
+                        </list>
+                    </t>
+                    <t hangText="draft-luff-relative-json-pointer-00">
+                        <list style="symbols">
+                            <t>Initial draft.</t>
+                        </list>
+                    </t>
+                </list>
+            </t>
+        </section>
     </back>
 </rfc>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -57,8 +57,8 @@
             <t>
                 JSON Pointer (<xref target="RFC6901">RFC 6901</xref>) is a syntax for specifying
                 locations in a JSON document, starting from the document root.  This
-                document defines an extension to the JSON Pointer syntax, allowing
-                relative locations from within the document.
+                document defines a related syntax allowing identification of relative locations
+                from within the document.
             </t>
         </section>
 
@@ -237,6 +237,15 @@
                 existent value.  This specification does not define how errors are
                 handled.  An application of JSON Relative Pointer SHOULD specify the
                 impact and handling of each type of error.
+            </t>
+        </section>
+
+        <section title="Relationship to JSON Pointer">
+            <t>
+                Relative JSON Pointers are intended as a companion to JSON Pointers.
+                Applications MUST specify the use of each syntax separately.
+                Defining either JSON Pointer or Relative JSON Pointer as an acceptable
+                syntax does not imply that the other syntax is also acceptable.
             </t>
         </section>
 


### PR DESCRIPTION
This addresses the source of a moderately absurd grammatical argument that @epoberezkin and I had in #115.  I took @epoberezkin interpretation and made it explicit in the specification language and gave it a section to clarify it.  Writing the hyper-schema spec with Relative JSON Pointer, it seemed more useful to be able to indicate each syntax separately.  So while I did not originally read it this way, I think @epoberezkin interpretation is the more helpful one.

Also fix a typo and add a change log.
