### PR TITLE
Remove duplicate hrefSchema from meta-schema

### DIFF
--- a/links.json
+++ b/links.json
@@ -29,9 +29,7 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "allOf": [
-                        { "$ref": "http://json-schema.org/draft-07/hyper-schema#" }
-                    ]
+                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
                 },
                 "templatePointers": {
                     "type": "object",
@@ -63,9 +61,6 @@
                     "type": "string"
                 },
                 "targetHints": { },
-                "hrefSchema": {
-                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
-                },
                 "headerSchema": {
                     "$ref": "http://json-schema.org/draft-07/hyper-schema#"
                 },


### PR DESCRIPTION
I have no idea why this was like this, but fortunately they
both did the same thing.  One was needlessly complex.

This will get updated in place as the published draft-07
meta-schema as it's less confusing and functionally identical.