### PR TITLE
Keywords can depend on subschema or adjacent keyword annotation results

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1264,9 +1264,10 @@
                             index of the instance, such as when "items" is a schema.
                         </t>
                         <t>
-                            Annotation results from multiple "items" keyword are combined
+                            Annotation results for "items" keywords from multiple
+                            schemas applied to the same instance location are combined
                             by setting the combined result to true if any of the values
-                            are true, and otherwise retaining the larges numerical value.
+                            are true, and otherwise retaining the largest numerical value.
                         </t>
                         <t>
                             Omitting this keyword has the same assertion behavior as
@@ -1293,14 +1294,17 @@
                             If the "additionalItems" subschema is applied to any
                             positions within the instance array, it produces an
                             annotation result of boolean true, analogous to the
-                            single schema behavior of "items".
+                            single schema behavior of "items".  If any "additionalItems"
+                            keyword from any subschema applied to the same instance
+                            location produces an annotation value of true, then
+                            the combined result from these keywords is also true.
                         </t>
                         <t>
                             Omitting this keyword has the same assertion behavior as
                             an empty schema.
                         </t>
                         <t>
-                            Implementation MAY choose to implement or optimize this keyword
+                            Implementations MAY choose to implement or optimize this keyword
                             in another way that produces the same effect, such as by directly
                             checking for the presence and size of an "items" array.
                             Implementations that do not support annotation collection MUST do so.
@@ -1341,8 +1345,9 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names matched by this keyword.  Multiple annotation
-                            results for "properties" are combined by taking the union
+                            property names matched by this keyword.  Annotation results
+                            for "properties" keywords from multiple schemas applied to
+                            the same instance location are combined by taking the union
                             of the sets.
                         </t>
                         <t>
@@ -1366,8 +1371,9 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names matched by this keyword.  Multiple annotation
-                            results for "patternProperties" are combined by taking the union
+                            property names matched by this keyword.  Annotation results
+                            for "patternProperties" keywords from multiple schemas applied to
+                            the same instance location are combined by taking the union
                             of the sets.
                         </t>
                         <t>
@@ -1395,6 +1401,9 @@
                         <t>
                             The annotation result of this keyword is the set of instance
                             property names validated by this keyword's subschema.
+                            Annotation results for "additionalProperties" keywords from
+                            multiple schemas applied to the same instance location are combined
+                            by taking the union of the sets.
                         </t>
                         <t>
                             Omitting this keyword has the same assertion behavior as

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -126,8 +126,9 @@
             <section title="Keyword Behaviors">
                 <t>
                     JSON Schema keywords fall into several general behavior categories.
-                    Assertions validate that an instance satisfies constraints.  Annotations
-                    attach information that applications may use in any way they see fit.
+                    Assertions validate that an instance satisfies constraints, producing
+                    a boolean result.  Annotations attach information that applications
+                    may use in any way they see fit.
                     Applicators apply subschemas to parts of the instance and combine
                     their results.
                 </t>
@@ -144,6 +145,38 @@
                     Evaluation of a parent schema object can complete once all of its
                     subschemas have been evaluated, although in some circumstance evaluation
                     may be short-circuited due to assertion results.
+                </t>
+                <t>
+                    Keyword behavior MAY be defined in terms of the annotation results
+                    of <xref target="root">subschemas</xref> and/or adjacent keywords.
+                    Such keywords MUST NOT result in a circular dependency.
+                    Keywords MAY modify their behavior based on the presence or absence
+                    of another keyword in the same
+                    <xref target="schema-document">schema object</xref>.
+                </t>
+                <t>
+                    A missing keyword MUST NOT produce a false assertion result, MUST
+                    NOT produce annotation results, and MUST NOT cause any other schema
+                    to be evaluated as part of its own behavioral definition.
+                    However, given that missing keywords do not contribute annotations,
+                    the lack of annotation results may indirectly change the behavior
+                    of other keywords.
+                </t>
+                <t>
+                    In some cases, the missing keyword assertion behavior of a keyword is
+                    identical to that produced by a certain value, and keyword definitions
+                    SHOULD note such values where known.  However, even if the value which
+                    produces the default behavior would produce annotation results if
+                    present, the default behavior still MUST NOT result in annotations.
+                </t>
+                <t>
+                    Because annotation collection can add significant cost in terms of both
+                    computation and memory, implementations MAY opt out of this feature.
+                    Keywords known to an implementation to have assertion or applicator behavior
+                    that depend on annotation results MUST then be treated as errors, unless
+                    an alternate implementation producing the same behavior is available.
+                    Keywords of this sort SHOULD describe reasonable alternate approaches
+                    when appropriate.
                 </t>
                 <t>
                     Extension keywords SHOULD stay within these categories, keeping in mind
@@ -190,9 +223,7 @@
                     </t>
                     <t>
                         An instance can only fail an assertion that is present in the schema.
