### PR TITLE
Prep for handrews-*-01 (Hyper-Schema and Rel JSON Pointer **ONLY**)

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -24,7 +24,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-handrews-json-schema-hyperschema-00" ipr="trust200902">
+<rfc category="info" docName="draft-handrews-json-schema-hyperschema-01" ipr="trust200902">
     <front>
         <title abbrev="JSON Hyper-Schema">
             JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON
@@ -2548,9 +2548,9 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     <author initials="H." surname="Andrews">
                         <organization>Cloudflare, Inc.</organization>
                     </author>
-                    <date year="2017" month="November"/>
+                    <date year="2018" month="January"/>
                 </front>
-                <seriesInfo name="Internet-Draft" value="draft-handrews-relative-json-pointer-00" />
+                <seriesInfo name="Internet-Draft" value="draft-handrews-relative-json-pointer-01" />
             </reference>
             <reference anchor="json-schema">
                 <front>
@@ -2674,6 +2674,16 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-json-schema-hyperschema-01">
+                        <list style="symbols">
+                            <t>This draft is purely a bug fix with no functional changes</t>
+                            <t>Fixed erroneous meta-schema URI (draft-07, not draft-07-wip)</t>
+                            <t>Removed stray "work in progress" language left over from review period</t>
+                            <t>Fixed missing trailing "/" in various "base" examples</t>
+                            <t>Fixed incorrect draft name in changelog (luff-*-00, not -01)</t>
+                            <t>Update relative pointer ref to handrews-*-01, also purely a bug fix</t>
+                        </list>
+                    </t>
                     <t hangText="draft-handrews-json-schema-hyperschema-00">
                         <list style="symbols">
                             <t>Top to bottom reorganization and rewrite</t>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -12,7 +12,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-handrews-relative-json-pointer-00" ipr="trust200902">
+<rfc category="info" docName="draft-handrews-relative-json-pointer-01" ipr="trust200902">
     <front>
         <title abbrev="Relative JSON Pointers">Relative JSON Pointers</title>
 
@@ -304,6 +304,11 @@
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-relative-json-pointer-01">
+                        <list style="symbols">
+                            <t>The initial number is "non-negative", not "positive"</t>
+                        </list>
+                    </t>
                     <t hangText="draft-handrews-relative-json-pointer-00">
                         <list style="symbols">
                             <t>Revived draft with identical wording and structure.</t>


### PR DESCRIPTION
This is just for Hyper-Schema and Relative JSON Pointer, both
of which need some bug fixing.  In particular, the hyper-schema
meta-schema link and some aspects of examples were blatantly
wrong and would not work.

***If folks think I should push all three instead, we could clarify
some wording and do that- there's been at least one wording
complaint on if/then/else, for instance.  But I don't want to
hold things up for that, or add new keywords or change behavior.***

This is against "newyear" which is against "master".  Once these
are merged to "master", I will merge "master" to "draft-07" and
tag new releases of these two specs.  The only commits on master
since the handrews-*-00 tags are:

* actual bug fixes to hyperschema (already on draft-07 and master)
* fixing the munged old changelogs (useful to include for -01)
* actual bug fixe to relative json pointer
* update year to 2018
* some README and CONTRIBUTING stuff which is irrelevant to the actual drafts
