### PR TITLE
Initial update for draft-08 / handrews-*-02

### DIFF
--- a/hyper-schema-output.json
+++ b/hyper-schema-output.json
@@ -1,10 +1,10 @@
 {
-    "$id": "http://json-schema.org/draft-7/hyper-schema-output",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-08/hyper-schema-output",
+    "$schema": "http://json-schema.org/draft-08/schema#",
     "type": "array",
     "items": {
         "allOf": [
-            {"$ref": "http://json-schema.org/draft-07/links#/definitions/noRequiredFields" }
+            {"$ref": "http://json-schema.org/draft-08/links#/definitions/noRequiredFields" }
         ],
         "type": "object",
         "required": [

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,18 +1,18 @@
 {
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
-    "$id": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
+    "$id": "http://json-schema.org/draft-08/hyper-schema#",
     "title": "JSON Hyper-Schema",
     "definitions": {
         "schemaArray": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray" },
+                { "$ref": "http://json-schema.org/draft-08/schema#/definitions/schemaArray" },
                 {
                     "items": { "$ref": "#" }
                 }
             ]
         }
     },
-    "allOf": [ { "$ref": "http://json-schema.org/draft-07/schema#" } ],
+    "allOf": [ { "$ref": "http://json-schema.org/draft-08/schema#" } ],
     "properties": {
         "additionalItems": { "$ref": "#" },
         "additionalProperties": { "$ref": "#"},
@@ -56,7 +56,7 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "http://json-schema.org/draft-07/links#"
+                "$ref": "http://json-schema.org/draft-08/links#"
             }
         }
     },

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -19,7 +19,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-handrews-json-schema-01" ipr="trust200902">
+<rfc category="info" docName="draft-handrews-json-schema-02" ipr="trust200902">
     <front>
         <title abbrev="JSON Schema">JSON Schema: A Media Type for Describing JSON Documents</title>
 
@@ -1123,7 +1123,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     </author>
                     <date year="2017" month="November"/>
                 </front>
-                <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-validation-01" />
+                <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-validation-02" />
             </reference>
             <reference anchor="json-hyper-schema">
                 <front>
@@ -1136,7 +1136,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     </author>
                     <date year="2017" month="November"/>
                 </front>
-                <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-hyperschema-01" />
+                <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-hyperschema-02" />
             </reference>
         </references>
 
@@ -1170,6 +1170,11 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-json-schema-02">
+                        <list style="symbols">
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-handrews-json-schema-01">
                         <list style="symbols">
                             <t>This draft is purely a clarification with no functional changes</t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -24,7 +24,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-handrews-json-schema-hyperschema-01" ipr="trust200902">
+<rfc category="info" docName="draft-handrews-json-schema-hyperschema-02" ipr="trust200902">
     <front>
         <title abbrev="JSON Hyper-Schema">
             JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON
@@ -286,14 +286,14 @@
         <section title="Meta-Schemas and Output Schema">
             <t>
                 The current URI for the JSON Hyper-Schema meta-schema is
-                <eref target="http://json-schema.org/draft-07/hyper-schema#"/>.
+                <eref target="http://json-schema.org/draft-08/hyper-schema#"/>.
             </t>
             <t>
                 The <xref target="ldo">link description format</xref> can be used without JSON
                 Schema, and use of this format can be declared by referencing the normative
                 link description schema as the schema for the data structure that uses the links.
                 The URI of the normative link description schema is:
-                <eref target="http://json-schema.org/draft-07/links#"/>.
+                <eref target="http://json-schema.org/draft-08/links#"/>.
             </t>
             <t>
                 JSON Hyper-Schema implementations are free to provide output in any format.
@@ -304,7 +304,7 @@
                 It is RECOMMENDED that implementations be capable of producing output
                 in this format to facilitated testing.  The URI of the JSON Schema
                 describing the recommended output format is
-                <eref target="http://json-schema.org/draft-07/hyper-schema-output#"/>.
+                <eref target="http://json-schema.org/draft-08/hyper-schema-output#"/>.
             </t>
         </section>
         <section title="Schema Keywords">
@@ -1569,7 +1569,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
 <![CDATA[
 {
     "$id": "https://schema.example.com/entry",
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "base": "https://api.example.com/",
     "links": [
         {
@@ -1623,7 +1623,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/thing",
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "base": "https://api.example.com/",
     "type": "object",
     "required": ["data"],
@@ -1739,7 +1739,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/interesting-stuff",
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "required": ["stuffWorthEmailingAbout", "email", "title"],
     "properties": {
         "title": {
@@ -1926,7 +1926,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/tree-node",
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "base": "trees/{treeId}/",
     "properties": {
         "id": {"type": "integer"},
@@ -1988,7 +1988,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/thing",
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "base": "https://api.example.com/",
     "type": "object",
     "required": ["data"],
@@ -2041,7 +2041,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/thing-collection",
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "base": "https://api.example.com/",
     "type": "object",
     "required": ["elements"],
@@ -2674,6 +2674,11 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-json-schema-hyperschema-02">
+                        <list style="symbols">
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-handrews-json-schema-hyperschema-01">
                         <list style="symbols">
                             <t>This draft is purely a bug fix with no functional changes</t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -26,7 +26,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-handrews-json-schema-validation-01" ipr="trust200902">
+<rfc category="info" docName="draft-handrews-json-schema-validation-02" ipr="trust200902">
     <front>
         <title abbrev="JSON Schema Validation">
             JSON Schema Validation: A Vocabulary for Structural Validation of JSON
@@ -337,7 +337,7 @@
         <section title="Meta-Schema">
             <t>
                 The current URI for the JSON Schema Validation is
-                <eref target="http://json-schema.org/draft-07/schema#"/>.
+                <eref target="http://json-schema.org/draft-08/schema#"/>.
             </t>
         </section>
 
@@ -1462,7 +1462,7 @@
                     </author>
                     <date year="2017" month="November"/>
                 </front>
-                <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-01" />
+                <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-02" />
             </reference>
         </references>
 
@@ -1501,6 +1501,11 @@
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-json-schema-validation-02">
+                        <list style="symbols">
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-handrews-json-schema-validation-01">
                         <list style="symbols">
                             <t>This draft is purely a clarification with no functional changes</t>

--- a/links.json
+++ b/links.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
-    "$id": "http://json-schema.org/draft-07/links#",
+    "$schema": "http://json-schema.org/draft-08/hyper-schema#",
+    "$id": "http://json-schema.org/draft-08/links#",
     "title": "Link Description Object",
     "allOf": [
         { "required": [ "rel", "href" ] },
@@ -29,7 +29,7 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
                 },
                 "templatePointers": {
                     "type": "object",
@@ -55,21 +55,21 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
                 },
                 "targetMediaType": {
                     "type": "string"
                 },
                 "targetHints": { },
                 "headerSchema": {
-                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
                 },
                 "submissionMediaType": {
                     "type": "string",
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$ref": "http://json-schema.org/draft-07/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
                 },
                 "$comment": {
                     "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-08/schema#",
+    "$id": "http://json-schema.org/draft-08/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {


### PR DESCRIPTION
This updates the various numberings to avoid confusion between
the work-in-progress drafts and the published draft-07 and
draft-handrews-*-01 documents.

Having examples using new keywords but referencing draft-07
is confusing, as is having meta-schemas identified as draft-07
with keywords that are not part of draft-07.  Similarly, having
a set of draft-handrews-*-01 documents that are buildable
that do not match the published ones is confusing.

Last time I did some "-wip" suffixes but I'm not sure how
clear this was to anyone else, and the main result was that
I accidentally left about half of them in at publication :-(

This seems more straightforward.