### PR TITLE
Mention that enum values may be of any type

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -227,7 +227,7 @@
                         equal to one of the elements in this keyword's array value.
                     </t>
                     <t>
-                        Elements in the array might be of any value, including null.
+                        Elements in the array might be of any type, including null.
                     </t>
                 </section>
 


### PR DESCRIPTION
So question https://stackoverflow.com/questions/53041395/how-to-include-jsonschema-multiple-type-parameter-with-enum highlights an issue where the title of the specification section are required to properly define how an enum is applicable for validation.

In addition, I'm considering if I should open an issue with something along the lines of "Define applicability at start of section for keywords under each section". It should be clear from the title, but that means it's currently omitted from the spec, as far as I can see.

@handrews ?