### PR TITLE
Update hostname RFC reference

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
-<!ENTITY RFC1034 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1034.xml">
+<!ENTITY RFC1123 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1123.xml">
 <!ENTITY RFC2045 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2045.xml">
 <!ENTITY RFC2046 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2046.xml">
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
@@ -616,12 +616,12 @@
                         representation for an Internet hostname as follows:
                         <list style="hanging">
                             <t hangText="hostname:">
-                                As defined by <xref target="RFC1034">RFC 1034, section 3.1</xref>,
+                                As defined by <xref target="RFC1123">RFC 1123, section 2.1</xref>,
                                 including host names produced using the Punycode algorithm
                                 specified in <xref target="RFC5891">RFC 5891, section 4.4</xref>.
                             </t>
                             <t hangText="idn-hostname:">
-                                As defined by either RFC 1034 as for hostname, or an
+                                As defined by either RFC 1123 as for hostname, or an
                                 internationalized hostname as defined by
                                 <xref target="RFC5890">RFC 5890, section 2.3.2.3</xref>.
                             </t>
@@ -1056,7 +1056,7 @@
         <!-- References Section -->
         <references title="Normative References">
             &RFC2119;
-            &RFC1034;
+            &RFC1123;
             &RFC2045;
             &RFC2046;
             &RFC2673;


### PR DESCRIPTION
RFC 1123 modifies the syntax to allow a leading digit, which is
present in modern practice.