### PR TITLE
Add "unevaluatedProperties" and "unevaluatedItems"

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1341,7 +1341,12 @@
                     <list>
                         <t>
                             "additionalProperties", whose behavior is defined in terms of
-                            "properties" and "patternProperties"; and
+                            "properties" and "patternProperties"
+                        </t>
+                        <t>
+                            "unevaluatedProperties", whose behavior is defined in terms of
+                            annotations from "properties", "patternProperties",
+                            "additionalProperties" and itself.
                         </t>
                         <t>
                             "additionalItems", whose behavior is defined in terms of "items".
@@ -1350,7 +1355,7 @@
                 </t>
             </section>
 
-            <section title="Keywords for Applying Subschemas in Place">
+            <section title="Keywords for Applying Subschemas in Place" anchor="in-place">
                 <t>
                     These keywords apply subschemas to the same location in the instance
                     as the parent schema is being applied.  They allow combining
@@ -1687,11 +1692,61 @@
                             an empty schema.
                         </t>
                         <t>
-                            Implementation MAY choose to implement or optimize this keyword
+                            Implementations MAY choose to implement or optimize this keyword
                             in another way that produces the same effect, such as by directly
                             checking the names in "properties" and the patterns in
                             "patternProperties" against the instance property set.
                             Implementations that do not support annotation collection MUST do so.
+                        </t>
+                    </section>
+
+                    <section title="unevaluatedProperties" anchor="unevaluatedProperties">
+                        <t>
+                            The value of "unevaluatedProperties" MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            The behavior of this keyword depends on the annotation results of
+                            adjacent keywords that apply to the instance location being validated.
+                            Specifically, the annotations from "properties", "patternProperties",
+                            and "additionalProperties", which can come from those keywords when
+                            they are adjacent to the "unvevaluatedProperties" keyword.  Those
+                            three annotations, as well as "unevaluatedProperties", can also
+                            result from any and all adjacent
+                            <xref target="in-place">in-place applicator</xref> keywords.
+                            This includes but is not limited to the in-place applicators
+                            defined in this document.
+                        </t>
+                        <t>
+                            Validation with "unevaluatedProperties" applies only to the child
+                            values of instance names that do not appear in the "properties",
+                            "patternProperties", "additionalProperties", or
+                            "unevaluatedProperties" annotation results that apply to the
+                            instance location being validated.
+                        </t>
+                        <t>
+                            For all such properties, validation succeeds if the child instance
+                            validates against the "unevaluatedProperties" schema.
+                        </t>
+                        <t>
+                            This means that "properties", "patternProperties", "additionalProperties",
+                            and all in-place applicators MUST be evaluated before this keyword can
+                            be evaluated.  Authors of extension keywords MUST NOT define an in-place
+                            applicator that would need to be evaluated before this keyword.
+                        </t>
+                        <t>
+                            The annotation result of this keyword is the set of instance
+                            property names validated by this keyword's subschema.
+                            Annotation results for "unevaluatedProperties" keywords from
+                            multiple schemas applied to the same instance location are combined
+                            by taking the union of the sets.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty schema.
+                        </t>
+                        <t>
+                            Implementations that do not collect annotations MUST raise an error
+                            upon encountering this keyword.
                         </t>
                     </section>
 

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1346,10 +1346,14 @@
                         <t>
                             "unevaluatedProperties", whose behavior is defined in terms of
                             annotations from "properties", "patternProperties",
-                            "additionalProperties" and itself.
+                            "additionalProperties" and itself
                         </t>
                         <t>
-                            "additionalItems", whose behavior is defined in terms of "items".
+                            "additionalItems", whose behavior is defined in terms of "items"
+                        </t>
+                        <t>
+                            "unevaluatedItems", whose behavior is defined in terms of annotations
+                            from "items", "additionalItems" and itself
                         </t>
                     </list>
                 </t>
@@ -1593,6 +1597,60 @@
                         </t>
                     </section>
 
