### PR TITLE
"client-side user agent" is wrong, plus various formatting fixes

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -169,7 +169,7 @@
                     A JSON document to which a schema is applied is known as an "instance".
                 </t>
 
-                <section title="Instance data model">
+                <section title="Instance Data Model">
                     <t>
                         JSON Schema interprets documents according to a data model. A JSON value
                         interpreted according to this data model is called an "instance".
@@ -211,7 +211,7 @@
                     </t>
                 </section>
 
-                <section title="Instance media types">
+                <section title="Instance Media Types">
                     <t>
                         JSON Schema is designed to fully work with "application/json" documents,
                         as well as media types using the "+json" structured syntax suffix.
@@ -230,7 +230,7 @@
                     </t>
                 </section>
 
-                <section title="Instance equality">
+                <section title="Instance Equality">
                     <t>
                         Two JSON instances are said to be equal if and only if they are of the same type
                         and have the same value according to the data model. Specifically, this means:
@@ -258,7 +258,7 @@
                 </section>
             </section>
 
-            <section title="JSON Schema documents">
+            <section title="JSON Schema Documents">
                 <t>
                     A JSON Schema document, or simply a schema, is a JSON document used to describe
                     an instance.
@@ -269,7 +269,7 @@
                     fragment identifier syntax and semantics provided by
                     "application/schema-instance+json".
                 </t>
-                <section title="JSON Schema values and keywords">
+                <section title="JSON Schema Values and Keywords">
                     <t>
                         A JSON Schema MUST be an object or a boolean.
                     </t>
@@ -314,7 +314,7 @@
                         properties.
                     </t>
                 </section>
-                <section title="JSON Schema vocabularies" anchor="vocabulary">
+                <section title="JSON Schema Vocabularies" anchor="vocabulary">
                     <t>
                         A JSON Schema vocabulary is a set of keywords defined for a particular
                         purpose.  The vocabulary specifies the meaning of its keywords as
@@ -354,7 +354,7 @@
                         </cref>
                     </t>
                 </section>
-                <section title="Root schema and subschemas">
+                <section title="Root Schema and Subschemas">
                     <t>
                         The root schema is the schema that comprises the entire JSON document
                         in question.
@@ -386,7 +386,7 @@
 
         </section>
 
-        <section title="Fragment identifiers" anchor="fragments">
+        <section title="Fragment Identifiers" anchor="fragments">
             <t>
                 In accordance with section 3.1 of <xref target="RFC6839"></xref>,
                 the syntax and semantics of fragment identifiers specified for
@@ -424,9 +424,9 @@
             </t>
         </section>
 
-        <section title="General considerations">
+        <section title="General Considerations">
 
-            <section title="Range of JSON values">
+            <section title="Range of JSON Values">
                 <t>
                     An instance may be any valid JSON value as defined by <xref target="RFC7159">JSON</xref>.
                     JSON Schema imposes no restrictions on type: JSON Schema can describe any JSON
@@ -434,7 +434,7 @@
                 </t>
             </section>
 
-            <section title="Programming language independence" anchor="language">
+            <section title="Programming Language Independence" anchor="language">
                 <t>
                     JSON Schema is programming language agnostic, and supports the full range of
                     values described in the data model.
@@ -443,7 +443,7 @@
                 </t>
             </section>
 
-            <section title="Mathematical integers" anchor="integers">
+            <section title="Mathematical Integers" anchor="integers">
                 <t>
                     Some programming languages and parsers use different internal representations
                     for floating point numbers than they do for integers.
@@ -476,7 +476,7 @@
 
         </section>
 
-        <section title='The "$schema" keyword'>
+        <section title='The "$schema" Keyword'>
             <!-- TODO a custom $schema keyword might also be used to enforce minimum required functionality of a validator -->
             <t>
                 The "$schema" keyword is both used as a JSON Schema version identifier and the
@@ -521,7 +521,7 @@
             </t>
         </section>
 
