### PR TITLE
Example of $recursiveRoot and $recursiveRef

### DIFF
--- a/hyper-operations.json
+++ b/hyper-operations.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-08/hyper-operations-FAKE#",
+    "$id": "http://json-schema.org/draft-08/hyper-operations-FAKE",
+    "$recursiveRoot": true,
+
+    "title": "FAKE DEMO JSON Hypermedia Operations FOR RECURSION EXAMPLE",
+    "$ref": "http://json-schema.org/draft-08/hyper-schema",
+    "properties": {
+        "base": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "links": {
+            "items": {
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "someKindOfSchema": { "$recursiveRef": "#" }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+%24id}"
+        }
+    ]
+}

--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,58 +1,11 @@
 {
     "$schema": "http://json-schema.org/draft-08/hyper-schema#",
-    "$id": "http://json-schema.org/draft-08/hyper-schema#",
-    "title": "JSON Hyper-Schema",
-    "$defs": {
-        "schemaArray": {
-            "allOf": [
-                { "$ref": "http://json-schema.org/draft-08/schema#/$defs/schemaArray" },
-                {
-                    "items": { "$ref": "#" }
-                }
-            ]
-        }
-    },
-    "allOf": [ { "$ref": "http://json-schema.org/draft-08/schema#" } ],
-    "properties": {
-        "additionalItems": { "$ref": "#" },
-        "additionalProperties": { "$ref": "#"},
-        "dependencies": {
-            "additionalProperties": {
-                "anyOf": [
-                    { "$ref": "#" },
-                    { "type": "array" }
-                ]
-            }
-        },
-        "items": {
-            "anyOf": [
-                { "$ref": "#" },
-                { "$ref": "#/$defs/schemaArray" }
-            ]
-        },
-        "$defs": {
-            "additionalProperties": { "$ref": "#" }
-        },
-        "definitions": {
-            "$comment": "Renamed to $defs, but retained here to ensure compatibility",
-            "additionalProperties": { "$ref": "#" }
-        },
-        "patternProperties": {
-            "additionalProperties": { "$ref": "#" }
-        },
-        "properties": {
-            "additionalProperties": { "$ref": "#" }
-        },
-        "if": {"$ref": "#"},
-        "then": {"$ref": "#"},
-        "else": {"$ref": "#"},
-        "allOf": { "$ref": "#/$defs/schemaArray" },
-        "anyOf": { "$ref": "#/$defs/schemaArray" },
-        "oneOf": { "$ref": "#/$defs/schemaArray" },
-        "not": { "$ref": "#" },
-        "contains": { "$ref": "#" },
-        "propertyNames": { "$ref": "#" },
+    "$id": "http://json-schema.org/draft-08/hyper-schema",
+    "$recursiveRoot": true,
 
+    "title": "JSON Hyper-Schema",
+    "$ref": "http://json-schema.org/draft-08/schema",
+    "properties": {
         "base": {
             "type": "string",
             "format": "uri-template"
@@ -60,7 +13,7 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "http://json-schema.org/draft-08/links#"
+                "$ref": "http://json-schema.org/draft-08/links"
             }
         }
     },

--- a/links.json
+++ b/links.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-08/hyper-schema#",
-    "$id": "http://json-schema.org/draft-08/links#",
+    "$id": "http://json-schema.org/draft-08/links",
     "title": "Link Description Object",
     "allOf": [
         { "required": [ "rel", "href" ] },
@@ -29,7 +29,7 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$recursiveRef": "http://json-schema.org/draft-08/hyper-schema"
                 },
                 "templatePointers": {
                     "type": "object",
@@ -55,21 +55,21 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$recursiveRef": "http://json-schema.org/draft-08/hyper-schema"
                 },
                 "targetMediaType": {
                     "type": "string"
                 },
                 "targetHints": { },
                 "headerSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$recursiveRef": "http://json-schema.org/draft-08/hyper-schema"
                 },
                 "submissionMediaType": {
                     "type": "string",
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$recursiveRef": "http://json-schema.org/draft-08/hyper-schema"
                 },
                 "$comment": {
                     "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -1,12 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-08/schema#",
     "$id": "http://json-schema.org/draft-08/schema#",
+    "$recursiveRoot": true,
+
     "title": "Core schema meta-schema",
     "$defs": {
         "schemaArray": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "#" }
+            "items": { "$recursiveRef": "#" }
         },
         "nonNegativeInteger": {
             "type": "integer",
@@ -55,13 +57,13 @@
         },
         "$defs": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$recursiveRef": "#" },
             "default": {}
         },
         "definitions": {
             "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$recursiveRef": "#" },
             "default": {}
         },
         "title": {
@@ -101,10 +103,10 @@
             "type": "string",
             "format": "regex"
         },
