### PR TITLE
Add "examples" to the draft-06 meta-schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -57,6 +57,10 @@
             "type": "string"
         },
         "default": {},
+        "examples": {
+            "type": "array",
+            "items": {}
+        },
         "multipleOf": {
             "type": "number",
             "exclusiveMinimum": 0


### PR DESCRIPTION
"examples" is described in the draft-06 spec, but is not defined in the meta-schema.