### PR TITLE
Fix several early changelog oddities

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1116,16 +1116,18 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     </t>
                     <t hangText="draft-zyp-json-schema-04">
                         <list style="symbols">
-                            <t>Split validation keywords into separate document</t>
+                            <t>Salvaged from draft v3.</t>
+                            <t>Split validation keywords into separate document.</t>
+                            <t>Split hypermedia keywords into separate document.</t>
+                            <t>Initial post-split draft.</t>
+                            <t>Mandate the use of JSON Reference, JSON Pointer.</t>
+                            <t>Define the role of "id". Define URI resolution scope.</t>
+                            <t>Add interoperability considerations.</t>
                         </list>
                     </t>
                     <t hangText="draft-zyp-json-schema-00">
                         <list style="symbols">
                             <t>Initial draft.</t>
-                            <t>Salvaged from draft v3.</t>
-                            <t>Mandate the use of JSON Reference, JSON Pointer.</t>
-                            <t>Define the role of "id". Define URI resolution scope.</t>
-                            <t>Add interoperability considerations.</t>
                         </list>
                     </t>
                 </list>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2728,7 +2728,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                             <t>Changed behavior of "method" property to align with hypermedia best current practices</t>
                         </list>
                     </t>
-                    <t hangText="draft-luff-json-hyper-schema-01">
+                    <t hangText="draft-luff-json-hyper-schema-00">
                         <list style="symbols">
                             <t>Split from main specification.</t>
                         </list>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1518,7 +1518,7 @@
                             <t>Added "uriref" format that also allows relative URI references</t>
                         </list>
                     </t>
-                    <t hangText="draft-fge-json-schema-validation-01">
+                    <t hangText="draft-fge-json-schema-validation-00">
                         <list style="symbols">
                             <t>Initial draft.</t>
                             <t>Salvaged from draft v3.</t>


### PR DESCRIPTION
The core spec's change log seemed to have been spliced across
draft-04 and draft-00.  This dates back to draft-04.  Move the
obviously draft-04-related stuff up to that part of the changelog,
and add a line about splitting out hypermedia (analogous to the
existing line about splitting out validation).

It did not seem worthwhile to import the old changelogs from
draft-01, -02, and -03, although we can do that if necessary.
This change just fixes things that really did not make sense.

Also, in both the validation and hyper-schema specs, the oldest
draft was erroneously numbered -01 when it should be -00.

_**NOTE:** I'll probably also merge this to the draft-07 branch,
since if we do a bugfix this would be fine to include._