### PR TITLE
Fix microscopic typo in Core spec

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1916,7 +1916,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
             </t>
             <t>
                 Servers MUST ensure that malicious parties can't change the functionality of
-                existing schemas by uploading a schema with an pre-existing or very similar "$id".
+                existing schemas by uploading a schema with a pre-existing or very similar "$id".
             </t>
             <t>
                 Individual JSON Schema vocabularies are liable to also have their own security


### PR DESCRIPTION
Fix microscopic typo in Core spec.

Change 

```
[...] an pre-existing [...]
``` 

to 

```
[...] a pre-existing [...]
```

References:

* Webster's (very verbose article): https://www.merriam-webster.com/words-at-play/is-it-a-or-an
* Simpler/quicker article by a less known source: https://www.englishclub.com/pronunciation/a-an.htm