### PR TITLE
Fix #74: add "deprecated" keyword

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -51,7 +51,7 @@
                 <email>henry@cloudflare.com</email>
             </address>
         </author>
-        
+
         <author fullname="Ben Hutton" initials="B" surname="Hutton" role="editor">
             <organization>Wellcome Sanger Institute</organization>
             <address>
@@ -956,7 +956,7 @@
                 "const": {
                     "typ": "JWT",
                     "alg": "HS256"
-                }   
+                }
             },
             {
                 "type": "object",
@@ -967,7 +967,7 @@
                 }
             }
         ]
-    }   
+    }
 }]]>
                     </artwork>
                     <postamble>
@@ -1025,6 +1025,26 @@
                     This keyword can be used to supply a default JSON value associated with a
                     particular schema. It is RECOMMENDED that a default value be valid against
                     the associated schema.
+                </t>
+            </section>
+
+            <section title='"deprecated"'>
+                <t>
+                    The value of this keyword MUST be a boolean.  When multiple occurrences
+                    of this keyword are applicable to a single sub-instance, the resulting
+                    value MUST be true if any occurrence specifies a true value, and MUST
+                    be false otherwise.
+                </t>
+                <t>
+                    If "deprecated" has a value of boolean true, it indicates that the property
+                    MAY be removed from the document in the future.
+                </t>
+                <t>
+                    An instance document that is marked as "deprecated" for the entire document
+                    means the entire document MAY be removed in the future.
+                </t>
+                <t>
+                    Omitting this keyword has the same behavior as a value of false.
                 </t>
             </section>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1037,12 +1037,12 @@
                 </t>
                 <t>
                     If "deprecated" has a value of boolean true, it indicates that applications
-                    SHOULD refrain from usage of the declared operation. It MAY mean the property
-                    is going to be removed in the futuree.
+                    SHOULD refrain from usage of the declared property. It MAY mean the property
+                    is going to be removed in the future.
                 </t>
                 <t>
-                    An instance document that is marked as "deprecated" for the entire document
-                    means the entire document MAY be removed in the future.
+                    A root schema containing "deprecated" with a value of true indicates the entire
+                    root schema MAY be removed in the future.
                 </t>
                 <t>
                     Omitting this keyword has the same behavior as a value of false.

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1036,8 +1036,9 @@
                     be false otherwise.
                 </t>
                 <t>
-                    If "deprecated" has a value of boolean true, it indicates that the property
-                    MAY be removed from the document in the future.
+                    If "deprecated" has a value of boolean true, it indicates that applications
+                    SHOULD refrain from usage of the declared operation. It MAY mean the property
+                    is going to be removed in the futuree.
                 </t>
                 <t>
                     An instance document that is marked as "deprecated" for the entire document

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -17,6 +17,10 @@
             "type": "string"
         },
         "default": true,
+        "deprecated": {
+            "type": "boolean",
+            "default": false
+        },
         "readOnly": {
             "type": "boolean",
             "default": false


### PR DESCRIPTION
There is often talk about getting OpenAPI in line with JSON Schema, but this is one instance where JSON Schema can be brought in line with OpenAPI, with a new`"deprecated"` keyword.

<img width="909" alt="Screen Shot 2019-05-15 at 14 51 10" src="https://user-images.githubusercontent.com/67381/57776921-f5529680-7720-11e9-856f-cb2678f80327.png">

Just a simple true/false (default false) for this keyword, and it means the thing might be going away sometime. Easy.

**Justification**

There have been talks of all sorts of complex forms of deprecation, including deprecatedSince and deprecateVersion and deprecate*d*Version over on OpenAPI, and this lead to all sorts of confusion for me in what JSON Schema should do.

I have thought through this on and off for months, and it's become clear to me that since JSON Schema currently has no concept of versions or dates or any sort of timeline, there is no reason to start trying to add a whole new dimension just for a deprecated keyword. 

A lot of people want to know  _when_ something was deprecated, and a lot of other people want to know when it will go away. These are two incredibly valid use cases, and they do not need to be handled directly in the spec. 

Let's take the example of API documentation as a use case. If you have API reference documentation up on your website, and you have made a general statement that deprecated things will stick around for 3 months, so you need the data to show when something was deprecated. If you are using evolution then you are marking properties deprecated over time, and when you publish a new version of your specs your documentation hub can notice the addition of the deprecated keyword, and the documentation hubs changelog will have this noticed added in.

Lots of folks are starting to implement changelogs in their docs for OpenAPI, for example my employer [Stoplight.io](http://stoplight.io), a competitor who I've actually forgotten about whilst writing this, and open-source tools like [Azure/openapi-diff](https://github.com/Azure/openapi-diff).

So, it seems like diffing is a good way to see a trail of history for those who are interested, and the future? If you aren't interested in generic statements like "Deprecations will last three months" then you can use runtime solutions like `Deprecated` / `Sunset` HTTP headers to mark whole URLs as deprecated in runtime. 

If anyone is curious, here is how deprecation in general are handled in HTTP APIs using HTTP Sunset as a runtime option, and OpenAPI `deprecated: true`as a build time option, for evolution and deprecation of whole global versions too

https://blog.apisyouwonthate.com/api-evolution-for-rest-http-apis-b4296519e564

Sunset lets you say when an entire URI is going away, but this does not help folks who want to deprecate a single property on a specific day. In my experience deprecation are rarely on the exact day anyway. People flop out a random day, try and pester people to stop using the thing, track the usage, then extend the date because people are still using the darn thing. 

For this reason I don't think we need another property keyword `deprecatedUntil` or `sunsetAt` or future looking date. Put simply, if an application notices as deprecated keyword, warnings should go into bug trackers and the person investigating that bug can try to figure out how long they have to get 
it done, if its a Priority 1 or Trivial.

*Questions*

1. Do we want reason too? GraphQL has this, they do `deprecated(reason: String)`, but this is mostly as they have nowhere lese to put text related to a property. JSON Schema has description and $comment, so maybe it is not so important.

2. Do we want a date? Some folks want one or the other and so some other folks recommend having both, which makes either an object or a bunch of interdependent keywords which would be a pain in the butt. 

_*Note:* I'll improve this PR once I've got xml2rfc installed. Please give feedback on the writing so far, I dont think it needs too many words at it but I might be missing something._
