### PR TITLE
Typo fixes

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -220,7 +220,7 @@
                         Some functionality that is useful for working with schemas is
                         defined by each media type, namely media type parameters and
                         URI fragment identifier syntax and semantics.  These features are
-                        useful in content negotiation and in caclulating URIs for specific
+                        useful in content negotiation and in calculating URIs for specific
                         locations within an instance, respectively.
                     </t>
                     <t>
@@ -468,7 +468,7 @@
                     allow tools to follow the correct behaviour.
                 </t>
                 <t>
-                    Note that the recursive nature of meta-schemas requires re-definining
+                    Note that the recursive nature of meta-schemas requires re-defining
                     recursive keywords in the extended meta-schema, as can be seen in
                     the JSON Hyper-Schema meta-schema.
                 </t>
@@ -581,7 +581,7 @@
                     have one that is an empty string.
                     <!-- All of the standard meta-schemas use an empty fragment in their id/$id values. -->
                     <cref>
-                        How should an "$id" URI reference containing a fragement with other components
+                        How should an "$id" URI reference containing a fragment with other components
                         be interpreted?  There are two cases:  when the other components match
                         the current base URI and when they change the base URI.
                     </cref>
@@ -909,7 +909,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                 fail to strip them if such behavior is expected.
             </t>
             <t>
-                A malicous schema author could place executable code or other dangerous
+                A malicious schema author could place executable code or other dangerous
                 material within a "$comment".  Implementations MUST NOT parse or otherwise
                 take action based on "$comment" contents.
             </t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -368,7 +368,7 @@
                     application/json does not define a URI fragment resolution syntax, so
                     properties or array elements within a plain JSON document cannot be fully
                     identified by a URI.  When it is not possible to produce a complete URI,
-                    the position of the context SHOULD be conveyed by a the URI of the instance
+                    the position of the context SHOULD be conveyed by the URI of the instance
                     document, together with a separate plain-string JSON Pointer.
                 </t>
                 <t>
@@ -621,7 +621,7 @@
                         For protocols supporting content-negotiation, implementations MAY choose to
                         describe possible target media types using protocol-specific information in
                         <xref target="headerSchema">"headerSchema"</xref>.  If both
-                        protocol-specific information and "targtMediaType" are present, then the
+                        protocol-specific information and "targetMediaType" are present, then the
                         value of "targetMediaType" MUST be compatible with the protocol-specific
                         information, and SHOULD indicate the media type that will be returned in the
                         absence of content negotiation.
@@ -1068,7 +1068,7 @@ for varname in T:
                     <t>
                         <list style="numbers">
                             <t>
-                                Deterimine which variables can accept input
+                                Determine which variables can accept input
                             </t>
                             <t>
                                 Pre-populate the input data set if the template resolution data
@@ -1574,7 +1574,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                     </artwork>
                 </figure>
                 <t>
-                    The attachment pointer is the root pointer (the only possiblity with
+                    The attachment pointer is the root pointer (the only possibility with
                     an empty object for the instance).  The context URI is the default,
                     which is the requested document.  Since application/json does not allow
                     for fragments, the context pointer is necessary to fully describe the
@@ -1887,7 +1887,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                         The following hyper-schema, applied to the instance in the response
                         above, would produce the same "self" link and "up" link with "anchor".
                         It also shows the use of a templated "base" URI, plus both absolute
-                        and relative JSON Pointers in "tempaltePointers".
+                        and relative JSON Pointers in "templatePointers".
                     </preamble>
                     <artwork>
 <![CDATA[

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -122,7 +122,7 @@
                 and asserts constraints on the structure of the data at each location.
                 An instance location that satisfies all asserted constraints is then
                 annotated with any keywords that contain non-assertion information,
-                such as desciptive metadata and usage hints.  If all locations within
+                such as descriptive metadata and usage hints.  If all locations within
                 the instance satisfy all asserted constraints, then the instance is
                 said to be valid against the schema.
             </t>
@@ -246,7 +246,7 @@
                 <section title="Annotations and Short-Circuit Validation">
                     <t>
                         Annotation keywords MUST be applied to all possible sub-instances.
-                        even if such application can be short-circuited when only assertion
+                        Even if such application can be short-circuited when only assertion
                         evaluation is needed.  For instance, the "contains" keyword need only
                         be checked for assertions until at least one array item proves valid.
                         However, when working with annotations, all items in the array must
@@ -866,7 +866,7 @@
                     The "format" keyword functions as both an annotation
                     (<xref target="annotations" />) and as an assertion
                     (<xref target="assertions" />).  While no special effort is required to
-                    implement it as an annotation convenying semantic meaning, implementing
+                    implement it as an annotation conveying semantic meaning, implementing
                     validation is non-trivial.
                 </t>
                 <t>
@@ -1098,7 +1098,7 @@
                     The content keywords function as both annotations
                     (<xref target="annotations" />) and as assertions
                     (<xref target="assertions" />).
-                    While no special effort is required to implement them as annotations convenying
+                    While no special effort is required to implement them as annotations conveying
                     how applications can interpret the data in the string, implementing
                     validation of conformance to the media type and encoding is non-trivial.
                 </t>


### PR DESCRIPTION
@handrews You earlier comment about Vim's spellcheck for XML files bugged me and I found that `:syntax spell toplevel` (in addition to `:set spell`) makes spellchecking work on tag's text.