-        <section title='Schema references with "$ref"'>
+        <section title='Schema References With "$ref"'>
             <t>
                 The "$ref" keyword is used to reference a schema, and provides the ability to
                 validate recursive structures through self-reference.
@@ -548,8 +548,8 @@
             </t>
         </section>
 
-        <section title="Base URI and dereferencing">
-            <section title="Initial base URI">
+        <section title="Base URI and Dereferencing">
+            <section title="Initial Base URI">
                 <t>
                     <xref target="RFC3986">RFC3986 Section 5.1</xref> defines how to determine the
                     default base URI of a document.
@@ -560,7 +560,7 @@
                 </t>
             </section>
 
-            <section title='The "$id" keyword' anchor="id-keyword">
+            <section title='The "$id" Keyword' anchor="id-keyword">
                 <t>
                     The "$id" keyword defines a URI for the schema, and the base URI that
                     other URI references within the schema are resolved against.
@@ -646,7 +646,7 @@
                         <t hangText="#/definitions/C">urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f</t>
                     </list>
                 </t>
-                <section title="Internal references">
+                <section title="Internal References">
                     <t>
                         Schemas can be identified by any URI that has been given to them, including
                         a JSON Pointer or their URI given directly by "$id".
@@ -692,7 +692,7 @@
                         resolve the fragment against the base URI.
                     </t>
                 </section>
-                <section title="External references">
+                <section title="External References">
                     <t>
                         To differentiate schemas between each other in a vast ecosystem, schemas are
                         identified by URI. As specified above, this does not necessarily mean
@@ -714,7 +714,7 @@
             </section>
         </section>
 
-        <section title='Comments with "$comment"'>
+        <section title='Comments With "$comment"'>
             <t>
                 This keyword is reserved for comments from schema authors to readers or
                 maintainers of the schema.
@@ -746,7 +746,7 @@
             </t>
         </section>
 
-        <section title="Usage for hypermedia">
+        <section title="Usage for Hypermedia">
 
             <t>
                 JSON has been adopted widely by HTTP servers for automated APIs and robots. This
@@ -755,7 +755,7 @@
                 <xref target="RFC8288">Web linking</xref>.
             </t>
 
-            <section title='Linking to a schema'>
+            <section title='Linking to a Schema'>
                 <t>
                     It is RECOMMENDED that instances described by a schema provide a link to
                     a downloadable JSON Schema using the link relation "describedby", as defined by
@@ -778,7 +778,7 @@ Link: <http://example.com/my-hyper-schema#>; rel="describedby"
             </section>
 
 
-            <section title='Identifying a schema via a media type parameter' anchor="parameter">
+            <section title='Identifying a Schema via a Media Type Parameter' anchor="parameter">
                 <t>
                     Media types MAY allow for a "schema" media type parameter, which gives
                     HTTP servers the ability to perform Content-Type Negotiation based on schema.
@@ -847,7 +847,7 @@ Link: </alice>;rel="schema", </bob>;rel="schema"
 
             </section>
 
-             <section title="Usage over HTTP">
+             <section title="Usage Over HTTP">
                 <t>
                     When used for hypermedia systems over a network,
                     <xref target="RFC7231">HTTP</xref> is frequently the protocol of choice for
@@ -883,7 +883,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
 
        </section>
 
-        <section title="Security considerations" anchor="security">
+        <section title="Security Considerations" anchor="security">
             <t>
                 Both schemas and instances are JSON values. As such, all security considerations
                 defined in <xref target="RFC7159">RFC 7159</xref> apply.

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2506,7 +2506,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             </section>
         </section>
 
-        <section title="Change Log">
+        <section title="ChangeLog">
             <t>
                 <cref>This section to be removed before leaving Internet-Draft status.</cref>
             </t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -249,7 +249,7 @@
             </section>
         </section>
 
