### PR TITLE
Give ECMA 262 reference section for RegExp dialect.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -552,8 +552,8 @@
                 <t>
                     Keywords MAY use regular expressions to express constraints, or constrain
                     the instance value to be a regular expression.
-                     These regular expressions SHOULD be valid according to the
-                    <xref target="ecma262">ECMA 262</xref> regular expression dialect.
+                    These regular expressions SHOULD be valid according to the regular expression
+                    dialect described in <xref target="ecma262">ECMA 262, section 15.10.1</xref>.
                 </t>
                 <t>
                     Furthermore, given the high disparity in regular expression constructs support,


### PR DESCRIPTION
Fixes #774 .  Note that I found a better reference, [section 15.10.1](https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1), than I mentioned in the quote in the issue.

This does not change any behavior, it just ensures that no one thinks we meant the RegExp literal syntax.  Something resembling a RegExp grammar is given in three different places (the RegExp literal section, the actual normative pattern definition in 15.10.1, and an informative definition in A.7), so it's a little confusing to the casual spec reader without a section reference.