### PR TITLE
Added Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+version: draft-08.build-{build}
+
+image: Visual Studio 2017
+
+environment:
+  OUTPUT_DIR: output
+  DOCS: jsonschema-core jsonschema-validation jsonschema-hyperschema
+
+cache:
+- '%LOCALAPPDATA%\pip\Cache'
+  
+install:
+- pip install xml2rfc
+
+before_build:
+- ps: if ($Env:APPVEYOR_REPO_TAG_NAME) { $Env:TAG = $Env:APPVEYOR_REPO_TAG_NAME } else { $Env:TAG = "latest" }
+
+build_script:
+- cmd: mkdir %OUTPUT_DIR%
+- cmd: FOR %%x IN (%DOCS%) DO xml2rfc %%x.xml -o %OUTPUT_DIR%\%%x-%TAG%.txt --text
+- cmd: FOR %%x IN (%DOCS%) DO xml2rfc %%x.xml -o %OUTPUT_DIR%\%%x-%TAG%.html --html
+
+artifacts:
+- path: $(OUTPUT_DIR)\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ build_script:
 - cmd: mkdir %OUTPUT_DIR%
 - cmd: FOR %%x IN (%DOCS%) DO xml2rfc %%x.xml -o %OUTPUT_DIR%\%%x-%TAG%.txt --text
 - cmd: FOR %%x IN (%DOCS%) DO xml2rfc %%x.xml -o %OUTPUT_DIR%\%%x-%TAG%.html --html
+- cmd: cd %OUTPUT_DIR% && 7z a -tzip jsonschema-%APPVEYOR_BUILD_VERSION%.zip "*"
 
 artifacts:
 - path: $(OUTPUT_DIR)\*.*


### PR DESCRIPTION
Added an Appveyor CI configuration file that generates the text and HTML outputs from the xml RFCs and packages these outputs as artifacts.

The difference from the current Travis CI is the packaging of artifacts, that can be easily accessed by everybody on the net, making therefore access to the latest draft version easier in human-readable HTML form instead of in "half-human-readable" XML form. E.g., the json-schema web can be updated as shown in this [commit](https://github.com/jgonzalezdr/json-schema-org.github.io/commit/900525d63f15a9087eb067a9213acbd987818749).

The only thing that should be done in the project side is signing in to [Appveyor](https://ci.appveyor.com) using the project's GitHub account and enable monitoring of the json-schema-spec repository (all that can be done in less than 5 minutes).

If this PR is accepted, automatic deploying of official releases in GitHub based on tags and automatic deploying of the latest release as a "latest" pre-release can also be achievable with some additional changes.

I hope you find this interesting, otherwise just close the PR.