### PR TITLE
Fixes to dates, author credits, HTTPS

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,21 +1,21 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
-    "$id": "http://json-schema.org/draft/2019-04/hyper-schema",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
+    "$id": "https://json-schema.org/draft/2019-08/hyper-schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/core": true,
-        "https://json-schema.org/draft/2019-04/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-04/vocab/validation": true,
-        "https://json-schema.org/draft/2019-04/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-04/vocab/format": true,
-        "https://json-schema.org/draft/2019-04/vocab/content": true,
-        "https://json-schema.org/draft/2019-04/vocab/hyper-schema": true
+        "https://json-schema.org/draft/2019-08/vocab/core": true,
+        "https://json-schema.org/draft/2019-08/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-08/vocab/validation": true,
+        "https://json-schema.org/draft/2019-08/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-08/vocab/format": true,
+        "https://json-schema.org/draft/2019-08/vocab/content": true,
+        "https://json-schema.org/draft/2019-08/vocab/hyper-schema": true
     },
     "$recursiveAnchor": true,
 
     "title": "JSON Hyper-Schema",
     "allOf": [
-        {"$ref": "http://json-schema.org/draft/2019-04/schema"},
-        {"$ref": "http://json-schema.org/draft/2019-04/meta/hyper-schema"}
+        {"$ref": "https://json-schema.org/draft/2019-08/schema"},
+        {"$ref": "https://json-schema.org/draft/2019-08/meta/hyper-schema"}
     ],
     "links": [
         {

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -87,7 +87,7 @@
                 <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
             </t>
             <t>
-                For additional information, see <eref target="http://json-schema.org/"/>.
+                For additional information, see <eref target="https://json-schema.org/"/>.
             </t>
             <t>
                 To provide feedback, use this issue tracker, the communication methods listed on the
@@ -1036,11 +1036,11 @@
                 </t>
                 <t>
                     The current URI for the Core vocabulary is:
-                    <eref target="https://json-schema.org/draft/2019-04/vocab/core"/>.
+                    <eref target="https://json-schema.org/draft/2019-08/vocab/core"/>.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
-                    <eref target="https://json-schema.org/draft/2019-04/meta/core"/>.
+                    <eref target="https://json-schema.org/draft/2019-08/meta/core"/>.
                 </t>
                 <t>
                     Updated vocabulary and meta-schema URIs MAY be published between
@@ -1066,16 +1066,16 @@
                     <artwork>
 <![CDATA[
 {
-  "$schema": "https://json-schema.org/draft/2019-04/core-app-example#",
-  "$id": "https://json-schema.org/draft/2019-04/core-app-example",
+  "$schema": "https://json-schema.org/draft/2019-08/core-app-example#",
+  "$id": "https://json-schema.org/draft/2019-08/core-app-example",
   "$recursiveAnchor": true,
   "$vocabulary": {
-    "https://json-schema.org/draft/2019-04/vocab/core": true,
-    "https://json-schema.org/draft/2019-04/vocab/applicator": true
+    "https://json-schema.org/draft/2019-08/vocab/core": true,
+    "https://json-schema.org/draft/2019-08/vocab/applicator": true
   },
   "allOf": [
-    {"$ref": "https://json-schema.org/draft/2019-04/meta/core"},
-    {"$ref": "https://json-schema.org/draft/2019-04/meta/applicator"}
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/core"},
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/applicator"}
   ],
   "patternProperties": {
     "^unevaluated.*$": false
@@ -1211,7 +1211,7 @@
                         <artwork>
 <![CDATA[
 {
-    "$id": "http://example.com/root.json",
+    "$id": "https://example.com/root.json",
     "$defs": {
         "A": { "$id": "#foo" },
         "B": {
@@ -1239,43 +1239,43 @@
                         <list style="hanging">
                             <t hangText="# (document root)">
                                 <list>
-                                    <t>http://example.com/root.json</t>
-                                    <t>http://example.com/root.json#</t>
+                                    <t>https://example.com/root.json</t>
+                                    <t>https://example.com/root.json#</t>
                                 </list>
                             </t>
                             <t hangText="#/$defs/A">
                                 <list>
-                                    <t>http://example.com/root.json#foo</t>
-                                    <t>http://example.com/root.json#/$defs/A</t>
+                                    <t>https://example.com/root.json#foo</t>
+                                    <t>https://example.com/root.json#/$defs/A</t>
                                 </list>
                             </t>
                             <t hangText="#/$defs/B">
                                 <list>
-                                    <t>http://example.com/other.json</t>
-                                    <t>http://example.com/other.json#</t>
-                                    <t>http://example.com/root.json#/$defs/B</t>
+                                    <t>https://example.com/other.json</t>
+                                    <t>https://example.com/other.json#</t>
+                                    <t>https://example.com/root.json#/$defs/B</t>
                                 </list>
                             </t>
                             <t hangText="#/$defs/B/$defs/X">
                                 <list>
-                                    <t>http://example.com/other.json#bar</t>
-                                    <t>http://example.com/other.json#/$defs/X</t>
-                                    <t>http://example.com/root.json#/$defs/B/$defs/X</t>
+                                    <t>https://example.com/other.json#bar</t>
+                                    <t>https://example.com/other.json#/$defs/X</t>
+                                    <t>https://example.com/root.json#/$defs/B/$defs/X</t>
                                 </list>
                             </t>
                             <t hangText="#/$defs/B/$defs/Y">
                                 <list>
-                                    <t>http://example.com/t/inner.json</t>
-                                    <t>http://example.com/t/inner.json#</t>
-                                    <t>http://example.com/other.json#/$defs/Y</t>
-                                    <t>http://example.com/root.json#/$defs/B/$defs/Y</t>
+                                    <t>https://example.com/t/inner.json</t>
+                                    <t>https://example.com/t/inner.json#</t>
+                                    <t>https://example.com/other.json#/$defs/Y</t>
+                                    <t>https://example.com/root.json#/$defs/B/$defs/Y</t>
                                 </list>
                             </t>
                             <t hangText="#/$defs/C">
                                 <list>
                                     <t>urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f</t>
                                     <t>urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#</t>
-                                    <t>http://example.com/root.json#/$defs/C</t>
+                                    <t>https://example.com/root.json#/$defs/C</t>
                                 </list>
                             </t>
                         </list>
@@ -1342,7 +1342,7 @@
                         <artwork>
 <![CDATA[
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
     "$id": "https://example.com/original",
 
     "properties": {
@@ -1356,7 +1356,7 @@
 }
 
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
     "$id": "https://example.com/extension",
 
     "$ref": "original",
@@ -1455,7 +1455,7 @@
                             <artwork>
 <![CDATA[
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
     "$id": "https://example.com/original",
     "$recursiveAnchor": true,
 
@@ -1470,7 +1470,7 @@
 }
 
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
     "$id": "https://example.com/extension",
     "$recursiveAnchor": true,
 
@@ -1611,7 +1611,7 @@
                         <artwork>
 <![CDATA[
 {
-    "$id": "http://example.net/root.json",
+    "$id": "https://example.net/root.json",
     "items": {
         "type": "array",
         "items": { "$ref": "#item" }
@@ -1630,17 +1630,17 @@
                     <t>
                         When an implementation encounters the &lt;#/$defs/single&gt; schema,
                         it resolves the "$id" URI reference against the current base URI to form
-                        &lt;http://example.net/root.json#item&gt;.
+                        &lt;https://example.net/root.json#item&gt;.
                     </t>
                     <t>
                         When an implementation then looks inside the &lt;#/items&gt; schema, it
                         encounters the &lt;#item&gt; reference, and resolves this to
-                        &lt;http://example.net/root.json#item&gt;, which it has seen defined in
+                        &lt;https://example.net/root.json#item&gt;, which it has seen defined in
                         this same document and can therefore use automatically.
                     </t>
                     <t>
                         When an implementation encounters the reference to "other.json", it resolves
-                        this to &lt;http://example.net/other.json&gt;, which is not defined in this
+                        this to &lt;https://example.net/other.json&gt;, which is not defined in this
                         document.  If a schema with that identifier has otherwise been supplied to
                         the implementation, it can also be used automatically.
                         <cref>
@@ -1912,11 +1912,11 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Applicator vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-04/vocab/applicator"/>.
+                <eref target="https://json-schema.org/draft/2019-08/vocab/applicator"/>.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
-                <eref target="https://json-schema.org/draft/2019-04/meta/applicator"/>.
+                <eref target="https://json-schema.org/draft/2019-08/meta/applicator"/>.
             </t>
             <t>
                 Updated vocabulary and meta-schema URIs MAY be published between
@@ -2511,7 +2511,7 @@
                     <figure>
                         <artwork>
 <![CDATA[
-http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
+https://json-schema.org/draft/2019-08/schema#/$defs/nonNegativeInteger/minimum
 ]]>
                         </artwork>
                     </figure>
@@ -2586,8 +2586,8 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
                     <artwork>
 <![CDATA[
 {
-  "$id": "http://example.com/polygon#",
-  "$schema": "http://json-schema.org/draft/2019-04/schema#",
+  "$id": "https://example.com/polygon#",
+  "$schema": "https://json-schema.org/draft/2019-08/schema#",
   "$defs": {
     "point": {
       "type": "object",
@@ -2682,21 +2682,21 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
     {
       "keywordLocation": "#/items/$ref",
       "absoluteKeywordLocation":
-        "http://example.com/polygon#/$defs/point",
+        "https://example.com/polygon#/$defs/point",
       "instanceLocation": "#/1",
       "error": "A subschema had errors."
     },
     {
       "keywordLocation": "#/items/$ref/required",
       "absoluteKeywordLocation":
-        "http://example.com/polygon#/$defs/point/required",
+        "https://example.com/polygon#/$defs/point/required",
       "instanceLocation": "#/1",
       "error": "Required property 'y' not found."
     },
     {
       "keywordLocation": "#/items/$ref/additionalProperties",
       "absoluteKeywordLocation":
-        "http://example.com/polygon#/$defs/point/additionalProperties",
+        "https://example.com/polygon#/$defs/point/additionalProperties",
       "instanceLocation": "#/1/z",
       "error": "Additional property 'z' found but was invalid."
     },
@@ -2749,14 +2749,14 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
       "valid": false,
       "keywordLocation": "#/items/$ref",
       "absoluteKeywordLocation":
-        "http://example.com/polygon#/$defs/point",
+        "https://example.com/polygon#/$defs/point",
       "instanceLocation": "#/1",
       "errors": [
         {
           "valid": false,
           "keywordLocation": "#/items/$ref/required",
           "absoluteKeywordLocation":
-            "http://example.com/polygon#/$defs/point/required",
+            "https://example.com/polygon#/$defs/point/required",
           "instanceLocation": "#/1",
           "error": "Required property 'y' not found."
         },
@@ -2764,7 +2764,7 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
           "valid": false,
           "keywordLocation": "#/items/$ref/additionalProperties",
           "absoluteKeywordLocation":
-            "http://example.com/polygon#/$defs/point/additionalProperties",
+            "https://example.com/polygon#/$defs/point/additionalProperties",
           "instanceLocation": "#/1/z",
           "error": "Additional property 'z' found but was invalid."
         }
@@ -2800,15 +2800,15 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
                     <t>
                         Because this output structure can be quite large, a smaller example is given
                         here for brevity.  The URI of the full output structure of the example above is:
-                        <eref target="https://json-schema.org/draft/2019-04/output/verbose-example"/>.
+                        <eref target="https://json-schema.org/draft/2019-08/output/verbose-example"/>.
                     </t>
                     <figure>
                         <artwork>
 <![CDATA[
 // schema
 {
-  "$id": "http://example.com/polygon#",
-  "$schema": "http://json-schema.org/draft/2019-04/schema#",
+  "$id": "https://example.com/polygon#",
+  "$schema": "https://json-schema.org/draft/2019-08/schema#",
   "type": "object",
   "properties": {
     "validProp": true,
@@ -2862,7 +2862,7 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
                     <t>
                         For convenience, JSON Schema has been provided to validate output generated
                         by implementations.  Its URI is:
-                        <eref target="https://json-schema.org/draft/2019-04/output/schema"/>.
+                        <eref target="https://json-schema.org/draft/2019-08/output/schema"/>.
                     </t>
                 </section>
 
@@ -2894,7 +2894,7 @@ http://json-schema.org/draft/2019-04/schema#/$defs/nonNegativeInteger/minimum
                 <figure>
                     <artwork>
 <![CDATA[
-Link: <http://example.com/my-hyper-schema#>; rel="describedby"
+Link: <https://example.com/my-hyper-schema#>; rel="describedby"
 ]]>
                     </artwork>
                 </figure>
@@ -2940,7 +2940,7 @@ Link: <http://example.com/my-hyper-schema#>; rel="describedby"
                     <artwork>
 <![CDATA[
 Content-Type: application/json;
-          schema="http://example.com/my-hyper-schema#"
+          schema="https://example.com/my-hyper-schema#"
 ]]>
                     </artwork>
                 </figure>
@@ -2954,7 +2954,7 @@ Content-Type: application/json;
                     <artwork>
 <![CDATA[
 Content-Type: application/json;
-          schema="http://example.com/alice http://example.com/bob"
+          schema="https://example.com/alice https://example.com/bob"
 ]]>
                     </artwork>
                 </figure>
@@ -2967,9 +2967,9 @@ Content-Type: application/json;
                     <artwork>
 <![CDATA[
 Accept: application/json;
-          schema="http://example.com/qiang http://example.com/li",
+          schema="https://example.com/qiang https://example.com/li",
         application/json;
-          schema="http://example.com/kumar"
+          schema="https://example.com/kumar"
 ]]>
                     </artwork>
                 </figure>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -30,15 +30,8 @@
         </author>
 
         <author fullname="Henry Andrews" initials="H" surname="Andrews" role="editor">
-            <organization>Riverbed Technology</organization>
             <address>
-                <postal>
-                    <street>680 Folsom St.</street>
-                    <city>San Francisco</city>
-                    <region>CA</region>
-                    <country>USA</country>
-                </postal>
-                <email>handrews@riverbed.com</email>
+                <email>andrews_henry@yahoo.com</email>
             </address>
         </author>
 

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -31,15 +31,8 @@
         </title>
 
         <author fullname="Henry Andrews" initials="H" surname="Andrews" role="editor">
-            <organization>Riverbed Technology</organization>
             <address>
-                <postal>
-                    <street>680 Folsom St.</street>
-                    <city>San Francisco</city>
-                    <region>CA</region>
-                    <country>USA</country>
-                </postal>
-                <email>handrews@riverbed.com</email>
+                <email>andrews_henry@yahoo.com</email>
             </address>
         </author>
 

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -77,7 +77,7 @@
             </t>
             <t>
                 For additional information, see
-                <eref target="http://json-schema.org/"/>.
+                <eref target="https://json-schema.org/"/>.
             </t>
             <t>
                 To provide feedback, use this issue tracker, the communication methods listed on the
@@ -289,24 +289,24 @@
         <section title="Meta-Schemas and Output Schema">
             <t>
                 The current URI for the JSON Hyper-Schema meta-schema is
-                <eref target="http://json-schema.org/draft/2019-04/hyper-schema#"/>.
+                <eref target="https://json-schema.org/draft/2019-08/hyper-schema#"/>.
             </t>
             <t>
                 The current URI for this vocabulary, known as the Hyper-Schema vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-04/vocab/hyper-schema"/>.
+                <eref target="https://json-schema.org/draft/2019-08/vocab/hyper-schema"/>.
             </t>
             <t>
                 The current URI for the corresponding meta-schema, which differs from the
                 convenience meta-schema above in that it describes only the hyper-schema
                 keywords ("base" and "link") is:
-                <eref target="https://json-schema.org/draft/2019-04/meta/hyper-schema"/>.
+                <eref target="https://json-schema.org/draft/2019-08/meta/hyper-schema"/>.
             </t>
             <t>
                 The <xref target="ldo">link description format</xref> can be used without JSON
                 Schema, and use of this format can be declared by referencing the normative
                 link description schema as the schema for the data structure that uses the links.
                 The URI of the normative link description schema is:
-                <eref target="http://json-schema.org/draft/2019-04/links#"/>.
+                <eref target="https://json-schema.org/draft/2019-08/links#"/>.
             </t>
             <t>
                 JSON Hyper-Schema implementations are free to provide output in any format.
@@ -317,7 +317,7 @@
                 It is RECOMMENDED that implementations be capable of producing output
                 in this format to facilitated testing.  The URI of the JSON Schema
                 describing the recommended output format is
-                <eref target="http://json-schema.org/draft/2019-04/output/hyper-schema#"/>.
+                <eref target="https://json-schema.org/draft/2019-08/output/hyper-schema#"/>.
             </t>
             <t>
                 Updated vocabulary and meta-schema URIs MAY be published between
@@ -1625,7 +1625,7 @@ Link: <https://schema.example.com/entry>; rel="describedBy"
 <![CDATA[
 {
     "$id": "https://schema.example.com/entry",
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
     "base": "https://example.com/api/",
     "links": [
         {
@@ -1699,7 +1699,7 @@ Link: <https://schema.example.com/entry>; rel="describedBy"
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/thing",
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
     "base": "https://example.com/api/",
     "type": "object",
     "required": ["data"],
@@ -1815,7 +1815,7 @@ Link: <https://schema.example.com/entry>; rel="describedBy"
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/interesting-stuff",
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
     "required": ["stuffWorthEmailingAbout", "email", "title"],
     "properties": {
         "title": {
@@ -2002,7 +2002,7 @@ Link: <https://example.com/api/trees/1/nodes/456>; rev="up"
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/tree-node",
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
     "base": "trees/{treeId}/",
     "properties": {
         "id": {"type": "integer"},
@@ -2064,7 +2064,7 @@ Link: <https://example.com/api/trees/1/nodes/456>; rev="up"
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/thing",
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
     "base": "https://example.com/api/",
     "type": "object",
     "required": ["data"],
@@ -2117,7 +2117,7 @@ Link: <https://example.com/api/trees/1/nodes/456>; rev="up"
                     <artwork>
 <![CDATA[{
     "$id": "https://schema.example.com/thing-collection",
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
     "base": "https://example.com/api/",
     "type": "object",
     "required": ["elements"],

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -94,7 +94,7 @@
                 <eref target="https://github.com/json-schema-org/json-schema-spec/issues"/>.
             </t>
             <t>
-                For additional information, see <eref target="http://json-schema.org/"/>.
+                For additional information, see <eref target="https://json-schema.org/"/>.
             </t>
             <t>
                 To provide feedback, use this issue tracker, the communication methods listed on the
@@ -195,7 +195,7 @@
         <section title="Meta-Schema">
             <t>
                 The current URI for the JSON Schema Validation meta-schema is
-                <eref target="http://json-schema.org/draft/2019-04/schenma#"/>.
+                <eref target="https://json-schema.org/draft/2019-08/schenma#"/>.
                 For schema author convenience, this meta-schema describes all vocabularies
                 defined in this specification and the JSON Schema Core specification.
                 Individual vocabulary and vocabulary meta-schema URIs are given for
@@ -221,11 +221,11 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Validation vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-04/vocab/validation"/>.
+                <eref target="https://json-schema.org/draft/2019-08/vocab/validation"/>.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
-                <eref target="https://json-schema.org/draft/2019-04/meta/validation"/>.
+                <eref target="https://json-schema.org/draft/2019-08/meta/validation"/>.
             </t>
 
             <section title="Validation Keywords for Any Instance Type" anchor="general">
@@ -546,11 +546,11 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Format vocabulary, is:
-                    <eref target="https://json-schema.org/draft/2019-04/vocab/format"/>.
+                    <eref target="https://json-schema.org/draft/2019-08/vocab/format"/>.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
-                    <eref target="https://json-schema.org/draft/2019-04/meta/format"/>.
+                    <eref target="https://json-schema.org/draft/2019-08/meta/format"/>.
                 </t>
 
             </section>
@@ -809,11 +809,11 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Content vocabulary, is:
-                    <eref target="https://json-schema.org/draft/2019-04/vocab/content"/>.
+                    <eref target="https://json-schema.org/draft/2019-08/vocab/content"/>.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
-                    <eref target="https://json-schema.org/draft/2019-04/meta/content"/>.
+                    <eref target="https://json-schema.org/draft/2019-08/meta/content"/>.
                 </t>
             </section>
 
@@ -998,11 +998,11 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Meta-Data vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-04/vocab/meta-data"/>.
+                <eref target="https://json-schema.org/draft/2019-08/vocab/meta-data"/>.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
-                <eref target="https://json-schema.org/draft/2019-04/meta/meta-data"/>.
+                <eref target="https://json-schema.org/draft/2019-08/meta/meta-data"/>.
             </t>
 
             <section title='"title" and "description"'>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -54,17 +54,6 @@
             </address>
         </author>
 
-        <author fullname="Geraint Luff" initials="G" surname="Luff">
-            <address>
-                <postal>
-                    <street></street>
-                    <city>Cambridge</city>
-                    <country>UK</country>
-                </postal>
-                <email>luffgd@gmail.com</email>
-            </address>
-        </author>
-
         <date year="2019"/>
         <workgroup>Internet Engineering Task Force</workgroup>
         <keyword>JSON</keyword>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -41,15 +41,8 @@
         </author>
 
         <author fullname="Henry Andrews" initials="H" surname="Andrews" role="editor">
-            <organization>Riverbed Technology</organization>
             <address>
-                <postal>
-                    <street>680 Folsom St.</street>
-                    <city>San Francisco</city>
-                    <region>CA</region>
-                    <country>USA</country>
-                </postal>
-                <email>handrews@riverbed.com</email>
+                <email>andrews_henry@yahoo.com</email>
             </address>
         </author>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -195,7 +195,7 @@
         <section title="Meta-Schema">
             <t>
                 The current URI for the JSON Schema Validation meta-schema is
-                <eref target="https://json-schema.org/draft/2019-08/schenma#"/>.
+                <eref target="http://json-schema.org/draft/2019-08/schema#"/>.
                 For schema author convenience, this meta-schema describes all vocabularies
                 defined in this specification and the JSON Schema Core specification.
                 Individual vocabulary and vocabulary meta-schema URIs are given for

--- a/links.json
+++ b/links.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
-    "$id": "http://json-schema.org/draft/2019-04/links",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
+    "$id": "https://json-schema.org/draft/2019-08/links",
     "title": "Link Description Object",
     "allOf": [
         { "required": [ "rel", "href" ] },
@@ -36,7 +36,7 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "https://json-schema.org/draft/2019-08/hyper-schema",
                     "default": false
                 },
                 "templatePointers": {
@@ -63,7 +63,7 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "https://json-schema.org/draft/2019-08/hyper-schema",
                     "default": true
                 },
                 "targetMediaType": {
@@ -71,7 +71,7 @@
                 },
                 "targetHints": { },
                 "headerSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "https://json-schema.org/draft/2019-08/hyper-schema",
                     "default": true
                 },
                 "submissionMediaType": {
@@ -79,7 +79,7 @@
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$recursiveRef": "http://json-schema.org/draft/2019-04/hyper-schema",
+                    "$recursiveRef": "https://json-schema.org/draft/2019-08/hyper-schema",
                     "default": true
                 },
                 "$comment": {

--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "https://json-schema.org/draft/2019-04/meta/applicator",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/applicator",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/applicator": true
+        "https://json-schema.org/draft/2019-08/vocab/applicator": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/content.json
+++ b/meta/content.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/content",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/content",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/content": true
+        "https://json-schema.org/draft/2019-08/vocab/content": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/core.json
+++ b/meta/core.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "https://json-schema.org/draft/2019-04/meta/core",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/core",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/core": true
+        "https://json-schema.org/draft/2019-08/vocab/core": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/format.json
+++ b/meta/format.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/format",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/format",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/format": true
+        "https://json-schema.org/draft/2019-08/vocab/format": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/hyper-schema.json
+++ b/meta/hyper-schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/hyper-schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/hyper-schema",
+    "$schema": "https://json-schema.org/draft/2019-08/hyper-schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/hyper-schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/hyper-schema": true
+        "https://json-schema.org/draft/2019-08/vocab/hyper-schema": true
     },
     "$recursiveAnchor": true,
 
@@ -16,7 +16,7 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "http://json-schema.org/draft/2019-04/links"
+                "$ref": "https://json-schema.org/draft/2019-08/links"
             }
         }
     },

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/meta-data",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/meta-data",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/meta-data": true
+        "https://json-schema.org/draft/2019-08/vocab/meta-data": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/meta/validation",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/meta/validation",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/validation": true
+        "https://json-schema.org/draft/2019-08/vocab/validation": true
     },
     "$recursiveAnchor": true,
 

--- a/output/hyper-schema.json
+++ b/output/hyper-schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/output/hyper-schema",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/output/hyper-schema",
     "title": "JSON Hyper-Schema Output",
     "type": "array",
     "items": {
         "allOf": [
-            {"$ref": "http://json-schema.org/draft/2019-04/links#/$defs/noRequiredFields" }
+            {"$ref": "https://json-schema.org/draft/2019-08/links#/$defs/noRequiredFields" }
         ],
         "type": "object",
         "required": [

--- a/output/schema.json
+++ b/output/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft/2019-04/schema#",
-  "$id": "http://json-schema.org/draft/2019-04/output/schema",
+  "$schema": "https://json-schema.org/draft/2019-08/schema#",
+  "$id": "https://json-schema.org/draft/2019-08/output/schema",
   "description": "A schema that validates the minimum requirements for validation output",
 
   "oneOf": [

--- a/output/verbose-example.json
+++ b/output/verbose-example.json
@@ -22,42 +22,42 @@
           "valid": true,
           "keywordLocation": "#/items/$ref",
           "absoluteKeywordLocation":
-            "http://example.com/polygon#/items/$ref",
+            "https://example.com/polygon#/items/$ref",
           "instanceLocation": "#/0",
           "annotations": [
             {
               "valid": true,
               "keywordLocation": "#/items/$ref",
               "absoluteKeywordLocation":
-                "http://example.com/polygon#/definitions/point",
+                "https://example.com/polygon#/definitions/point",
               "instanceLocation": "#/0",
               "annotations": [
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/type",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/type",
+                    "https://example.com/polygon#/definitions/point/type",
                   "instanceLocation": "#/0"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/properties",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/properties",
+                    "https://example.com/polygon#/definitions/point/properties",
                   "instanceLocation": "#/0"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/required",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/required",
+                    "https://example.com/polygon#/definitions/point/required",
                   "instanceLocation": "#/0"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/additionalProperties",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/additionalProperties",
+                    "https://example.com/polygon#/definitions/point/additionalProperties",
                   "instanceLocation": "#/0"
                 }
               ]
@@ -68,49 +68,49 @@
           "valid": false,
           "keywordLocation": "#/items/$ref",
           "absoluteKeywordLocation":
-            "http://example.com/polygon#/items/$ref",
+            "https://example.com/polygon#/items/$ref",
           "instanceLocation": "#/1",
           "errors": [
             {
               "valid": false,
               "keywordLocation": "#/items/$ref",
               "absoluteKeywordLocation":
-                "http://example.com/polygon#/definitions/point",
+                "https://example.com/polygon#/definitions/point",
               "instanceLocation": "#/1",
               "errors": [
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/type",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/type",
+                    "https://example.com/polygon#/definitions/point/type",
                   "instanceLocation": "#/1"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/properties",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/properties",
+                    "https://example.com/polygon#/definitions/point/properties",
                   "instanceLocation": "#/1"
                 },
                 {
                   "valid": false,
                   "keywordLocation": "#/items/$ref/required",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/required",
+                    "https://example.com/polygon#/definitions/point/required",
                   "instanceLocation": "#/1"
                 },
                 {
                   "valid": false,
                   "keywordLocation": "#/items/$ref/additionalProperties",
                   "absoluteKeywordLocation":
-                    "http://example.com/polygon#/definitions/point/additionalProperties",
+                    "https://example.com/polygon#/definitions/point/additionalProperties",
                   "instanceLocation": "#/1",
                   "errors": [
                     {
                       "valid": false,
                       "keywordLocation": "#/items/$ref/additionalProperties",
                       "absoluteKeywordLocation":
-                        "http://example.com/polygon#/definitions/point/additionalProperties",
+                        "https://example.com/polygon#/definitions/point/additionalProperties",
                       "instanceLocation": "#/1/z"
                     }
                   ]

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -28,15 +28,8 @@
         </author>
 
         <author fullname="Henry Andrews" initials="H" surname="Andrews" role="editor">
-            <organization>Riverbed Technology</organization>
             <address>
-                <postal>
-                    <street>680 Folsom St.</street>
-                    <city>San Francisco</city>
-                    <region>CA</region>
-                    <country>USA</country>
-                </postal>
-                <email>handrews@riverbed.com</email>
+                <email>andrews_henry@yahoo.com</email>
             </address>
         </author>
 

--- a/schema.json
+++ b/schema.json
@@ -1,13 +1,13 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-04/schema#",
-    "$id": "http://json-schema.org/draft/2019-04/schema#",
+    "$schema": "https://json-schema.org/draft/2019-08/schema#",
+    "$id": "https://json-schema.org/draft/2019-08/schema#",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-04/vocab/core": true,
-        "https://json-schema.org/draft/2019-04/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-04/vocab/validation": true,
-        "https://json-schema.org/draft/2019-04/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-04/vocab/format": true,
-        "https://json-schema.org/draft/2019-04/vocab/content": true
+        "https://json-schema.org/draft/2019-08/vocab/core": true,
+        "https://json-schema.org/draft/2019-08/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-08/vocab/validation": true,
+        "https://json-schema.org/draft/2019-08/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-08/vocab/format": true,
+        "https://json-schema.org/draft/2019-08/vocab/content": true
     },
     "$recursiveAnchor": true,
 


### PR DESCRIPTION
The first commit changes all of the meta-schema and vocabulary dates to `2019-08`.  I'm pretty sure we're not publishing this within the next week, and if we do we can always reset them to 2019-07.  I'm working on things as quickly as I can.

It also makes everything `https://` including examples.  I could be convinced to change the examples back, but I think we'd already agreed to to HTTPS but just hadn't changed it consistently (it was really random).

The next commit fixes a typo in a meta-schema URI.

The third commit removes Riverbed from my credit and changes my email since I no longer work there.

The final commit removes G. Luff from the co-author list of the validation spec because he appeared to have been added by error in draft-wright-...-00 (copy-paste from hyper-schema, I think).  He was not credited on the previous validation spec, and @awwright confirmed that he was not involved in the wright-00 effort.  He is still thanked in the acknowledgements with the other past major contributors to the project.