-                        In some cases, this no-op behavior is identical to a keyword that exists with
-                        certain values, and keyword definitions SHOULD note such values where known.
-                        These default behaviors MUST NOT result in assertion failures.
+
                     </t>
                     <section title="Assertions and Instance Primitive Types">
                         <t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1246,10 +1246,6 @@
                             JSON Schemas.
                         </t>
                         <t>
-                            This keyword determines how child instances validate for arrays,
-                            and does not directly validate the immediate instance itself.
-                        </t>
-                        <t>
                             If "items" is a schema, validation succeeds if all elements
                             in the array successfully validate against that schema.
                         </t>
@@ -1266,10 +1262,6 @@
                     <section title="additionalItems">
                         <t>
                             The value of "additionalItems" MUST be a valid JSON Schema.
-                        </t>
-                        <t>
-                            This keyword determines how child instances validate for arrays,
-                            and does not directly validate the immediate instance itself.
                         </t>
                         <t>
                             If "items" is an array of schemas, validation succeeds
@@ -1304,10 +1296,6 @@
                             Each value of this object MUST be a valid JSON Schema.
                         </t>
                         <t>
-                            This keyword determines how child instances validate for objects,
-                            and does not directly validate the immediate instance itself.
-                        </t>
-                        <t>
                             Validation succeeds if, for each name that appears in both
                             the instance and as a name within this keyword's value, the child
                             instance for that name successfully validates against the
@@ -1326,12 +1314,6 @@
                             MUST be a valid JSON Schema.
                         </t>
                         <t>
-                            This keyword determines how child instances validate for objects,
-                            and does not directly validate the immediate instance itself.
-                            Validation of the primitive instance type against this keyword
-                            always succeeds.
-                        </t>
-                        <t>
                             Validation succeeds if, for each instance name that matches any
                             regular expressions that appear as a property name in this keyword's value,
                             the child instance for that name successfully validates against each
@@ -1345,10 +1327,6 @@
                     <section title="additionalProperties">
                         <t>
                             The value of "additionalProperties" MUST be a valid JSON Schema.
-                        </t>
-                        <t>
-                            This keyword determines how child instances validate for objects,
-                            and does not directly validate the immediate instance itself.
                         </t>
                         <t>
                             Validation with "additionalProperties" applies only to the child

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -176,7 +176,10 @@
                     that depend on annotation results MUST then be treated as errors, unless
                     an alternate implementation producing the same behavior is available.
                     Keywords of this sort SHOULD describe reasonable alternate approaches
-                    when appropriate.
+                    when appropriate.  This approach is demonstrated by the
+                    "<xref target="additionalItems" format="title"/>" and
+                    "<xref target="additionalProperties" format="title"/>" keywords in this
+                    document.
                 </t>
                 <t>
                     Extension keywords SHOULD stay within these categories, keeping in mind
@@ -1242,8 +1245,8 @@
                 <section title="Keywords for Applying Subschemas to Arrays">
                     <section title="items">
                         <t>
-                            The value of "items" MUST be either a valid JSON Schema or an array of valid
-                            JSON Schemas.
+                            The value of "items" MUST be either a valid JSON Schema or
+                            an array of valid JSON Schemas.
                         </t>
                         <t>
                             If "items" is a schema, validation succeeds if all elements
@@ -1255,26 +1258,52 @@
                             same position, if any.
                         </t>
                         <t>
-                            Omitting this keyword has the same behavior as an empty schema.
+                            This keyword produces an annotation value which is the largest
+                            index to which this keyword applied a subschema.  The value
+                            MAY be a boolean true if a subschema was applied to every
+                            index of the instance, such as when "items" is a schema.
+                        </t>
+                        <t>
+                            Annotation results from multiple "items" keyword are combined
+                            by setting the combined result to true if any of the values
+                            are true, and otherwise retaining the larges numerical value.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty schema.
                         </t>
                     </section>
 
-                    <section title="additionalItems">
+                    <section title="additionalItems" anchor="additionalItems">
                         <t>
                             The value of "additionalItems" MUST be a valid JSON Schema.
                         </t>
                         <t>
-                            If "items" is an array of schemas, validation succeeds
-                            if every instance element at a position greater than the size
-                            of "items" validates against "additionalItems".
+                            The behavior of this keyword depends on the presence and
+                            annotation result of "items" within the same schema object.
+                            If "items" is present, and its annotation result is a number,
+                            validation succeeds if every instance element at an index
+                            greater than that number validates against "additionalItems".
                         </t>
                         <t>
-                            Otherwise, "additionalItems" MUST be ignored, as the "items"
-                            schema (possibly the default value of an empty schema) is
-                            applied to all elements.
+                            Otherwise, if "items" is absent or its annotation result
+                            is the boolean true, "additionalItems" MUST be ignored.
                         </t>
                         <t>
