### PR TITLE
Feature/ref is delegation 2

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -791,14 +791,19 @@
 
             <section title='Schema References With "$ref"'>
                 <t>
-                    The "$ref" keyword is used to reference a schema, and provides the ability to
-                    validate recursive structures through self-reference.
+                    The "$ref" keyword can be used to reference a schema which is to be applied to the
+                    current instance location. "$ref" is an assertion key word, which MUST produce a boolean
+                    assertion result when the resolved schema is applied.
                 </t>
+                <cref anchor="REF1" source="BH">
+                    The use of "$ref" MUST NOT effect adjacent keywords.
+                    Given previously the use of "$ref" would negate the use of other keywords in that object,
+                    it seems like a good thing to mention.
+                    Should be removed before leaving Internet Draft
+                </cref>
                 <t>
-                    An object schema with a "$ref" property MUST be interpreted as a "$ref" reference.
                     The value of the "$ref" property MUST be a URI Reference.
                     Resolved against the current URI base, it identifies the URI of a schema to use.
-                    All other properties in a "$ref" object MUST be ignored.
                 </t>
                 <t>
                     The URI is not a network locator, only an identifier. A schema need not be

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -928,6 +928,24 @@
                     </t>
                 </section>
             </section>
+            <section title="Dereferencing By Inclusion">
+                <t>
+                    It MUST NOT be expected that any schema can be dereferenced by the means of replacing any object that
+                    uses the "$ref" keyword with the resolved referenced schema (inclusion). An interface MAY be provided
+                    to dereference a schema by means of inclusion, however it MUST NOT be the default behaviour.
+                </t>
+                <t>
+                    The use of "$id" and "$ref" from external schemas MUST be evaluate correctly, and not evaluated after
+                    any inclusion process.
+                </t>
+                <t>
+                    The result of any inclusion process MUST NOT effect previously adjacent keywords to the original "$ref" keyword
+                </t>
+                <t>
+                    A behaviour when a resolved schema which defines a schema version which is different to that of the base JSON Schema document
+                    is not defined.
+                </t>
+            </section>
 
             <section title='Schema Re-Use With "$defs"'>
                 <t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -806,10 +806,7 @@
                     Resolved against the current URI base, it identifies the URI of a schema to use.
                 </t>
                 <t>
-                    The URI is not a network locator, only an identifier. A schema need not be
-                    downloadable from the address if it is a network-addressable URL, and
-                    implementations SHOULD NOT assume they should perform a network operation when they
-                    encounter a network-addressable URI.
+                    A URI may be a locator, a name, or both, per <xref target="RFC3986">RFC 3986</xref>.
                 </t>
                 <t>
                     A schema MUST NOT be run into an infinite loop against a schema. For example, if two
@@ -819,7 +816,30 @@
                     Schemas SHOULD NOT make use of infinite recursive nesting like this; the behavior is
                     undefined.
                 </t>
-                <section title="Loading a referenced schema">
+                <t>
+                    A URI reference without a protocol MUST be considered a plain name fragment,
+                    and the URI reference location resolved according to <xref target="id-keyword">"$id" keyword</xref> section.
+                </t>
+                    A URI reference with a network addressable locator defined MAY be provided with an interface to retrieve
+                    the network accessible resource.
+                <t>
+                <cref anchor="REF2" source="BH">
+                    A schema author wants to define a means to retrieve a specific URI protocol. An implementation may allow
+                    the user to specify a method to perform a network operation (or other operation) to retrieve the reference
+                    content. For example, the behaviour of a URI with a protocol of "file" is not defined. The implementation
+                    provides an interface to define a function which is called when it encounters a URI which uses the specified
+                    URI protocol (which is "file" in this case). The user defines "file" as the protocol, and includes a function
+                    (or some form of instruction) using the interface, which will be triggered to retrieve any reference defined
+                    with a URI that uses a protocol of "file". This is similar to "adding a schema" where implementations track
+                    added schema's $id, allowing them to be later used in reference.
+                </cref>
+                </t>
+                Any URI may be resolvable by use of externally defined references provided to the implementation as per the
+                <xref target="loading-references">Loading a referenced schema</xref> section.
+                <t>
+
+                </t>
+                <section title="Loading a referenced schema" anchor="loading-references">
                     <t>
                         The use of URIs to identify remote schemas does not necessarily mean anything is downloaded,
                         but instead JSON Schema implementations SHOULD understand ahead of time which schemas they will be using,


### PR DESCRIPTION
Retrying to resolve #523 and #514.
Opened in favour of #580 !


---
Possibly considered a sidetrack, but I think it's part of #514 :
Redacted previous change of removing comment on infinite loops.

> A schema MUST NOT be run into an infinite loop against a schema. For example, if two
>                     schemas "#alice" and "#bob" both have an "allOf" property that refers to the other,
>                     a naive validator might get stuck in an infinite recursive loop trying to validate
>                     the instance.
>                     Schemas SHOULD NOT make use of infinite recursive nesting like this; the behavior is
>                     undefined.

Do we actually want this? Later we say "Validators MUST NOT fall into an infinite loop." which suggests we expect that could be possible based on the schema.

Maybe I just missunderstand the intesnion. Happy to file a new issue if you (collective) find this preferable.