### PR TITLE
Minor hyper-schema fixes

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -945,9 +945,9 @@
                     </t>
                     <t hangText="attachmentPointer">
                         The JSON Pointer for the location within the instance to which the
-                        link is attached.  By default, "contextUri" and "attachmentUri" are
+                        link is attached.  By default, "contextUri" and "attachmentPointer" are
                         the same, but "contextUri" can be changed by LDO keywords, while
-                        "attachmentUri" cannot.
+                        "attachmentPointer" cannot.
                     </t>
                 </list>
                 Other LDO keywords that are not involved in producing the above information

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -2305,7 +2305,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         "contextPointer": "",
         "rel": "self",
         "targetUri":
-            "https://api.example.com/things?offset=20,limit=2",
+            "https://api.example.com/things?offset=0&limit=2",
         "attachmentPointer": ""
     },
     {
@@ -2313,7 +2313,7 @@ Link: <https://api.example.com/trees/1/nodes/456> rev=up
         "contextPointer": "",
         "rel": "next",
         "targetUri":
-            "https://api.example.com/things?offset=22,limit=2",
+            "https://api.example.com/things?offset=3&limit=2",
         "attachmentPointer": ""
     }
 ]]]>


### PR DESCRIPTION
One commit for each:

* Fix typo "attachmentUri" -> "attachmentPointer" #552 
* Fix example querystring (ampersand vs comma; correct offsets) #548 