-                            Omitting this keyword has the same behavior as an empty schema.
+                            If the "additionalItems" subschema is applied to any
+                            positions within the instance array, it produces an
+                            annotation result of boolean true, analogous to the
+                            single schema behavior of "items".
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty schema.
+                        </t>
+                        <t>
+                            Implementation MAY choose to implement or optimize this keyword
+                            in another way that produces the same effect, such as by directly
+                            checking for the presence and size of an "items" array.
+                            Implementations that do not support annotation collection MUST do so.
                         </t>
                     </section>
 
@@ -1284,7 +1313,16 @@
                         </t>
                         <t>
                             An array instance is valid against "contains" if at least one of
-                            its elements is valid against the given schema.
+                            its elements is valid against the given schema.  This keyword
+                            does not produce annotation results.
+                            <cref>
+                                Should it produce a set of the indices for which the
+                                array element is valid against the subschema?  "contains"
+                                does not affect "additionalItems" or any other current
+                                or proposed keyword, but the information could be useful,
+                                and implementation that collect annotations need to
+                                apply "contains" to every element anyway.
+                            </cref>
                         </t>
                     </section>
                 </section>
@@ -1302,7 +1340,14 @@
                             corresponding schema.
                         </t>
                         <t>
-                            Omitting this keyword has the same behavior as an empty object.
+                            The annotation result of this keyword is the set of instance
+                            property names matched by this keyword.  Multiple annotation
+                            results for "properties" are combined by taking the union
+                            of the sets.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty object.
                         </t>
                     </section>
 
@@ -1320,25 +1365,47 @@
                             schema that corresponds to a matching regular expression.
                         </t>
                         <t>
-                            Omitting this keyword has the same behavior as an empty object.
+                            The annotation result of this keyword is the set of instance
+                            property names matched by this keyword.  Multiple annotation
+                            results for "patternProperties" are combined by taking the union
+                            of the sets.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty object.
                         </t>
                     </section>
 
-                    <section title="additionalProperties">
+                    <section title="additionalProperties" anchor="additionalProperties">
                         <t>
                             The value of "additionalProperties" MUST be a valid JSON Schema.
                         </t>
                         <t>
+                            The behavior of this keyword depends on the presence and
+                            annotation results of "properties" and "patternProperties"
+                            within the same schema object.
                             Validation with "additionalProperties" applies only to the child
-                            values of instance names that do not match any names in "properties",
-                            and do not match any regular expression in "patternProperties".
+                            values of instance names that do not appear in the annotation
+                            results of either "properties" or "patternProperties".
                         </t>
                         <t>
                             For all such properties, validation succeeds if the child instance
                             validates against the "additionalProperties" schema.
                         </t>
                         <t>
-                            Omitting this keyword has the same behavior as an empty schema.
+                            The annotation result of this keyword is the set of instance
+                            property names validated by this keyword's subschema.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty schema.
+                        </t>
+                        <t>
+                            Implementation MAY choose to implement or optimize this keyword
+                            in another way that produces the same effect, such as by directly
+                            checking the names in "properties" and the patterns in
+                            "patternProperties" against the instance property set.
+                            Implementations that do not support annotation collection MUST do so.
                         </t>
                     </section>
 


### PR DESCRIPTION
## Keywords can depend on subschema or adjacent keyword annotation results

_The base of this PR is PR #595, not the current master_

This is the critical conceptual change that lets us implement #556 `unevaluatedProperties` and #557 `unevaluatedItems`.

There are three commits- two significant one and one mechanical one removing outdated text.  These are grouped together to ensure that a real-world use of the new concepts, with the familiar `additionalProperties` and `additionalItems` keywords, is included with the more abstract changes.

The [first commit](https://github.com/json-schema-org/json-schema-spec/commit/b0c208b378e3f540e215dfe19bf152cf7ecf1062) describes the newly allowed behavior and its implications for all types of keywords.  In particular, this required working out how default keyword behavior works with respect to annotations.

The [second commit](https://github.com/json-schema-org/json-schema-spec/commit/c80954647441fe24289a75e612da7e6b40d39bf5) just removes outdated boilerplate that I meant to remove when I moved the applicators from validation to core.  Now that all applicators are grouped into a vocabulary, we don't need to re-explain that concept on each keyword.

The [third commit](https://github.com/json-schema-org/json-schema-spec/commit/0942a62fc5e585d6754421e9e06e5e65951ea245) reworks the `*item` and `*properties` keywords to use the new approach of depending on annotation behavior.  Implementations are **not** required to code this approach exactly, as the current ways of implementing these keywords are faster (and implementations that do not opt-in to annotation collection still need to support these keywords!)

`items`, `properties`, and `patternProperties` now produce annotation results indicating what indexes / property names they cover, and `additionalItems` and `additionalProperties` now define their behavior in terms of those annotation results.  They, too, produce annotation results about what they cover- those results will be used by `unevaluatedItems` and `unevaluatedProperties`.