### PR TITLE
draft-07 meta-schemas, no longer -wip

### DIFF
--- a/hyper-schema-output.json
+++ b/hyper-schema-output.json
@@ -1,6 +1,6 @@
 {
-    "$id": "http://json-schema.org/draft-7-wip/hyper-schema-output",
-    "$schema": "http://json-schema.org/draft-07-wip/schema#",
+    "$id": "http://json-schema.org/draft-7/hyper-schema-output",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "items": {
         "allOf": [

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,18 +1,18 @@
 {
-    "$schema": "http://json-schema.org/draft-07-wip/hyper-schema#",
-    "$id": "http://json-schema.org/draft-07-wip/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$id": "http://json-schema.org/draft-07/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
         "schemaArray": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-07-wip/schema#/definitions/schemaArray" },
+                { "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray" },
                 {
                     "items": { "$ref": "#" }
                 }
             ]
         }
     },
-    "allOf": [ { "$ref": "http://json-schema.org/draft-07-wip/schema#" } ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft-07/schema#" } ],
     "properties": {
         "additionalItems": { "$ref": "#" },
         "additionalProperties": { "$ref": "#"},
@@ -56,7 +56,7 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "http://json-schema.org/draft-07-wip/links#"
+                "$ref": "http://json-schema.org/draft-07/links#"
             }
         }
     },

--- a/links.json
+++ b/links.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-07-wip/hyper-schema#",
-    "$id": "http://json-schema.org/draft-07-wip/links#",
+    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$id": "http://json-schema.org/draft-07/links#",
     "title": "Link Description Object",
     "allOf": [
         { "required": [ "rel", "href" ] },
@@ -30,7 +30,7 @@
                 },
                 "hrefSchema": {
                     "allOf": [
-                        { "$ref": "http://json-schema.org/draft-07-wip/hyper-schema#" }
+                        { "$ref": "http://json-schema.org/draft-07/hyper-schema#" }
                     ]
                 },
                 "templatePointers": {
@@ -57,24 +57,24 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$ref": "http://json-schema.org/draft-07-wip/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
                 },
                 "targetMediaType": {
                     "type": "string"
                 },
                 "targetHints": { },
                 "hrefSchema": {
-                    "$ref": "http://json-schema.org/draft-07-wip/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
                 },
                 "headerSchema": {
-                    "$ref": "http://json-schema.org/draft-07-wip/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
                 },
                 "submissionMediaType": {
                     "type": "string",
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$ref": "http://json-schema.org/draft-07-wip/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
                 },
                 "$comment": {
                     "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-07-wip/schema#",
-    "$id": "http://json-schema.org/draft-07-wip/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {


### PR DESCRIPTION
Prepare for publication of official meta-schemas for draft-07.

This `draft-07` branch will be rebased as needed for any further changes before publication, and then brought over to the upstream repository for ongoing use for any meta-schema bug fixes.  Which we've needed to do for drafts 3, 4, and 6.  Repeatedly :-P