### PR TITLE
Allow RFC 4648 encodings for "contentEncoding"

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -10,6 +10,7 @@
 <!ENTITY RFC3987 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3987.xml">
 <!ENTITY RFC4291 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4291.xml">
 <!ENTITY RFC4329 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4329.xml">
+<!ENTITY RFC4648 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4648.xml">
 <!ENTITY RFC5322 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5322.xml">
 <!ENTITY RFC5890 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5890.xml">
 <!ENTITY RFC5891 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5891.xml">
@@ -330,7 +331,7 @@
                     </t>
                 </section>
 
-                <section title="pattern">
+                <section title="pattern" anchor="pattern">
                     <t>
                         The value of this keyword MUST be a string. This string SHOULD be a
                         valid regular expression, according to the ECMA 262 regular expression
@@ -759,8 +760,16 @@
                     If the instance value is a string, this property defines that the string
                     SHOULD be interpreted as binary data and decoded using the encoding
                     named by this property.
-                    <xref target="RFC2045">RFC 2045, Sec 6.1</xref> lists the possible
-                    values for this property.
+                </t>
+
+                <t>
+                    Possible values for this property are listed in
+                    <xref target="RFC2045">RFC 2045, Sec 6.1</xref> and
+                    <xref target="RFC4648">RFC 4548</xref>.  For "base64", which is defined
+                    in both RFCs, the definition in RFC 4648, which removes line length
+                    limitations, SHOULD be used, as various other specifications have
+                    mandated different lengths.  Note that line lengths within a string
+                    can be constrained using the <xref target="pattern">"pattern"</xref> keyword.
                 </t>
 
                 <t>
@@ -991,6 +1000,7 @@
             &RFC3986;
             &RFC3987;
             &RFC4291;
+            &RFC4648;
             &RFC5322;
             &RFC5890;
             &RFC5891;


### PR DESCRIPTION
Addresses #594 

[RFC 4648](https://tools.ietf.org/html/rfc4648) is a more modern standard for encodings, and addresses
ambiguities and application-specific limits of the "base64"
encoding from [RFC 2045](https://tools.ietf.org/html/rfc2045).  It also adds several commonly used
variations, such as "base64url", that are relevant to modern systems.

RFC 2045 values are still allowed, although for "base64", RFC 4648
now takes precedence.