### PR TITLE
Rename "dependencies" to "schemaDependencies"

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -16,7 +16,9 @@
     "properties": {
         "additionalItems": { "$ref": "#" },
         "additionalProperties": { "$ref": "#"},
+        "schemaDependencies": { "$ref": "#" },
         "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"schemaDependencies\" and \"requiredDependencies\"",
             "additionalProperties": {
                 "anyOf": [
                     { "$ref": "#" },

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1099,18 +1099,18 @@
 
                 <section title="Keywords for Applying Subschemas Conditionally" anchor="conditional">
                     <t>
-                        These keywords work together to implement conditional
-                        application of a subschema based on the outcome of
-                        another subschema.
+                        Three of these keywords work together to implement conditional
+                        application of a subschema based on the outcome of another subschema.
+                        The fourth is a shortcut for a specific conditional case.
                     </t>
                     <t>
-                        These keywords MUST NOT interact with each other across
+                        "if", "then", and "else" MUST NOT interact with each other across
                         subschema boundaries.  In other words, an "if" in one
                         branch of an "allOf" MUST NOT have an impact on a "then"
                         or "else" in another branch.
                     </t>
                     <t>
-                        There is no default behavior for any of these keywords
+                        There is no default behavior for "if", "then", or "else"
                         when they are not present.  In particular, they MUST NOT
                         be treated as if present with an empty schema, and when
                         "if" is not present, both "then" and "else" MUST be
@@ -1179,6 +1179,23 @@
                             subschema.  Implementations MUST NOT evaluate
                             the instance against this keyword, for either validation
                             or annotation collection purposes, in such cases.
+                        </t>
+                    </section>
+                    <section title="schemaDependencies">
+                        <t>
+                            This keyword specifies subschemas that are evaluated if the instance
+                            is an object and contains a certain property.
+                        </t>
+                        <t>
+                            This keyword's value MUST be an object.
+                            Each value in the object MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            If the object key is a property in the instance, the entire
+                            instance must validate against the dependency value.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same behavior as an empty object.
                         </t>
                     </section>
                 </section>
@@ -1325,24 +1342,6 @@
                         </t>
                         <t>
                             Omitting this keyword has the same behavior as an empty schema.
-                        </t>
-                    </section>
-
-                    <section title="dependencies">
-                        <t>
-                            This keyword specifies subschemas that are evaluated if the instance
-                            is an object and contains a certain property.
-                        </t>
-                        <t>
-                            This keyword's value MUST be an object.
-                            Each value in the object MUST be a valid JSON Schema.
-                        </t>
-                        <t>
-                            If the object key is a property in the instance, the entire
-                            instance must validate against the dependency value.
-                        </t>
-                        <t>
-                            Omitting this keyword has the same behavior as an empty object.
                         </t>
                     </section>
                 </section>
@@ -1686,6 +1685,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                             <t>Moved "definitions" from the Validation specification here as "$defs"</t>
                             <t>Moved applicator keywords from the Validation specification as their own vocabulary</t>
                             <t>Moved "dependencies" from the Validation specification, but only the schema form</t>
+                            <t>Renamed "dependencies" to "schemaDependencies" to avoid compatibility issues</t>
                         </list>
                     </t>
                     <t hangText="draft-handrews-json-schema-01">

--- a/schema.json
+++ b/schema.json
@@ -131,7 +131,20 @@
             "propertyNames": { "format": "regex" },
             "default": {}
         },
+        "schemaDependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#"
+            }
+        },
+        "requiredDependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        },
         "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"schemaDependencies\" and \"requiredDependencies\"",
             "type": "object",
             "additionalProperties": {
                 "anyOf": [


### PR DESCRIPTION
I also noticed that it was in the wrong section.  As an
in-place conditional applicator, it belongs with "if", "then",
and "else".  Not with the object child applicators.

Apparently, I had not made the meta-schema changes at all.
The "$comment" follows the precedent established from leaving
"definitions" in the meta-schema after the rename to "$defs".