### PR TITLE
Require xml2rfc < 2.10 in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 install:
-- pip install xml2rfc
+- pip install "xml2rfc<2.10"
 before_script:
 - TAG=$(git tag -l --points-at HEAD)
 script:


### PR DESCRIPTION
From version 2.10, option --basename changed its semantics and is now
expected to be a directory, which does not fit our current usage.

Alternatively, we could drop this option altogether (and thus avoid
version pinning) since I'm not sure what this is for.