### PR TITLE
Clarifying "const" usage.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -243,6 +243,10 @@
                         The value of this keyword MAY be of any type, including null.
                     </t>
                     <t>
+                        Use of this keyword is functionally equivalent to an
+                        <xref target="json-schema">"enum"</xref> with a single value.
+                    </t>
+                    <t>
                         An instance validates successfully against this keyword if its value is
                         equal to the value of the keyword.
                     </t>


### PR DESCRIPTION
It would seem to me that `const` is the same as a single-valued `enum`.  If that's correct, then that should be noted.  If it's not, then the difference should also be noted.