### PR TITLE
Email payload example typo fix

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -1828,7 +1828,7 @@ Link: <https://schema.example.com/entry> rel=describedBy
 <![CDATA[{
     "title": "The Awesome Thing",
     "stuffWorthEmailingAbout": "Lots of text here...",
-    "email": "someone@exapmle.com"
+    "email": "someone@example.com"
 }]]>
                     </artwork>
                 </figure>


### PR DESCRIPTION
`someone@exapmle.com` -> `someone@example.com`, rest of the example doesn't seem to have the same typo.