### PR TITLE
Fix normative vs informative references

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -5,7 +5,6 @@
 <!ENTITY rfc3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY rfc4151 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4151.xml">
 <!--<!ENTITY rfc4287 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4287.xml">-->
-<!--<!ENTITY rfc5226 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5226.xml">-->
 <!ENTITY rfc5789 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5789.xml">
 <!ENTITY rfc6068 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6068.xml">
 <!ENTITY rfc6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
@@ -2492,9 +2491,10 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             &rfc3986;
             <!--&rfc4287;-->
             &rfc6570;
+            &rfc6573;
             &rfc6901;
+            &rfc8288;
             &I-D.luff-relative-json-pointer;
-            &I-D.reschke-http-jfv;
             <reference anchor="json-schema">
                 <front>
                     <title>JSON Schema: A Media Type for Describing JSON Documents</title>
@@ -2518,15 +2518,13 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         </references>
         <references title="Informative References">
             &rfc2046;
-            <!--&rfc5226;-->
             &rfc4151;
             &rfc5789;
             &rfc6068;
-            &rfc6573;
             &rfc7230;
             &rfc7231;
             &rfc7807;
-            &rfc8288;
+            &I-D.reschke-http-jfv;
         </references>
         <section title="Using JSON Hyper-Schema in APIs" anchor="apis">
             <t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1381,6 +1381,30 @@
         <!-- References Section -->
         <references title="Normative References">
             &RFC2119;
+            &RFC1034;
+            &RFC2045;
+            &RFC2046;
+            &RFC2673;
+            &RFC3339;
+            &RFC3986;
+            &RFC3987;
+            &RFC4291;
+            &RFC5322;
+            &RFC5890;
+            &RFC5891;
+            &RFC6570;
+            &RFC6531;
+            &RFC6901;
+            &RFC7159;
+            <reference anchor="ecma262"
+            target="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">
+                <front>
+                    <title>ECMA 262 specification</title>
+                    <author/>
+                    <date/>
+                </front>
+            </reference>
+            &I-D.luff-relative-json-pointer;
             <reference anchor="json-schema">
                 <front>
                     <title>JSON Schema: A Media Type for Describing JSON Documents</title>
@@ -1392,31 +1416,7 @@
         </references>
 
         <references title="Informative References">
-            &RFC1034;
-            &RFC2045;
-            &RFC2046;
-            &RFC2673;
-            &RFC3339;
-            &RFC3986;
-            &RFC3987;
-            &RFC4291;
             &RFC4329;
-            &RFC5890;
-            &RFC5891;
-            &RFC6570;
-            &RFC6531;
-            &RFC6901;
-            &RFC7159;
-            &RFC5322;
-            &I-D.luff-relative-json-pointer;
-            <reference anchor="ecma262"
-            target="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">
-                <front>
-                    <title>ECMA 262 specification</title>
-                    <author/>
-                    <date/>
-                </front>
-            </reference>
         </references>
 
         <section title="Acknowledgments">
@@ -1462,6 +1462,8 @@
                             <t>I18N formats: "iri", "iri-reference", "idn-hostname", "idn-email"</t>
                             <t>Clarify that "json-pointer" format means string encoding, not URI fragment</t>
                             <t>Fixed typo that inverted the meaning of "minimum" and "exclusiveMinimum"</t>
+                            <t>Move format syntax references into Normative References</t>
+                            <t>JSON is a normative requirement</t>
                         </list>
                     </t>
                     <t hangText="draft-wright-json-schema-validation-01">


### PR DESCRIPTION
Addresses #471.  Note that no changes were needed in the core spec, and the commented-out RFC reference that was left in hyper-schema will be addressed by the next PR.

I left the HTTP RFCs (including PATCH) as informative because there is guidance on how they are used but I don't think anything rises to the level of a testable requirement, even an optional one.  Implementations, for instance, are not obligated to look for "accept-patch" in "targetHints", and if they do, the general directive that the meta-data is treated according to whatever protocol is in use is sufficient.  Additional information is present only to reduce confusion.

The one way in which this might not be correct is the requirement that API implementors MUST NOT define POST semantics for a collection other than collection item creation semantics.  That hinges on the use of POST.  But it's not actually a requirement for Hyper-Schema implementations, it's a requirement for hyper-schema users.  I'm not sure how that's supposed to work (or if that's improperly written to start with).