### PR TITLE
DRAFT-06 Fix propertyNames and contains meta-schema

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -95,6 +95,11 @@
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" },
 
+        "contains": { "$ref": "#" },
+        "propertyNames": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" }
+        },
         "base": {
             "description": "URI Template resolved as for the 'href' keyword in the Link Description Object.  The resulting URI Reference is resolved against the current URI base and sets the new URI base for URI references within the instance.",
             "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -122,7 +122,10 @@
                 ]
             }
         },
-        "propertyNames": { "$ref": "#" },
+        "propertyNames": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" }
+        },
         "const": {},
         "enum": {
             "type": "array",


### PR DESCRIPTION
Which has apparently been wrong the whole time.
Also, we apparently forget `contains`.
Also fix minor formatting inconsistencies.