### PR TITLE
Fix default usage in meta-schemas

### DIFF
--- a/links.json
+++ b/links.json
@@ -29,7 +29,8 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#",
+                    "default": false
                 },
                 "templatePointers": {
                     "type": "object",
@@ -55,21 +56,24 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#",
+                    "default": true
                 },
                 "targetMediaType": {
                     "type": "string"
                 },
                 "targetHints": { },
                 "headerSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#",
+                    "default": true
                 },
                 "submissionMediaType": {
                     "type": "string",
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$ref": "http://json-schema.org/draft-08/hyper-schema#"
+                    "$ref": "http://json-schema.org/draft-08/hyper-schema#",
+                    "default": true
                 },
                 "$comment": {
                     "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -106,8 +106,7 @@
             "anyOf": [
                 { "$ref": "#" },
                 { "$ref": "#/$defs/schemaArray" }
-            ],
-            "default": true
+            ]
         },
         "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
         "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
@@ -162,13 +161,12 @@
         "format": { "type": "string" },
         "contentMediaType": { "type": "string" },
         "contentEncoding": { "type": "string" },
-        "if": {"$ref": "#"},
-        "then": {"$ref": "#"},
-        "else": {"$ref": "#"},
+        "if": { "$ref": "#" },
+        "then": { "$ref": "#" },
+        "else": { "$ref": "#" },
         "allOf": { "$ref": "#/$defs/schemaArray" },
         "anyOf": { "$ref": "#/$defs/schemaArray" },
         "oneOf": { "$ref": "#/$defs/schemaArray" },
         "not": { "$ref": "#" }
-    },
-    "default": true
+    }
 }


### PR DESCRIPTION
With default values now having implication for both assertions
and annotation collection (see PR #600 for this), it no longer
makes sense to have a default value for subschemas.

Keywords such as `additionalProperties` now collect annotation
information based on the instance properties to which thier
subschema(s) are applied.  This means that a subschema of true
will cause a property to appear in the annotation, while an
absent subschema will not.  Therefore, a default of true does
not match the annotation collection behavior and is not accurate.

Additionally, as written this has always been problematic, as
it claims a default true value for `not`, which would in fact
cause all schemas without `not` to fail.

-------

However, the Hyper-Schema LDO schema keywords do have
reasonable defaults:

A resource is assumed to provide or accept any structure as its
representation, accept any structure for processing if it does processing
at all, and to allow any header usage.  So targetSchema, submissionSchema,
and headerSchema all default to true.

However, by default, URI templates may not be resolved from input,
so headerSchema defaults to false.