### PR TITLE
Fix verbose example to use `$defs`

### DIFF
--- a/output/verbose-example.json
+++ b/output/verbose-example.json
@@ -5,7 +5,7 @@
   "errors": [
     {
       "valid": true,
-      "keywordLocation": "#/definitions",
+      "keywordLocation": "#/$defs",
       "instanceLocation": "#"
     },
     {
@@ -29,35 +29,35 @@
               "valid": true,
               "keywordLocation": "#/items/$ref",
               "absoluteKeywordLocation":
-                "https://example.com/polygon#/definitions/point",
+                "https://example.com/polygon#/$defs/point",
               "instanceLocation": "#/0",
               "annotations": [
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/type",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/type",
+                    "https://example.com/polygon#/$defs/point/type",
                   "instanceLocation": "#/0"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/properties",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/properties",
+                    "https://example.com/polygon#/$defs/point/properties",
                   "instanceLocation": "#/0"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/required",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/required",
+                    "https://example.com/polygon#/$defs/point/required",
                   "instanceLocation": "#/0"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/additionalProperties",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/additionalProperties",
+                    "https://example.com/polygon#/$defs/point/additionalProperties",
                   "instanceLocation": "#/0"
                 }
               ]
@@ -75,42 +75,42 @@
               "valid": false,
               "keywordLocation": "#/items/$ref",
               "absoluteKeywordLocation":
-                "https://example.com/polygon#/definitions/point",
+                "https://example.com/polygon#/$defs/point",
               "instanceLocation": "#/1",
               "errors": [
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/type",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/type",
+                    "https://example.com/polygon#/$defs/point/type",
                   "instanceLocation": "#/1"
                 },
                 {
                   "valid": true,
                   "keywordLocation": "#/items/$ref/properties",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/properties",
+                    "https://example.com/polygon#/$defs/point/properties",
                   "instanceLocation": "#/1"
                 },
                 {
                   "valid": false,
                   "keywordLocation": "#/items/$ref/required",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/required",
+                    "https://example.com/polygon#/$defs/point/required",
                   "instanceLocation": "#/1"
                 },
                 {
                   "valid": false,
                   "keywordLocation": "#/items/$ref/additionalProperties",
                   "absoluteKeywordLocation":
-                    "https://example.com/polygon#/definitions/point/additionalProperties",
+                    "https://example.com/polygon#/$defs/point/additionalProperties",
                   "instanceLocation": "#/1",
                   "errors": [
                     {
                       "valid": false,
                       "keywordLocation": "#/items/$ref/additionalProperties",
                       "absoluteKeywordLocation":
-                        "https://example.com/polygon#/definitions/point/additionalProperties",
+                        "https://example.com/polygon#/$defs/point/additionalProperties",
                       "instanceLocation": "#/1/z"
                     }
                   ]


### PR DESCRIPTION
Follows on from 5b088711e78d472905ed37481d5ca055f370ba05.