-        <section title="Meta-schemas and output schema">
+        <section title="Meta-Schemas and Output Schema">
             <t>
                 <cref>The "draft-07-wip" is a placeholder.</cref>
             </t>
@@ -282,7 +282,7 @@
                 (draft-07 work-in-progress version).
             </t>
         </section>
-        <section title="Schema keywords">
+        <section title="Schema Keywords">
             <t>
                 Hyper-schema keywords from all schemas that are applicable to a position
                 in an instance, as defined by <xref target="json-schema-validation">Section
@@ -353,7 +353,7 @@
                 usage explanation and comprehensive examples given later in the document.
             </t>
 
-            <section title="Link context" anchor="context">
+            <section title="Link Context" anchor="context">
                 <t>
                     In JSON Hyper-Schema, the link's context resource is, by default, the
                     sub-instance to which it is attached (as defined by
@@ -420,7 +420,7 @@
                     </t>
                 </section>
             </section>
-            <section title="Link relation type" anchor="relationType">
+            <section title="Link Relation Type" anchor="relationType">
                 <t>
                     The link's relation type identifies its semantics.  It is the primary
                     means of conveying how an application can interact with a resource.
@@ -439,7 +439,7 @@
                         This property is required.
                     </t>
                 </section>
-                <section title='"self" links' anchor="self">
+                <section title='"self" Links' anchor="self">
                     <t>
                         A hyper-schema implementation MUST recognize that a link with relation
                         type "self" that is applicable to the entire instance document describes
@@ -452,7 +452,7 @@
                         "self" link has all instance data that is needed for use.
                     </t>
                 </section>
-                <section title='"collection" and "item" links' anchor="collectionAndItem">
+                <section title='"collection" and "item" Links' anchor="collectionAndItem">
                     <t>
                         <xref target="RFC6573">RFC 6573</xref> defines and registers
                         the "item" and "collection" link relation types.  JSON Hyper-Schema imposes
@@ -482,7 +482,7 @@
                         resource.
                     </t>
                 </section>
-                <section title="Using extension relation types" anchor="extensionRelationTypes">
+                <section title="Using Extension Relation Types" anchor="extensionRelationTypes">
                     <t>
                         When no registered relation (aside from "related") applies, users are
                         encouraged to mint their own extension relation types, as described in
@@ -498,7 +498,7 @@
                     </t>
                 </section>
             </section>
-            <section title="Link target" anchor="target">
+            <section title="Link Target" anchor="target">
                 <t>
                     The target URI template is used to identify the link's target, potentially
                     making use of instance data.  Additionally, with
@@ -522,7 +522,7 @@
                 </section>
             </section>
 
-            <section title="Adjusting URI Template resolution">
+            <section title="Adjusting URI Template Resolution">
                 <t>
                     The keywords in this section are used when resolving all URI Templates
                     involved in hyper-schema: "base", "anchor", and "href".  See the
@@ -563,7 +563,7 @@
                 </section>
             </section>
 
-            <section title="Link target attributes">
+            <section title="Link Target Attributes">
                 <t>
                     All properties in this section are advisory only.  While keywords such
                     as "title" and "description" are used primarily to present the link
@@ -695,7 +695,7 @@
                     </t>
                 </section>
             </section>
-            <section title="Link input" anchor="input">
+            <section title="Link Input" anchor="input">
                 <t>
                     There are four ways to use client-supplied data with a link, and each
                     is addressed by a separate link description object keyword.  When performing
@@ -783,7 +783,7 @@
                     </t>
                 </section>
 
-                <section title="Manipulating the target resource representation">
+                <section title="Manipulating the Target Resource Representation">
                     <t>
                         In JSON Hyper-Schema, <xref target="targetSchema">"targetSchema"</xref>
                         supplies a non-authoritative description of the target resource's
@@ -806,7 +806,7 @@
                     </t>
                 </section>
 
-                <section title="Submitting data for processing">
+                <section title="Submitting Data for Processing">
                     <t>
                         The <xref target="submissionSchema">"submissionSchema"</xref> and
                         <xref target="submissionMediaType">"submissionMediaType"</xref> keywords
@@ -858,7 +858,7 @@
             </section>
         </section>
 
-        <section title="Implementation requirements" anchor="implementation">
+        <section title="Implementation Requirements" anchor="implementation">
             <t>
                 At a high level, a conforming implementation will meet the following
                 requirements.  Each of these requirements is covered in more detail in the
@@ -921,7 +921,7 @@
                 Those fields will not be further discussed here unless specifically relevant.
             </t>
 
-            <section title="Link discovery and look-up">
+            <section title="Link Discovery and Look-Up">
                 <t>
                     Before links can be used, they must be discovered by applying the hyper-schema
                     to the instance and finding all applicable and valid links.  Note that in
@@ -1018,7 +1018,7 @@ R = rfc6570ResolutionAlgorithm(T, templateData)
                     </artwork>
                 </figure>
 
-                <section title="Populating template data from the instance">
+                <section title="Populating Template Data From the Instance">
                     <t>
                         This step looks at various locations in the instance for variable values.
                         For each variable:
@@ -1058,7 +1058,7 @@ for varname in T:
                     </figure>
                 </section>
 
-                <section title="Accepting input for template data">
+                <section title="Accepting Input for Template Data">
                     <t>
                         This step is relatively complex, as there are several cases to support.
                         Some variables will forbid input and some will allow it.  Some will
@@ -1128,7 +1128,7 @@ return inputData:
                     </figure>
                 </section>
 
-                <section title="Encoding data as strings">
+                <section title="Encoding Data as Strings">
                     <t>
                         This section is straightforward, converting literals to their names
                         as strings, and converting numbers to strings in the most obvious manner,
@@ -1165,7 +1165,7 @@ for varname in templateData:
                 </section>
             </section>
 
-            <section title="Providing access to LDO keywords">
+            <section title="Providing Access to LDO Keywords">
                 <t>
                     For a given link, an implementation MUST make the values of all
                     target attribute keywords directly available to the user agent.
@@ -1266,7 +1266,7 @@ for varname in templateData:
                 </t>
             </section>
 
-            <section title="Streaming parsers" anchor="streaming">
+            <section title="Streaming Parsers" anchor="streaming">
                 <t>
                     The requirements around discovering links based on their context, or
                     using the context of links to identify collections, present unique
@@ -1305,7 +1305,7 @@ for varname in templateData:
                 the techniques outlined in the core specification be used to whatever extent
                 is possible.
             </t>
-            <section title="One link per target and relation type">
+            <section title="One Link Per Target and Relation Type">
                 <t>
                     Link Description Objects do not directly indicate what operations, such
                     as HTTP methods, are supported by the target resource.  Instead, operations
@@ -1397,7 +1397,7 @@ for varname in templateData:
                     the scope of JSON Hyper-Schema.
                 </t>
             </section>
-            <section title='Optimizing HTTP discoverability with "targetHints"'>
+            <section title='Optimizing HTTP Discoverability With "targetHints"'>
                 <t>
                     <cref>It would be good to also include a section with CoAP examples.</cref>
                 </t>
@@ -1428,7 +1428,7 @@ for varname in templateData:
                     times SHOULD NOT be included in "targetHints".
                 </t>
             </section>
-            <section title='Advertising HTTP features with "headerSchema"'>
+            <section title='Advertising HTTP Features With "headerSchema"'>
                 <t>
                     Schemas SHOULD be written to describe JSON serializations that
                     follow guidelines established by the work in progress
@@ -1454,7 +1454,7 @@ for varname in templateData:
                     such headers and related responses is not resource-specific.
                 </t>
             </section>
-            <section title="Creating resources through collections">
+            <section title="Creating Resources Through Collections">
                 <t>
                     When using HTTP, or a protocol such as CoAP that is explicitly analogous
                     to HTTP, this is done by POST-ing a representation of the individual
@@ -1463,7 +1463,7 @@ for varname in templateData:
                     <xref target="collectionAndItem" />.
                 </t>
             </section>
-            <section title="Content negotiation and schema evolution">
+            <section title="Content Negotiation and Schema Evolution">
                 <t>
                     JSON Hyper-Schema facilitates HTTP content negotiation, and allows for
                     a hybrid of the proactive and reactive strategies.  As mentioned
@@ -1505,7 +1505,7 @@ for varname in templateData:
                 in <xref target="HTTP">an Appendix</xref>.
             </t>
 
-            <section title="Entry point links, no templates">
+            <section title="Entry Point Links, No Templates">
                 <t>
                     For this example, we will assume an example API with a documented
                     entry point URI of https://example.com, which is an empty JSON object
@@ -1582,7 +1582,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                     context.  Its default behavior is to be the same as the attachment pointer.
                 </t>
             </section>
-            <section title="Individually identified resources">
+            <section title="Individually Identified Resources">
                 <t>
                     Let's add "things" to our system, starting with an individual thing:
                 </t>
@@ -1662,7 +1662,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                     is the only possible source for resolving this link.
                 </t>
             </section>
-            <section title="Submitting a payload and accepting URI input" anchor="mailto">
+            <section title="Submitting a Payload and Accepting URI Input" anchor="mailto">
                 <t>
                     This example covers using the "submission" fields for non-representation
                     input, as well as using them alongside of resolving the URI Template with
@@ -1836,7 +1836,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                     </list>
                 </t>
             </section>
-            <section title='"anchor", "base" and URI Template resolution'>
+            <section title='"anchor", "base" and URI Template Resolution'>
                 <t>
                     A link is a typed connection from a context resource to a target resource.
                     Older link serializations support a "rev" keyword that takes a link relation
@@ -2310,7 +2310,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
 
         <section title="Security Considerations" anchor="security">
             <t><cref>Need to reference the core and validation security considerations.</cref></t>
-            <section title='"self" links'>
+            <section title='"self" Links'>
                 <t>
                     When link relation of "self" is used to denote a full representation of an
                     object, the user agent SHOULD NOT consider the representation to be the
@@ -2320,7 +2320,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     link.
                 </t>
             </section>
-            <section title="Target attributes">
+            <section title="Target Attributes">
                 <t>
                     <cref>
                         This whole section needs more work, but I do like having security
@@ -2455,7 +2455,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                 link scope, and such descriptions are outside of the boundaries
                 of JSON Hyper-Schema.
             </t>
-            <section title="Resource evolution with Hyper-Schema">
+            <section title="Resource Evolution With Hyper-Schema">
                 <t>
                     Since a given JSON Hyper-Schema is used with a single resource at a single
                     point in time, it has no inherent notion of versioning.  However, a given
@@ -2471,7 +2471,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     or older versions.
                 </t>
             </section>
-            <section title="Responses and errors" anchor="responses">
+            <section title="Responses and Errors" anchor="responses">
                 <t>
                     Because a hyper-schema represents a single resource at a time, it does not
                     provide for an enumeration of all possible responses to protocol operations
@@ -2483,7 +2483,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     information that is provided beyond the protocol's own status reporting.
                 </t>
             </section>
-            <section title="Static analysis of an API's hyper-schemas" anchor="staticAnalysis">
+            <section title="Static Analysis of an API's Hyper-Schemas" anchor="staticAnalysis">
                 <t>
                     It is possible to statically analyze a set of hyper-schemas without instance
                     data in order to generate output such as documentation or code.  However,

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -131,7 +131,7 @@
                 for hyper-schema-aware applications and user agents.
             </t>
             <t>
-                Client-side user agents can detect the presence of hyper-schema by looking for
+                User agents can detect the presence of hyper-schema by looking for
                 the application/schema+json media type and a "$schema" value that indicates the
                 presence of the hyper-schema vocabulary.  A user agent can then use an
                 implementation of JSON Hyper-Schema to provide an interface to the

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -158,7 +158,7 @@
                     the other keywords require that all subschemas are valid against all child
                     instances to which they apply.
                 </t>
-                <section title="Keyword independence">
+                <section title="Keyword Independence">
                     <t>
                         Validation keywords typically operate independently, without
                         affecting each other's outcomes.
@@ -201,7 +201,7 @@
                     of this specification, and the keywords convey additional non-assertion
                     information.
                 </t>
-                <section title="Assertions and instance primitive types">
+                <section title="Assertions and Instance Primitive Types">
                     <t>
                         Most validation assertions only constrain values within a certain
                         primitive type.  When the type of the instance is not of the type
@@ -235,7 +235,7 @@
                     Additional vocabularies SHOULD make use of this mechanism for applying
                     their own annotations to instances.
                 </t>
-                <section title="Negated schemas">
+                <section title="Negated Schemas">
                     <t>
                         Annotations in a subschema contained within a "not", at any depth,
                         including any number of intervening additional "not" subschemas, MUST be
@@ -243,7 +243,7 @@
                         "anyOf", "then", or "else" MUST be ignored.
                     </t>
                 </section>
-                <section title="Annotations and short-circuit validation">
+                <section title="Annotations and Short-Circuit Validation">
                     <t>
                         Annotation keywords MUST be applied to all possible sub-instances.
                         even if such application can be short-circuited when only assertion
@@ -257,9 +257,9 @@
             </section>
         </section>
 
-        <section title="Interoperability considerations">
+        <section title="Interoperability Considerations">
 
-            <section title="Validation of string instances">
+            <section title="Validation of String Instances">
                 <t>
                     It should be noted that the nul character (\u0000) is valid in a JSON string. An
                     instance to validate may contain a string value with this character, regardless
@@ -267,7 +267,7 @@
                 </t>
             </section>
 
-            <section title="Validation of numeric instances">
+            <section title="Validation of Numeric Instances">
                 <t>
                     The JSON specification allows numbers with arbitrary precision, and JSON Schema
                     does not add any such bounds.
@@ -277,7 +277,7 @@
                 </t>
             </section>
 
-            <section title="Regular expressions" anchor="regexInterop">
+            <section title="Regular Expressions" anchor="regexInterop">
                 <t>
                     Two validation keywords, "pattern" and "patternProperties", use regular
                     expressions to express constraints, and the "regex" value for the
@@ -313,20 +313,20 @@
 
         </section>
 
-        <section title="Meta-schema">
+        <section title="Meta-Schema">
             <t>
                 The current URI for the JSON Schema Validation is
                 &lt;http://json-schema.org/draft-06/schema#&gt;.
             </t>
         </section>
 
-        <section title="Validation keywords">
+        <section title="Validation Keywords">
             <t>
                 Validation keywords in a schema impose requirements for successful validation of an
                 instance.
             </t>
 
-            <section title="Validation keywords for any instance type" anchor="general">
+            <section title="Validation Keywords for Any Instance Type" anchor="general">
                 <section title="type">
                     <t>
                         The value of this keyword MUST be either a string or an array. If it is
@@ -368,7 +368,7 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for numeric instances (number and integer)"
+            <section title="Validation Keywords for Numeric Instances (number and integer)"
                      anchor="numeric">
                 <section title="multipleOf">
                     <t>
@@ -425,7 +425,7 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for strings" anchor="string">
+            <section title="Validation Keywords for Strings" anchor="string">
                 <section title="maxLength">
                     <t>
                         The value of this keyword MUST be a non-negative integer.</t>
@@ -471,7 +471,7 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for arrays">
+            <section title="Validation Keywords for Arrays">
                 <section title="items">
                     <t>
                         The value of "items" MUST be either a valid JSON Schema or an array of valid
@@ -566,7 +566,7 @@
                 </section>
             </section>
 
-            <section title="Validation keywords for objects">
+            <section title="Validation Keywords for Objects">
                 <section title="maxProperties">
                     <t>
                         The value of this keyword MUST be a non-negative integer.
@@ -723,7 +723,7 @@
                 </section>
             </section>
 
-            <section title="Keywords for applying subschemas conditionally" anchor="conditional">
+            <section title="Keywords for Applying Subschemas Conditionally" anchor="conditional">
                 <t>
                     These keywords work together to implement conditional
                     application of a subschema based on the outcome of
@@ -795,7 +795,7 @@
                 </section>
             </section>
 
-            <section title="Keywords for applying subschemas with boolean logic" anchor="logic">
+            <section title="Keywords for Applying Subschemas With Boolean Logic" anchor="logic">
                 <section title="allOf">
                     <t>
                         This keyword's value MUST be a non-empty array.
@@ -841,7 +841,7 @@
             </section>
         </section>
 
-        <section title='Semantic validation with "format"' anchor="format">
+        <section title='Semantic Validation With "format"' anchor="format">
 
             <section title="Foreword">
                 <t>
@@ -861,7 +861,7 @@
 
             </section>
 
-            <section title="Implementation requirements">
+            <section title="Implementation Requirements">
                 <t>
                     The "format" keyword functions as both an annotation
                     (<xref target="annotations" />) and as an assertion
@@ -887,9 +887,9 @@
                 </t>
             </section>
 
-            <section title="Defined formats">
+            <section title="Defined Formats">
 
-                <section title="Dates and times">
+                <section title="Dates and Times">
                     <t>
                         These attributes apply to string instances.
                     </t>
@@ -934,7 +934,7 @@
                     </t>
                 </section>
 
-                <section title="Email addresses">
+                <section title="Email Addresses">
                     <t>
                         These attributes apply to string instances.
                     </t>
@@ -977,7 +977,7 @@
                     </t>
                 </section>
 
-                <section title="IP addresses">
+                <section title="IP Addresses">
                     <t>
                         These attributes apply to string instances.
                     </t>
@@ -998,7 +998,7 @@
                     </t>
                 </section>
 
-                <section title="Resource identifiers">
+                <section title="Resource Identifiers">
                     <t>
                         These attributes apply to string instances.
                     </t>
@@ -1079,7 +1079,7 @@
             </section>
         </section>
 
-        <section title='String-encoding non-JSON data' anchor="content">
+        <section title='String-Encoding Non-JSON Data' anchor="content">
 
             <section title="Foreword">
                 <t>
@@ -1093,7 +1093,7 @@
                 </t>
             </section>
 
-            <section title="Implementation requirements">
+            <section title="Implementation Requirements">
                 <t>
                     The content keywords function as both annotations
                     (<xref target="annotations" />) and as assertions
@@ -1198,7 +1198,7 @@
 
         </section>
 
-        <section title='Schema re-use with "definitions"'>
+        <section title='Schema Re-Use With "definitions"'>
             <t>
                 The "definitions" keywords provides a standardized location for schema
                 authors to inline re-usable JSON Schemas into a more general schema.
@@ -1232,7 +1232,7 @@
             </t>
         </section>
 
-        <section title="Schema annotations">
+        <section title="Schema Annotations">
             <t>
                 Schema validation is a useful mechanism for annotating instance data
                 with additional information.  The rules for determining when and how
@@ -1337,7 +1337,7 @@
             </section>
         </section>
 
-        <section title="Security considerations">
+        <section title="Security Considerations">
             <t>
                 JSON Schema validation defines a vocabulary for JSON Schema core and concerns all
                 the security considerations listed there.


### PR DESCRIPTION
A few trivial changes.  Mostly title style changes based on [RFC 7322 RFC Style Guide](https://tools.ietf.org/html/rfc7322), which was not published when the bulk of these documents were written.  See individual commits for more.