+                    <section title="unevaluatedItems" anchor="unevaluatedItems">
+                        <t>
+                            The value of "unevaluatedItems" MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            The behavior of this keyword depends on the annotation results of
+                            adjacent keywords that apply to the instance location being validated.
+                            Specifically, the annotations from "items" and  "additionalItems",
+                            which can come from those keywords when they are adjacent to the
+                            "unevaluatedItems" keyword.  Those two annotations, as well as
+                            "unevaluatedItems", can also result from any and all adjacent
+                            <xref target="in-place">in-place applicator</xref> keywords.
+                            This includes but is not limited to the in-place applicators
+                            defined in this document.
+                        </t>
+                        <t>
+                            If an "items" annotation is present, and its annotation result
+                            is a number, and no "additionalItems" or "unevaluatedItems"
+                            annotation is present, then validation succeeds if every instance
+                            element at an index greater than the "items" annotation validates
+                            against "unevaluatedItems".
+                        </t>
+                        <t>
+                            Otherwise, if any "items", "additionalItems", or "unevaluatedItems"
+                            annotations are present with a value of boolean true, then
+                            "unevaluatedItems" MUST be ignored.  However, if none of these
+                            annotations are present, "unevaluatedItems" MUST be applied to
+                            all locations in the array.
+                        </t>
+                        <t>
+                            This means that "items", "additionalItems", and all in-place applicators
+                            MUST be evaluated before this keyword can be evaluated.  Authors of
+                            extension keywords MUST NOT define an in-place applicator that would need
+                            to be evaluated before this keyword.
+                        </t>
+                        <t>
+                            If the "unevaluatedItems" subschema is applied to any
+                            positions within the instance array, it produces an
+                            annotation result of boolean true, analogous to the
+                            single schema behavior of "items".  If any "unevaluatedItems"
+                            keyword from any subschema applied to the same instance
+                            location produces an annotation value of true, then
+                            the combined result from these keywords is also true.
+                        </t>
+                        <t>
+                            Omitting this keyword has the same assertion behavior as
+                            an empty schema.
+                        </t>
+                        <t>
+                            Implementations that do not collect annotations MUST raise an error
+                            upon encountering this keyword.
+                        </t>
+                    </section>
+
                     <section title="contains">
                         <t>
                             The value of this keyword MUST be a valid JSON Schema.
@@ -1709,7 +1767,7 @@
                             adjacent keywords that apply to the instance location being validated.
                             Specifically, the annotations from "properties", "patternProperties",
                             and "additionalProperties", which can come from those keywords when
-                            they are adjacent to the "unvevaluatedProperties" keyword.  Those
+                            they are adjacent to the "unevaluatedProperties" keyword.  Those
                             three annotations, as well as "unevaluatedProperties", can also
                             result from any and all adjacent
                             <xref target="in-place">in-place applicator</xref> keywords.


### PR DESCRIPTION
Address #556 and #557.

The only slightly unusual thing here is that while `additionalItems` only takes effect when `items` is present, due to the more dynamic nature of `unevaluatedItems`, I decided that it could take place whether `items` is present anywhere or not.

I believe the restriction on `additionalItems` is to avoid an ambiguity where you can use either `items` or `additionalItems` to perform the same assertion.  Requiring `additionalItems` to be ignored in the absence of `items` makes the single-schema use of `items` unambiguously the only way to validated every item in an array.

For `unevaluatedItems`, it seems more correct for it to apply even when no array elements have had a schema evaluated against them, rather than requiring that somewhere in the depths of subschemas there must have been an array-form `items`.  I could be persuaded otherwise, but with this approach, the single schema form of `items` becomes a way to unconditionally apply a schema to the enter array, while `unevaluatedItems` has an inherently conditional behavior- it applies to all only if none were already evaluated.

`unevaluatedProperties` has no such ambiguities, and I believe is specified exactly as it has been extensively discussed.