### PR TITLE
fixed note about error message wording

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2651,9 +2651,10 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
                             There are only two vertices, but three are required.
                         </t>
                     </list>
-                    Note that neither the error message property nor its wording as depicted in these
-                    examples is not a requirement of this specification.  Implementations SHOULD craft
-                    error messages tailored for their audience.
+                    Note that the error message wording as depicted in these examples is not a
+                    requirement of this specification.  Implementations SHOULD craft error messages
+                    tailored for their audience or provide a templating mechanism that allows their
+                    users to craft their own messages.
                 </t>
 
                 <section title="Flag">


### PR DESCRIPTION
In the first version, I mention that the error message property itself is not a requirement, but in the "output unit" requirements I specify that an error message is required, soooo.....