### PR TITLE
Fix entry point URI in example description

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -1551,7 +1551,7 @@ for varname in templateData:
             <section title="Entry Point Links, No Templates" anchor="entryPoint">
                 <t>
                     For this example, we will assume an example API with a documented
-                    entry point URI of https://example.com, which is an empty JSON object
+                    entry point URI of https://api.example.com, which is an empty JSON object
                     with a link to a schema.  Here, the entry point has no data of its
                     own and exists only to provide an initial set of links:
                 </t>


### PR DESCRIPTION
Since the URI in the `GET` is `https://api.example.com`, presumably the text was supposed to be referring to that URI as well.