### PR TITLE
Updated Schema.json to force full paterns

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -199,6 +199,13 @@
                     </list>
                 </t>
                 <t>
+                     Validation rules should make sure they validate the complete input.
+                    <list>
+                        <t>Validation rules should begin with "^"</t>
+                        <t>Validation rules should terminate with "$"</t>
+                    </list>
+                </t>
+                <t>
                     Finally, implementations MUST NOT take regular expressions to be
                     anchored, neither at the beginning nor at the end. This means, for instance,
                     the pattern "es" matches "expression".

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -205,6 +205,7 @@
                         <t>Validation rules should terminate with "$"</t>
                     </list>
                 </t>
+                <t>
                     Keywords that use regular expressions, or constrain the instance value
                     to be a regular expression, are subject to the interoperability
                     considerations for regular expressions in the

--- a/schema.json
+++ b/schema.json
@@ -99,7 +99,8 @@
         "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
         "pattern": {
             "type": "string",
-            "format": "regex"
+            "format": "regex",
+            "pattern": "^(\\^(.[^\\$]*)\\$)$"
         },
         "additionalItems": { "$ref": "#" },
         "items": {


### PR DESCRIPTION
As partial pattern matching going against the point of matching a pattern for validation of an input allowing a input to pass validation even though it could end in an incompatible way to the definition.

For Example:
 `"pattern": "([1-9]+[0-9]*)(,\\s{0,1}[1-9][0-9]*)*"` would allow `1,3, fr` because the 1, 3 matches the pattern however because the pattern is not enforcing complete input validation the `, fr` does not break the validation

This pull request implements a fix in the schema to force patterns to start with `^` and end in `$` forcing the pattern to be `"pattern": "^([1-9]+[0-9]*)(,\\s{0,1}[1-9][0-9]*)*$"`