### PR TITLE
Fix cross-references

### DIFF
--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -188,8 +188,8 @@
                 </t>
                 <t>
                     The terms "applicable" and "attached" are to be interpreted as defined in
-                    <xref target="json-schema-validation">Section 3 of the
-                    JSON Schema validation specification</xref>.
+                    <xref target="json-schema">Section 3.1 of the
+                    JSON Schema core specification</xref>.
                 </t>
                 <t>
                     The terms "link", "link context" (or "context"), "link target" (or "target"),
@@ -329,8 +329,8 @@
         <section title="Schema Keywords">
             <t>
                 Hyper-schema keywords from all schemas that are applicable to a position
-                in an instance, as defined by <xref target="json-schema-validation">Section
-                3 of JSON Schema validation</xref>, can be used with that instance.
+                in an instance, as defined by <xref target="json-schema">Section
+                3.1 of JSON Schema core</xref>, can be used with that instance.
             </t>
             <t>
                 When multiple subschemas are applicable to a given sub-instance, all "link"
@@ -401,8 +401,8 @@
                 <t>
                     In JSON Hyper-Schema, the link's context resource is, by default, the
                     sub-instance to which it is attached (as defined by
-                    <xref target="json-schema-validation">Section 3 of the JSON Schema
-                    validation specification</xref>).  This is often not the entire instance
+                    <xref target="json-schema">Section 3.1 of the JSON Schema
+                    core specification</xref>).  This is often not the entire instance
                     document.  This default context can be changed using the keywords
                     in this section.
                 </t>
@@ -1364,7 +1364,7 @@ for varname in templateData:
                 describing possible HTTP request headers that are relevant to the given resource.
             </t>
             <t>
-                <xref target="json-schema">Section 11 of the JSON Schema core specification</xref>
+                <xref target="json-schema">Section 13 of the JSON Schema core specification</xref>
                 provides guidance on linking instances in a hypermedia system to their schemas.
                 This may be done with network-accessible schemas, or may simply identify schemas
                 which were pre-packaged within the client application.  JSON Hyper-Schema

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -243,7 +243,7 @@
                     </t>
                 </section>
 
-                <section title="enum">
+                <section title="enum" anchor="enum">
                     <t>
                         The value of this keyword MUST be an array. This array SHOULD have at
                         least one element. Elements in the array SHOULD be unique.
@@ -263,7 +263,7 @@
                     </t>
                     <t>
                         Use of this keyword is functionally equivalent to an
-                        <xref target="json-schema">"enum"</xref> with a single value.
+                        <xref target="enum">"enum"</xref> with a single value.
                     </t>
                     <t>
                         An instance validates successfully against this keyword if its value is


### PR DESCRIPTION
Also a reference within the validation spec was accidentally
done as a cross-ref to core, so fixed that as well.

Fixes #721 