### PR TITLE
Clarify $comment and annotations

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -999,7 +999,8 @@
                 schemas is a concern.
 
                 Implementations MUST NOT take any other action based on the presence, absence,
-                or contents of "$comment" properties.
+                or contents of "$comment" properties.  In particular, the value of "$comment"
+                MUST NOT be collected as an annotation result.
             </t>
         </section>
 


### PR DESCRIPTION
"$comment" is not an annotation.  Now that we have the concept of
keyword classifications, this makes the distinction between
"description" (which is an annotation) and "$comment" (which is
not) more clear.