### PR TITLE
Fix enum definition according to spec.

### DIFF
--- a/meta/validation.json
+++ b/meta/validation.json
@@ -55,9 +55,7 @@
         "const": true,
         "enum": {
             "type": "array",
-            "items": true,
-            "minItems": 1,
-            "uniqueItems": true
+            "items": true
         },
         "type": {
             "anyOf": [


### PR DESCRIPTION
Issue: https://github.com/json-schema-org/json-schema-spec/issues/717

enum no longer requires minimum number of items or unique items, in accordance with the spec.