### PR TITLE
Acknowledge that PUT can create

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -1392,8 +1392,8 @@ for varname in templateData:
                     HTTP methods.  In particular, "targetSchema" suggests what a client
                     application can expect for the response to an HTTP GET or any response
                     for which the "Content-Location" header is equal to the request URI,
-                    and what a client application should send if it replaces the resource
-                    in an HTTP PUT request.
+                    and what a client application should send if it creates or replaces
+                    the resource with an HTTP PUT request.
                     These correlations are defined by <xref target="RFC7231">RFC 7231,
                     section 4.3.1 - "GET", section 4.3.4 "PUT", and section 3.1.4.2,
                     "Content-Location"</xref>.


### PR DESCRIPTION
Addresses the immediate concerns of #581 (paging @davidarnold, my apologies for taking so long to get around to this).

Based on feedback that the current wording, in the context of
all the discussion of POST-to-create-via-collection, can give
the mistaken impression that PUT cannot create.

While we are not responsible for explaining all HTTP semantics,
we can make a bit of an effort here to ensure that we do not
confuse more people.