### PR TITLE
Clarify data model vs unicode characters

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -188,7 +188,13 @@
                         </list>
                     </t>
                     <t>
-                        Whitespace and formatting concerns are thus outside the scope of JSON Schema.
+                        Whitespace and formatting concerns, including different lexical
+                        representations of numbers that are equal within the data model, are thus
+                        outside the scope of JSON Schema.  JSON Schema vocabularies that wish
+                        to work with such differences in lexical representations SHOULD define
+                        keywords to precisely interpret formatted strings within the data model
+                        rather than relying on having the original JSON representation Unicode
+                        characters available.
                     </t>
                     <t>
                         Since an object cannot have two properties with the same key, behavior for a


### PR DESCRIPTION
This addresses #221.

JSON Schema does not care about unicode characters, only the
data model.  Vocabularies SHOULD account for this by working
with data model strings instead of the original unicode
representation of numbers.

For example, define a value for the "format" validation keyword
that indicates that a string should be interpreted as a fixed-point
decimal if you wish to retain precision information in your data.