### PR TITLE
Use boolean true instead of {} where possible

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -59,14 +59,14 @@
         "description": {
             "type": "string"
         },
-        "default": {},
+        "default": true,
         "readOnly": {
             "type": "boolean",
             "default": false
         },
         "examples": {
             "type": "array",
-            "items": {}
+            "items": true
         },
         "multipleOf": {
             "type": "number",
@@ -96,7 +96,7 @@
                 { "$ref": "#" },
                 { "$ref": "#/definitions/schemaArray" }
             ],
-            "default": {}
+            "default": true
         },
         "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
         "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
@@ -135,9 +135,10 @@
             }
         },
         "propertyNames": { "$ref": "#" },
-        "const": {},
+        "const": true,
         "enum": {
             "type": "array",
+            "items": true,
             "minItems": 1,
             "uniqueItems": true
         },
@@ -163,5 +164,5 @@
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" }
     },
-    "default": {}
+    "default": true
 }


### PR DESCRIPTION
Addresses #486 (sorry, @epoberezkin, I'm trying to nail down
as much as possible by end of day tomorrow/Friday, so can't
wait for your PR :-)

Let's emphasize the clarity of the boolean schemas as that is
why they were added.

Note that the default values of "definitions", "properties",
and "patternProperties" is an actual empty object, not an
empty schema, so those stay as they were.

We were using an explicit empty schema to emphasize/document
that a keyword accepts any possible value in several places,
but were not using it in a few others such as "items" within
the "enum" schema.  Consistently make it explicit.

There were no empty object subschemas in the other meta-schemas.

I used ajv to validate the schema against itself, which worked fine.