### PR TITLE
Move "definitions" to core as "$defs", start appendix on moved/renamed keywords

### DIFF
--- a/hyper-schema-output.json
+++ b/hyper-schema-output.json
@@ -4,7 +4,7 @@
     "type": "array",
     "items": {
         "allOf": [
-            {"$ref": "http://json-schema.org/draft-08/links#/definitions/noRequiredFields" }
+            {"$ref": "http://json-schema.org/draft-08/links#/$defs/noRequiredFields" }
         ],
         "type": "object",
         "required": [

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -2,10 +2,10 @@
     "$schema": "http://json-schema.org/draft-08/hyper-schema#",
     "$id": "http://json-schema.org/draft-08/hyper-schema#",
     "title": "JSON Hyper-Schema",
-    "definitions": {
+    "$defs": {
         "schemaArray": {
             "allOf": [
-                { "$ref": "http://json-schema.org/draft-08/schema#/definitions/schemaArray" },
+                { "$ref": "http://json-schema.org/draft-08/schema#/$defs/schemaArray" },
                 {
                     "items": { "$ref": "#" }
                 }
@@ -27,10 +27,14 @@
         "items": {
             "anyOf": [
                 { "$ref": "#" },
-                { "$ref": "#/definitions/schemaArray" }
+                { "$ref": "#/$defs/schemaArray" }
             ]
         },
+        "$defs": {
+            "additionalProperties": { "$ref": "#" }
+        },
         "definitions": {
+            "$comment": "Renamed to $defs, but retained here to ensure compatibility",
             "additionalProperties": { "$ref": "#" }
         },
         "patternProperties": {
@@ -42,9 +46,9 @@
         "if": {"$ref": "#"},
         "then": {"$ref": "#"},
         "else": {"$ref": "#"},
-        "allOf": { "$ref": "#/definitions/schemaArray" },
-        "anyOf": { "$ref": "#/definitions/schemaArray" },
-        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
         "not": { "$ref": "#" },
         "contains": { "$ref": "#" },
         "propertyNames": { "$ref": "#" },

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -814,6 +814,40 @@
                     </t>
                 </section>
             </section>
+
+            <section title='Schema Re-Use With "$defs"'>
+                <t>
+                    The "$defs" keyword provides a standardized location for schema
+                    authors to inline re-usable JSON Schemas into a more general schema.
+                    The keyword does not directly affect the validation result.
+                </t>
+                <t>
+                    This keyword's value MUST be an object.
+                    Each member value of this object MUST be a valid JSON Schema.
+                </t>
+                <t>
+                    As an example, here is a schema describing an array of positive
+                    integers, where the positive integer constraint is a subschema in
+                    "$defs":
+
+                    <figure>
+                        <artwork>
+<![CDATA[
+{
+    "type": "array",
+    "items": { "$ref": "#/$defs/positiveInteger" },
+    "$defs": {
+        "positiveInteger": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+        }
+    }
+}
+]]>
+                        </artwork>
+                    </figure>
+                </t>
+            </section>
         </section>
 
         <section title='Comments With "$comment"'>
@@ -1172,7 +1206,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                 <list style="hanging">
                     <t hangText="draft-handrews-json-schema-02">
                         <list style="symbols">
-                            <t></t>
+                            <t>Moved "definitions" from the Validation specification here as "$defs"</t>
                         </list>
                     </t>
                     <t hangText="draft-handrews-json-schema-01">

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -629,11 +629,11 @@
 <![CDATA[
 {
     "$id": "http://example.com/root.json",
-    "definitions": {
+    "$defs": {
         "A": { "$id": "#foo" },
         "B": {
             "$id": "other.json",
-            "definitions": {
+            "$defs": {
                 "X": { "$id": "#bar" },
                 "Y": { "$id": "t/inner.json" }
             }
@@ -660,39 +660,39 @@
                                     <t>http://example.com/root.json#</t>
                                 </list>
                             </t>
-                            <t hangText="#/definitions/A">
+                            <t hangText="#/$defs/A">
                                 <list>
                                     <t>http://example.com/root.json#foo</t>
-                                    <t>http://example.com/root.json#/definitions/A</t>
+                                    <t>http://example.com/root.json#/$defs/A</t>
                                 </list>
                             </t>
-                            <t hangText="#/definitions/B">
+                            <t hangText="#/$defs/B">
                                 <list>
                                     <t>http://example.com/other.json</t>
                                     <t>http://example.com/other.json#</t>
-                                    <t>http://example.com/root.json#/definitions/B</t>
+                                    <t>http://example.com/root.json#/$defs/B</t>
                                 </list>
                             </t>
-                            <t hangText="#/definitions/B/definitions/X">
+                            <t hangText="#/$defs/B/$defs/X">
                                 <list>
                                     <t>http://example.com/other.json#bar</t>
-                                    <t>http://example.com/other.json#/definitions/X</t>
-                                    <t>http://example.com/root.json#/definitions/B/definitions/X</t>
+                                    <t>http://example.com/other.json#/$defs/X</t>
+                                    <t>http://example.com/root.json#/$defs/B/$defs/X</t>
                                 </list>
                             </t>
-                            <t hangText="#/definitions/B/definitions/Y">
+                            <t hangText="#/$defs/B/$defs/Y">
                                 <list>
                                     <t>http://example.com/t/inner.json</t>
                                     <t>http://example.com/t/inner.json#</t>
-                                    <t>http://example.com/other.json#/definitions/Y</t>
-                                    <t>http://example.com/root.json#/definitions/B/definitions/Y</t>
+                                    <t>http://example.com/other.json#/$defs/Y</t>
+                                    <t>http://example.com/root.json#/$defs/B/$defs/Y</t>
                                 </list>
                             </t>
-                            <t hangText="#/definitions/C">
+                            <t hangText="#/$defs/C">
                                 <list>
                                     <t>urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f</t>
                                     <t>urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#</t>
-                                    <t>http://example.com/root.json#/definitions/C</t>
+                                    <t>http://example.com/root.json#/$defs/C</t>
                                 </list>
                             </t>
                         </list>
@@ -776,7 +776,7 @@
         "type": "array",
         "items": { "$ref": "#item" }
     },
-    "definitions": {
+    "$defs": {
         "single": {
             "$id": "#item",
             "type": "object",
@@ -788,7 +788,7 @@
                         </artwork>
                     </figure>
                     <t>
-                        When an implementation encounters the &lt;#/definitions/single&gt; schema,
+                        When an implementation encounters the &lt;#/$defs/single&gt; schema,
                         it resolves the "$id" URI reference against the current base URI to form
                         &lt;http://example.net/root.json#item&gt;.
                     </t>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -1628,7 +1628,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
     "type": "object",
     "required": ["data"],
     "properties": {
-        "id": {"$ref": "#/definitions/id"},
+        "id": {"$ref": "#/$defs/id"},
         "data": true
     },
     "links": [
@@ -1639,7 +1639,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
             "targetSchema": {"$ref": "#"}
         }
     ],
-    "definitions": {
+    "$defs": {
         "id": {
             "type": "integer",
             "minimum": 1,
@@ -1652,7 +1652,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
                 <t>
                     Our "thing" has a server-assigned id, which is required in order to
                     construct the "self" link.  It also has a "data" field which can be
-                    of any type.  The reason for the "definitions" section will be clear
+                    of any type.  The reason for the "$defs" section will be clear
                     in the next example.
                 </t>
                 <t>
@@ -1678,7 +1678,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
     "hrefSchema": {
         "required": ["id"],
         "properties": {
-            "id": {"$ref": "thing#/definitions/id"}
+            "id": {"$ref": "thing#/$defs/id"}
         }
     },
     "targetSchema": {"$ref": "thing#"}
@@ -1993,7 +1993,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
     "type": "object",
     "required": ["data"],
     "properties": {
-        "id": {"$ref": "#/definitions/id"},
+        "id": {"$ref": "#/$defs/id"},
         "data": true
     },
     "links": [
@@ -2009,7 +2009,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             "submissionSchema": {"$ref": "#"}
         }
     ],
-    "definitions": {
+    "$defs": {
         "id": {
             "type": "integer",
             "minimum": 1,
@@ -2206,9 +2206,9 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         "meta": {
             "type": "object",
             "properties": {
-                "prev": {"$ref": "#/definitions/pagination"},
-                "current": {"$ref": "#/definitions/pagination"},
-                "next": {"$ref": "#/definitions/pagination"}
+                "prev": {"$ref": "#/$defs/pagination"},
+                "current": {"$ref": "#/$defs/pagination"},
+                "next": {"$ref": "#/$defs/pagination"}
             }
         }
     },
@@ -2242,7 +2242,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
             "targetSchema": {"$ref": "#"}
         }
     ],
-    "definitions": {
+    "$defs": {
         "pagination": {
             "type": "object",
             "properties": {
@@ -2348,7 +2348,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
     "rel": "tag:rel.example.com,2017:thing-collection",
     "href": "/things{?offset,limit}",
     "hrefSchema": {
-        "$ref": "thing-collection#/definitions/pagination"
+        "$ref": "thing-collection#/$defs/pagination"
     },
     "submissionSchema": {
         "$ref": "thing#"

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1436,6 +1436,23 @@
             &RFC4329;
         </references>
 
+        <section title="Keywords Moved from Validation to Core">
+            <t>
+                Several keywords have been moved from this document into the
+                <xref target="json-schema">Core Specification</xref> as of this draft, in some
+                cases with re-naming or other changes.  This affects the following former
+                validation keywords:
+                <list style="hanging">
+                    <t hangText='"definitions"'>
+                        Renamed to "$defs" to match "$ref" and be shorter to type.
+                        Schema vocabulary authors SHOULD NOT define a "definitions" keyword
+                        with different behavior in order to avoid invalidating schemas that
+                        still use the older name.
+                    </t>
+                </list>
+            </t>
+        </section>
+
         <section title="Acknowledgments">
             <t>
                 Thanks to

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1233,40 +1233,6 @@
 
         </section>
 
-        <section title='Schema Re-Use With "definitions"'>
-            <t>
-                The "definitions" keywords provides a standardized location for schema
-                authors to inline re-usable JSON Schemas into a more general schema.
-                The keyword does not directly affect the validation result.
-            </t>
-            <t>
-                This keyword's value MUST be an object.
-                Each member value of this object MUST be a valid JSON Schema.
-            </t>
-            <t>
-                As an example, here is a schema describing an array of positive
-                integers, where the positive integer constraint is a subschema in
-                "definitions":
-
-                <figure>
-                    <artwork>
-<![CDATA[
-{
-    "type": "array",
-    "items": { "$ref": "#/definitions/positiveInteger" },
-    "definitions": {
-        "positiveInteger": {
-            "type": "integer",
-            "exclusiveMinimum": 0
-        }
-    }
-}
-]]>
-                    </artwork>
-                </figure>
-            </t>
-        </section>
-
         <section title="Schema Annotations">
             <t>
                 Schema validation is a useful mechanism for annotating instance data
@@ -1503,7 +1469,7 @@
                 <list style="hanging">
                     <t hangText="draft-handrews-json-schema-validation-02">
                         <list style="symbols">
-                            <t></t>
+                            <t>Moved "definitions" to the core spec as "$defs"</t>
                         </list>
                     </t>
                     <t hangText="draft-handrews-json-schema-validation-01">

--- a/links.json
+++ b/links.json
@@ -4,9 +4,9 @@
     "title": "Link Description Object",
     "allOf": [
         { "required": [ "rel", "href" ] },
-        { "$ref": "#/definitions/noRequiredFields" }
+        { "$ref": "#/$defs/noRequiredFields" }
     ],
-    "definitions": {
+    "$defs": {
         "noRequiredFields": {
             "type": "object",
             "properties": {

--- a/schema.json
+++ b/schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-08/schema#",
     "$id": "http://json-schema.org/draft-08/schema#",
     "title": "Core schema meta-schema",
-    "definitions": {
+    "$defs": {
         "schemaArray": {
             "type": "array",
             "minItems": 1,
@@ -14,7 +14,7 @@
         },
         "nonNegativeIntegerDefault0": {
             "allOf": [
-                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "$ref": "#/$defs/nonNegativeInteger" },
                 { "default": 0 }
             ]
         },
@@ -95,8 +95,8 @@
         "exclusiveMinimum": {
             "type": "number"
         },
-        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
-        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
         "pattern": {
             "type": "string",
             "format": "regex"
@@ -105,20 +105,20 @@
         "items": {
             "anyOf": [
                 { "$ref": "#" },
-                { "$ref": "#/definitions/schemaArray" }
+                { "$ref": "#/$defs/schemaArray" }
             ],
             "default": true
         },
-        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
-        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
         "uniqueItems": {
             "type": "boolean",
             "default": false
         },
         "contains": { "$ref": "#" },
-        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
-        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
-        "required": { "$ref": "#/definitions/stringArray" },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
         "additionalProperties": { "$ref": "#" },
         "properties": {
             "type": "object",
@@ -136,7 +136,7 @@
             "additionalProperties": {
                 "anyOf": [
                     { "$ref": "#" },
-                    { "$ref": "#/definitions/stringArray" }
+                    { "$ref": "#/$defs/stringArray" }
                 ]
             }
         },
@@ -150,10 +150,10 @@
         },
         "type": {
             "anyOf": [
-                { "$ref": "#/definitions/simpleTypes" },
+                { "$ref": "#/$defs/simpleTypes" },
                 {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "items": { "$ref": "#/$defs/simpleTypes" },
                     "minItems": 1,
                     "uniqueItems": true
                 }
@@ -165,9 +165,9 @@
         "if": {"$ref": "#"},
         "then": {"$ref": "#"},
         "else": {"$ref": "#"},
-        "allOf": { "$ref": "#/definitions/schemaArray" },
-        "anyOf": { "$ref": "#/definitions/schemaArray" },
-        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
         "not": { "$ref": "#" }
     },
     "default": true

--- a/schema.json
+++ b/schema.json
@@ -53,6 +53,17 @@
         "$comment": {
             "type": "string"
         },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "definitions": {
+            "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
         "title": {
             "type": "string"
         },
@@ -109,11 +120,6 @@
         "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
         "required": { "$ref": "#/definitions/stringArray" },
         "additionalProperties": { "$ref": "#" },
-        "definitions": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
         "properties": {
             "type": "object",
             "additionalProperties": { "$ref": "#" },


### PR DESCRIPTION
Includes updates of the meta-schemas and examples to match.

Addresses #512 

_**NOTE:** There are multiple commits to make this easy, as it's all very simple and mostly mechanical, but if you look at it all together it looks big.  The commits in order:_
* _actually move/rename_
* _add the appendix to the validation spec_
* _add to meta-schemas_
* _use in meta-schemas_
* _update examples_
