### PR TITLE
Numerous improvements to security considerations

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2384,7 +2384,10 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         <section title="Security Considerations" anchor="security">
             <t>
                 JSON Hyper-Schema defines a vocabulary for JSON Schema core and concerns all
-                the security considerations listed there.
+                the security considerations listed there.  As a link serialization format,
+                the security considerations of <xref target="RFC8288">RFC 8288 Web Linking</xref>
+                also apply, with appropriate adjustments (e.g. "anchor" as an LDO keyword rather
+                than an HTTP Link header attribute).
             </t>
             <section title='"self" Links'>
                 <t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2394,7 +2394,18 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     As stated in <xref target="targetAttributes"/>, all LDO keywords describing
                     the target resource are advisory and MUST NOT be used in place of
                     the authoritative information supplied by the target resource in response
-                    to an operation.
+                    to an operation.  Target resource responses SHOULD indicate their own
+                    hyper-schema, which is authoritative.
+                </t>
+                <t>
+                    If the hyper-schema in the target response matches (by "$id") the hyper-schema
+                    in which the current LDO was found, then the target attributes MAY be
+                    considered authoritative.
+                    <cref>
+                        Need to add something about the risks of spoofing by "$id", but given
+                        that other parts of the specification discourage always re-downloading
+                        the linked schema, the risk mitigation options are unclear.
+                    </cref>
                 </t>
                 <t>
                     Clients MUST NOT use the value of "targetSchema" to aid in the interpretation

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2382,7 +2382,10 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         </section>
 
         <section title="Security Considerations" anchor="security">
-            <t><cref>Need to reference the core and validation security considerations.</cref></t>
+            <t>
+                JSON Hyper-Schema defines a vocabulary for JSON Schema core and concerns all
+                the security considerations listed there.
+            </t>
             <section title='"self" Links'>
                 <t>
                     When link relation of "self" is used to denote a full representation of an
@@ -2391,6 +2394,11 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     the target URI is not equivalent to or a sub-path of the URI used to request
                     the resource representation which contains the target URI with the "self"
                     link.
+                    <cref>
+                        It is no longer clear what was intended by the "sub-path" option in
+                        this paragraph.  While paths are defined as a hierarchical system
+                        by RFC 3986, there semantics of the hierarchy are not defined.
+                    </cref>
                 </t>
             </section>
             <section title="Target Attributes">

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -563,7 +563,7 @@
                 </section>
             </section>
 
-            <section title="Link Target Attributes">
+            <section title="Link Target Attributes" anchor="targetAttributes">
                 <t>
                     All properties in this section are advisory only.  While keywords such
                     as "title" and "description" are used primarily to present the link
@@ -2403,15 +2403,15 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             </section>
             <section title="Target Attributes">
                 <t>
-                    <cref>
-                        This whole section needs more work, but I do like having security
-                        concerns around target interactions consolidated and addressed as a whole.
-                    </cref>
+                    As stated in <xref target="targetAttributes"/>, all LDO keywords describing
+                    the target resource are advisory and MUST NOT be used in place of
+                    the authoritative information supplied by the target resource in response
+                    to an operation.
                 </t>
                 <t>
-                    The "targetMediaType" property in link definitions defines the expected
-                    format of the link's target.
-                    However, this is advisory only, and MUST NOT be considered authoritative.
+                    Clients MUST NOT use the value of "targetSchema" to aid in the interpretation
+                    of the data received in response to following the link, as this leaves
+                    "safe" data open to re-interpretation.
                 </t>
                 <t>
                     When choosing how to interpret data, the type information provided by the
@@ -2429,11 +2429,14 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     precautions for "targetSchema".
                 </t>
                 <t>
-                    The "targetSchema" keyword has similar security concerns to that of
-                    "targetMediaType".
-                    Clients MUST NOT use the value of this property to aid in the interpretation
-                    of the data received in response to following the link, as this leaves
-                    "safe" data open to re-interpretation.
+                    Protocol meta-data values conveyed in "targetHints" MUST NOT be considered
+                    authoritative.  Any security considerations defined by the protocol that
+                    may apply based on incorrect assumptions about meta-data values apply.
+                </t>
+                <t>
+                    Even when no protocol security considerations are directly applicable,
+                    implementations MUST be prepared to handle responses that do not
+                    match the link's "targetHints" values.
                 </t>
             </section>
         </section>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2389,21 +2389,6 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                 also apply, with appropriate adjustments (e.g. "anchor" as an LDO keyword rather
                 than an HTTP Link header attribute).
             </t>
-            <section title='"self" Links'>
-                <t>
-                    When link relation of "self" is used to denote a full representation of an
-                    object, the user agent SHOULD NOT consider the representation to be the
-                    authoritative representation of the resource denoted by the target URI if
-                    the target URI is not equivalent to or a sub-path of the URI used to request
-                    the resource representation which contains the target URI with the "self"
-                    link.
-                    <cref>
-                        It is no longer clear what was intended by the "sub-path" option in
-                        this paragraph.  While paths are defined as a hierarchical system
-                        by RFC 3986, there semantics of the hierarchy are not defined.
-                    </cref>
-                </t>
-            </section>
             <section title="Target Attributes">
                 <t>
                     As stated in <xref target="targetAttributes"/>, all LDO keywords describing
