### PR TITLE
xref for "self" rel type, improve the wording for usage guidance, security concerns

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2456,9 +2456,13 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     the resource representation which contains the target URI with the "self"
                     link.
                     <cref>
-                        It is no longer clear what was intended by the "sub-path" option in
-                        this paragraph.  While paths are defined as a hierarchical system
-                        by RFC 3986, there semantics of the hierarchy are not defined.
+                        It is no longer entirely clear what was intended by the "sub-path"
+                        option in this paragraph.  It may have been intended to allow
+                        "self" links for embedded item representations in a collection, which
+                        usually have target URIs that are sub-paths of that collection's URI,
+                        to be considered authoritative.  However, this is simply a common
+                        design convention and does not appear to be based in RFC 3986 or any other
+                        guidance on URI usage.  See GitHub issue #485 for further discussion.
                     </cref>
                 </t>
             </section>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -4,7 +4,7 @@
 <!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY rfc3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY rfc4151 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4151.xml">
-<!--<!ENTITY rfc4287 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4287.xml">-->
+<!ENTITY rfc4287 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4287.xml">
 <!ENTITY rfc5789 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5789.xml">
 <!ENTITY rfc6068 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6068.xml">
 <!ENTITY rfc6570 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml">
@@ -440,11 +440,17 @@
                 </section>
                 <section title='"self" Links' anchor="self">
                     <t>
+                        A "self" link, as originally defined by <xref target="RFC4287">Section
+                        4.2.7.2 of RFC 4287</xref>, indicates that the target URI identifies
+                        a resource equivalent to the link context.  In JSON Hyper-Schema,
+                        a "self" link MUST be resolvable from the instance, and therefore
+                        "hrefSchema" MUST NOT be present.
+                    </t>
+                    <t>
                         A hyper-schema implementation MUST recognize that a link with relation
-                        type "self" that is applicable to the entire instance document describes
-                        how a user agent can interact with the resource represented by that
-                        instance document.  A "self" link MUST be resolvable from the instance,
-                        and therefore "hrefSchema" MUST NOT be present.
+                        type "self" that has the entire current instance document as its context
+                        describes how a user agent can interact with the resource represented by
+                        that instance document.
                     </t>
                     <t>
                         Hyper-schema authors SHOULD use "templateRequired" to ensure that the
@@ -2493,7 +2499,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         <references title="Normative References">
             &rfc2119;
             &rfc3986;
-            <!--&rfc4287;-->
+            &rfc4287;
             &rfc6570;
             &rfc6573;
             &rfc6901;

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -447,14 +447,14 @@
                         "hrefSchema" MUST NOT be present.
                     </t>
                     <t>
+                        Hyper-schema authors SHOULD use "templateRequired" to ensure that the
+                        "self" link has all instance data that is needed for use.
+                    </t>
+                    <t>
                         A hyper-schema implementation MUST recognize that a link with relation
                         type "self" that has the entire current instance document as its context
                         describes how a user agent can interact with the resource represented by
                         that instance document.
-                    </t>
-                    <t>
-                        Hyper-schema authors SHOULD use "templateRequired" to ensure that the
-                        "self" link has all instance data that is needed for use.
                     </t>
                 </section>
                 <section title='"collection" and "item" Links' anchor="collectionAndItem">

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2074,7 +2074,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         "contextUri": "https://api.example.com/things",
         "contextPointer": "/elements/0",
         "rel": "self",
-        "targetUri": "https://api.example.com/things/1234",
+        "targetUri": "https://api.example.com/things/12345",
         "attachmentPointer": "/elements/0"
     },
     {
@@ -2088,7 +2088,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         "contextUri": "https://api.example.com/things",
         "contextPointer": "",
         "rel": "item",
-        "targetUri": "https://api.example.com/things/1234",
+        "targetUri": "https://api.example.com/things/12345",
         "attachmentPointer": "/elements/0"
     },
     {


### PR DESCRIPTION
For some reason the reference to the Atom RFC, where "self" was
originally defined, was commented out.  Restore the reference
and cite it.

The text for "self" was confusing in that it was unclear which
parts applied in general and which parts applied to only "self"
links for the entire instance document.  Rearrange some sentences
to make that more clear.

Also partially addresses issue #485 by improving CREF text about
the "self" security concerns.