-        "additionalItems": { "$ref": "#" },
+        "additionalItems": { "$recursiveRef": "#" },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
+                { "$recursiveRef": "#" },
                 { "$ref": "#/$defs/schemaArray" }
             ],
             "default": true
@@ -115,32 +117,37 @@
             "type": "boolean",
             "default": false
         },
-        "contains": { "$ref": "#" },
+        "contains": { "$recursiveRef": "#" },
         "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
         "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
         "required": { "$ref": "#/$defs/stringArray" },
-        "additionalProperties": { "$ref": "#" },
+        "additionalProperties": { "$recursiveRef": "#" },
         "properties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$recursiveRef": "#" },
             "default": {}
         },
         "patternProperties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": { "$recursiveRef": "#" },
             "propertyNames": { "format": "regex" },
             "default": {}
         },
         "dependencies": {
             "type": "object",
             "additionalProperties": {
-                "anyOf": [
-                    { "$ref": "#" },
-                    { "$ref": "#/$defs/stringArray" }
-                ]
+                "$recursiveRef": "#"
             }
         },
-        "propertyNames": { "$ref": "#" },
+        "requiredDependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        },
+        "propertyNames": {
+            "additionalProperties": { "$recursiveRef": "#" }
+        },
         "const": true,
         "enum": {
             "type": "array",
@@ -162,13 +169,13 @@
         "format": { "type": "string" },
         "contentMediaType": { "type": "string" },
         "contentEncoding": { "type": "string" },
-        "if": {"$ref": "#"},
-        "then": {"$ref": "#"},
-        "else": {"$ref": "#"},
+        "if": { "$recursiveRef": "#" },
+        "then": { "$recursiveRef": "#" },
+        "else": { "$recursiveRef": "#" },
         "allOf": { "$ref": "#/$defs/schemaArray" },
         "anyOf": { "$ref": "#/$defs/schemaArray" },
         "oneOf": { "$ref": "#/$defs/schemaArray" },
-        "not": { "$ref": "#" }
+        "not": { "$recursiveRef": "#" }
     },
     "default": true
 }

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-08/schema#",
     "$id": "http://json-schema.org/draft-08/schema#",
-    "$recursiveRoot": true,
 
     "title": "Core schema meta-schema",
     "$defs": {


### PR DESCRIPTION
***THIS WILL NOT BE MERGED.***

This PR is being used to ***illustrate*** a proposal for issue #558.

If the root schema of a schema document contains

`"$recursiveRoot": true`

then that root schema is set as the target of all `"$recursiveRef"` references in that document and any to which it refers, regardless of `"$recursiveRef"`'s value.

Encountering further `"$recursiveRoot"` keywords in root schemas of referenced documents does **not** further change the target.  This will be explained in detail with comments added to the diff.

`"$recursiveRoot"` MUST be ignored in subschemas (this is the same behavior as `"$schema"`).

When encountering a `"$recursiveRef"`, if no `"$recursiveRoot": true"` has been encountered, then `"$recursiveRef"` is evaluated exactly as if it were `"$ref"`.  Its value is a URI reference, which is resolved according to the usual rules involving `"$id".

The key point is that someone reading the schema will know that a `"$recursiveRef"` might have its target changed dynamically at runtime, while `"$ref"` never will.

-----------

The following changes were made:

* hyper-schema.json, and the additional _fake_ example of hyper-operations.json (further extending hyper-schema.json) all have `"$recursiveRoot": true`
* schema.json does not use `"$recursiveRoot"`, as it does not extend anything else
* links.json does not use `"$recursiveRoot"`, as it is not recursive
* The reference from each extension meta-schema to its "base" is a _normal_ `"$ref"`.  Otherwise it would be an infinite loop.
* All other schema references become `"$recursiveRef"`, with the same URI Reference value as before
* All of the properties and $defs duplicated from schema.json to hyper-schema.json can now be removed

Note that there were several odd trailing "#" fragments, which should not be present in `"$id"` in particular, so I dropped those.  They are not part of this change I just found them surprising.

Also, "propertyNames" had a bug.  How does nobody notice this stuff?  How do the meta-schemas have an apparently endless stream of bugs in them?  UGH.