@@ -2440,6 +2425,21 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     Even when no protocol security considerations are directly applicable,
                     implementations MUST be prepared to handle responses that do not
                     match the link's "targetHints" values.
+                </t>
+            </section>
+            <section title='"self" Links'>
+                <t>
+                    When link relation of "self" is used to denote a full representation of an
+                    object, the user agent SHOULD NOT consider the representation to be the
+                    authoritative representation of the resource denoted by the target URI if
+                    the target URI is not equivalent to or a sub-path of the URI used to request
+                    the resource representation which contains the target URI with the "self"
+                    link.
+                    <cref>
+                        It is no longer clear what was intended by the "sub-path" option in
+                        this paragraph.  While paths are defined as a hierarchical system
+                        by RFC 3986, there semantics of the hierarchy are not defined.
+                    </cref>
                 </t>
             </section>
         </section>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -9,6 +9,7 @@
 <!ENTITY RFC3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY RFC3987 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3987.xml">
 <!ENTITY RFC4291 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4291.xml">
+<!ENTITY RFC4329 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4329.xml">
 <!ENTITY RFC5322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5322.xml">
 <!ENTITY RFC5890 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5890.xml">
 <!ENTITY RFC5891 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5891.xml">
@@ -1351,6 +1352,20 @@
                 (with so-called "catastrophic backtracking"), resulting in a denial-of-service
                 attack.
             </t>
+            <t>
+                Implementations that support validating or otherwise evaluating instance
+                string data based on "contentEncoding" and/or "contentMediaType" are at
+                risk of evaluating data in an unsafe way based on misleading information.
+                Applications can mitigate this risk by only performing such processing
+                when a relationship between the schema and instance is established
+                (e.g., they share the same authority).
+            </t>
+            <t>
+                Processing a media type or encoding is subject to the security considerations
+                of that media type or encoding.  For example, the security considerations
+                of <xref target="RFC4329">RFC 4329 Scripting Media Types</xref> apply when
+                processing JavaScript or ECMAScript encoded within a JSON string.
+            </t>
         </section>
 
         <!--
@@ -1385,6 +1400,7 @@
             &RFC3986;
             &RFC3987;
             &RFC4291;
+            &RFC4329;
             &RFC5890;
             &RFC5891;
             &RFC6570;


### PR DESCRIPTION
This is probably about as much as we'll do for draft-07.  We'll keep working on the security sections as the drafts progress, but this is at least as good as it has been for the last few drafts.

Addresses #456 plus various things not filed as issues.

Commit log:
```
|     Security considerations for "content*"
|     
|     a.k.a. don't take executable content types from strangers
|  
* commit 58c6b96cb13d5a593209154cc854067c3bf0e954
| Author: Henry Andrews <henry@cloudflare.com>
| Date:   Tue Nov 14 12:44:59 2017 -0800
| 
|     Add a bit more about target attribute authority
|     
|     While "targetSchema" is technically never required to process
|     a response, as the response should indicate its own schema,
|     other target attributes in the LDO, such as the submission schema,
|     cannot be conveyed in any way other than through the LDO.
|     
|     It would seem like we need a provision for determining when the
|     LDO can be constructed, but it's not entirely clear how that
|     should work.  Put in a bit about it and a CREF to hopefully
|     attract the attention of someone who can improve the section.
|  
* commit b49541da81be4302f20d3f824ce50e8f6787c225
| Author: Henry Andrews <henry@cloudflare.com>
| Date:   Mon Nov 13 22:06:33 2017 -0800
| 
|     Move "self" link security bit to last subsection
|     
|     The other parts flow much more naturally from the mention of
|     RFC 8288 in the introductory part of the security section.
|  
* commit d7254824f8188a7e8ad8e441ead4f4eeb641d597
| Author: Henry Andrews <henry@cloudflare.com>
| Date:   Mon Nov 13 22:03:19 2017 -0800
| 
|     Reference RFC 8288 in Security Considerations
|     
|     8288 is the update of 5988 Web Linking.  As a link serialization
|     format, Hyper-Schema shares those vulnerabilities.
|  
* commit 11de781a2b863e36463b242c36e4f526db819a2f
| Author: Henry Andrews <henry@cloudflare.com>
| Date:   Mon Nov 13 16:26:23 2017 -0800
| 
|     Clean up target attribute security considerations
|     
|     This was an awkward copy-paste.  Fix it up and remove the CREF
|     reminding me to do so.
|  
* commit 379285ab5e3ef1c3a8f0b0033b8759c57740ea8b
| Author: Henry Andrews <henry@cloudflare.com>
| Date:   Mon Nov 13 16:08:47 2017 -0800
| 
|     Add CREF for "self" link sub-path
|     
|     Since I have no idea what it is trying to do.
```

See also #485 about possibly removing the "self" link bit.