### PR TITLE
Trivial: Consolidate core examples/best practices.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1302,177 +1302,6 @@
                         interoperable across implementations.
                     </t>
                 </section>
-                <section title="Best Practices for Vocabulary and Meta-Schema Authors">
-                    <t>
-                        Vocabulary authors SHOULD
-                        take care to avoid keyword name collisions if the vocabulary is intended
-                        for broad use, and potentially combined with other vocabularies.  JSON
-                        Schema does not provide any formal namespacing system, but also does
-                        not constrain keyword names, allowing for any number of namespacing
-                        approaches.
-                    </t>
-                    <t>
-                        Vocabularies may build on each other, such as by defining the behavior
-                        of their keywords with respect to the behavior of keywords from another
-                        vocabulary, or by using a keyword from another vocabulary with
-                        a restricted or expanded set of acceptable values.  Not all such
-                        vocabulary re-use will result in a new vocabulary that is compatible
-                        with the vocabulary on which it is built.  Vocabulary authors SHOULD
-                        clearly document what level of compatibility, if any, is expected.
-                    </t>
-                    <t>
-                        Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple
-                        vocabularies that define conflicting syntax or semantics for the same
-                        keyword.  As semantic conflicts are not generally detectable through
-                        schema validation, implementations are not expected to detect such
-                        conflicts.  If conflicting vocabularies are declared, the resulting
-                        behavior is undefined.
-                    </t>
-                    <t>
-                        Vocabulary authors SHOULD provide a meta-schema that validates the
-                        expected usage of the vocabulary's keywords on their own.  Such meta-schemas
-                        SHOULD NOT forbid additional keywords, and MUST NOT forbid any
-                        keywords from the Core vocabulary.
-                    </t>
-                    <t>
-                        It is RECOMMENDED that meta-schema authors reference each vocabulary's
-                        meta-schema using the <xref target="allOf">"allOf"</xref> keyword,
-                        although other mechanisms for constructing the meta-schema may be
-                        appropriate for certain use cases.
-                    </t>
-                    <t>
-                        The recursive nature of meta-schemas makes the "$recursiveAnchor"
-                        and "$recursiveRef" keywords particularly useful for extending
-                        existing meta-schemas, as can be seen in the JSON Hyper-Schema meta-schema
-                        which extends the Validation meta-schema.
-                    </t>
-                    <t>
-                        Meta-schemas MAY impose additional constraints, including describing
-                        keywords not present in any vocabulary, beyond what the meta-schemas
-                        associated with the declared vocabularies describe.  This allows for
-                        restricting usage to a subset of a vocabulary, and for validating
-                        locally defined keywords not intended for re-use.
-                    </t>
-                    <t>
-                        However, meta-schemas SHOULD NOT contradict any vocabularies that
-                        they declare, such as by requiring a different JSON type than
-                        the vocabulary expects.  The resulting behavior is undefined.
-                    </t>
-                    <t>
-                        Meta-schemas intended for local use, with no need to test for
-                        vocabulary support in arbitrary implementations, can safely omit
-                        "$vocabulary" entirely.
-                    </t>
-                </section>
-                <section title="Example Meta-Schema With Vocabulary Declarations"
-                         anchor="example-meta-schema">
-                    <t>
-                        This meta-schema explicitly declares both the Core and Applicator vocabularies,
-                        together with an extension vocabulary, and combines their meta-schemas with
-                        an "allOf".  The extension vocabulary's meta-schema, which describes only the
-                        keywords in that vocabulary, is shown after the main example meta-schema.
-                    </t>
-                    <t>
-                        The main example meta-schema also restricts the usage of the Applicator
-                        vocabulary by forbidding the keywords prefixed with "unevaluated", which
-                        are particularly complex to implement.  This does not change the semantics
-                        or set of keywords defined by the Applicator vocabulary.  It just ensures
-                        that schemas using this meta-schema that attempt to use the keywords
-                        prefixed with "unevaluted" will fail validation against this meta-schema.
-                    </t>
-                    <t>
-                        Finally, this meta-schema describes the syntax of a keyword, "localKeyword",
-                        that is not part of any vocabulary.  Presumably, the implementors and users
-                        of this meta-schema will understand the semantics of "localKeyword".
-                        JSON Schema does not define any mechanism for expressing keyword semantics
-                        outside of vocabularies, making them unsuitable for use except in a
-                        specific environment in which they are understood.
-                    </t>
-                    <figure>
-                        <preamble>
-                            This meta-schema combines several vocabularies for general use.
-                        </preamble>
-                        <artwork>
-<![CDATA[
-{
-  "$schema": "https://json-schema.org/draft/2019-08/schema",
-  "$id": "https://example.com/meta/general-use-example",
-  "$recursiveAnchor": true,
-  "$vocabulary": {
-    "https://json-schema.org/draft/2019-08/vocab/core": true,
-    "https://json-schema.org/draft/2019-08/vocab/applicator": true,
-    "https://json-schema.org/draft/2019-08/vocab/validation": true,
-    "https://example.com/vocab/example-vocab": true
-  },
-  "allOf": [
-    {"$ref": "https://json-schema.org/draft/2019-08/meta/core"},
-    {"$ref": "https://json-schema.org/draft/2019-08/meta/applicator"},
-    {"$ref": "https://json-schema.org/draft/2019-08/meta/validation"},
-    {"$ref": "https://example.com/meta/example-vocab",
-  ],
-  "patternProperties": {
-    "^unevaluated.*$": false
-  },
-  "properties": {
-    "localKeyword": {
-      "$comment": "Not in vocabulary, but validated if used",
-      "type": "string"
-    }
-  }
-}
-]]>
-                        </artwork>
-                    </figure>
-                    <figure>
-                        <preamble>
-                            This meta-schema describes only a single extension vocabulary.
-                        </preamble>
-                        <artwork>
-<![CDATA[
-{
-  "$schema": "https://json-schema.org/draft/2019-08/schema",
-  "$id": "https://example.com/meta/example-vocab",
-  "$recursiveAnchor": true,
-  "$vocabulary": {
-    "https://example.com/vocab/example-vocab": true,
-  },
-  "type": ["object", "boolean"],
-  "properties": {
-    "minDate": {
-      "type": "string",
-      "pattern": "\d\d\d\d-\d\d-\d\d",
-      "format": "date",
-    }
-  }
-}
-]]>
-                        </artwork>
-                    </figure>
-                    <t>
-                        As shown above, even though each of the single-vocabulary meta-schemas
-                        referenced in the general-use meta-schema's "allOf" declares its
-                        corresponding vocabulary, this new meta-schema must re-declare them.
-                    </t>
-                    <t>
-                        The standard meta-schemas that combine all vocabularies defined by
-                        the Core and Validation specification, and that combine all vocabularies
-                        defined by those specifications as well as the Hyper-Schema specification,
-                        demonstrate additional complex combinations.  These URIs for these
-                        meta-schemas may be found in the Validation and Hyper-Schema specifications,
-                        respectively.
-                    </t>
-                    <t>
-                        While the general-use meta-schema can validate the syntax of "minDate",
-                        it is the vocabulary that defines the logic behind the semantic meaning
-                        of "minDate".  Without an understanding of the semantics (in this example,
-                        that the instance value must be a date equal to or after the date
-                        provided as the keyword's value in the schema), an implementation can
-                        only validate the syntactic usage.  In this case, that means validating
-                        that it is a date-formatted string (using "pattern" to ensure that it is
-                        validated even when "format" functions purely as an annotation, as explained
-                        in the <xref target="json-schema-validation">Validation specification</xref>.
-                    </t>
-                </section>
             </section>
 
             <section title="Base URI, Anchors, and Dereferencing">
@@ -1700,126 +1529,6 @@
                         will be distinct.  However, the effect of two "$anchor" keywords with the
                         same value and the same base URI is undefined.  Implementations MAY
                         raise an error if such usage is detected.
-                    </t>
-                </section>
-                <section title="Schema identification examples" anchor="idExamples">
-                    <figure>
-                        <preamble>
-                            Consider the following schema, which shows "$id" being used to identify
-                            both the root schema and various subschemas, and "$anchor" being used
-                            to define plain name fragment identifiers.
-                        </preamble>
-                        <artwork>
-<![CDATA[
-{
-    "$id": "https://example.com/root.json",
-    "$defs": {
-        "A": { "$anchor": "foo" },
-        "B": {
-            "$id": "other.json",
-            "$defs": {
-                "X": { "$anchor": "bar" },
-                "Y": {
-                    "$id": "t/inner.json",
-                    "$anchor": "bar"
-                }
-            }
-        },
-        "C": {
-            "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
-        }
-    }
-}
-]]>
-                        </artwork>
-                    </figure>
-                    <t>
-                        The schemas at the following URI-encoded <xref target="RFC6901">JSON
-                        Pointers</xref> (relative to the root schema) have the following
-                        base URIs, and are identifiable by any listed URI in accordance with
-                        sections <xref target="fragments" format="counter"></xref> and
-                        <xref target="embedded" format="counter"></xref> above.  As previously
-                        noted, support for non-canonical URIs is OPTIONAL.
-                    </t>
-                    <t>
-                        <list style="hanging">
-                            <t hangText="# (document root)">
-                                <list style="hanging">
-                                    <t hangText="canonical absolute-URI (and also base URI)">
-                                        https://example.com/root.json
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/root.json#
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/A">
-                                <list>
-                                    <t hangText="base URI">https://example.com/root.json</t>
-                                    <t hangText="canonical URI with plain fragment">
-                                        https://example.com/root.json#foo
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/root.json#/$defs/A
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/B">
-                                <list style="hanging">
-                                    <t hangText="base URI">https://example.com/other.json</t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/other.json#
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/B
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/B/$defs/X">
-                                <list style="hanging">
-                                    <t hangText="base URI">https://example.com/other.json</t>
-                                    <t hangText="canonical URI with plain fragment">
-                                        https://example.com/other.json#bar
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/other.json#/$defs/X
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/B/$defs/X
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/B/$defs/Y">
-                                <list style="hanging">
-                                    <t hangText="base URI">https://example.com/t/inner.json</t>
-                                    <t hangText="canonical URI with plain fragment">
-                                        https://example.com/t/inner.json#bar
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/t/inner.json#
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to other.json">
-                                        https://example.com/other.json#/$defs/Y
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/B/$defs/Y
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/C">
-                                <list style="hanging">
-                                    <t hangText="base URI">
-                                        urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/C
-                                    </t>
-                                </list>
-                            </t>
-                        </list>
                     </t>
                 </section>
 
@@ -2261,6 +1970,302 @@
                     or contents of "$comment" properties.  In particular, the value of "$comment"
                     MUST NOT be collected as an annotation result.
                 </t>
+            </section>
+
+            <section title="Examples and best practices for the core vocabulary">
+                <section title="Schema identification examples" anchor="idExamples">
+                    <figure>
+                        <preamble>
+                            Consider the following schema, which shows "$id" being used to identify
+                            both the root schema and various subschemas, and "$anchor" being used
+                            to define plain name fragment identifiers.
+                        </preamble>
+                        <artwork>
+<![CDATA[
+{
+    "$id": "https://example.com/root.json",
+    "$defs": {
+        "A": { "$anchor": "foo" },
+        "B": {
+            "$id": "other.json",
+            "$defs": {
+                "X": { "$anchor": "bar" },
+                "Y": {
+                    "$id": "t/inner.json",
+                    "$anchor": "bar"
+                }
+            }
+        },
+        "C": {
+            "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+        }
+    }
+}
+]]>
+                        </artwork>
+                    </figure>
+                    <t>
+                        The schemas at the following URI-encoded <xref target="RFC6901">JSON
+                        Pointers</xref> (relative to the root schema) have the following
+                        base URIs, and are identifiable by any listed URI in accordance with
+                        sections <xref target="fragments" format="counter"></xref> and
+                        <xref target="embedded" format="counter"></xref> above.  As previously
+                        noted, support for non-canonical URIs is OPTIONAL.
+                    </t>
+                    <t>
+                        <list style="hanging">
+                            <t hangText="# (document root)">
+                                <list style="hanging">
+                                    <t hangText="canonical absolute-URI (and also base URI)">
+                                        https://example.com/root.json
+                                    </t>
+                                    <t hangText="canonical URI with pointer fragment">
+                                        https://example.com/root.json#
+                                    </t>
+                                </list>
+                            </t>
+                            <t hangText="#/$defs/A">
+                                <list>
+                                    <t hangText="base URI">https://example.com/root.json</t>
+                                    <t hangText="canonical URI with plain fragment">
+                                        https://example.com/root.json#foo
+                                    </t>
+                                    <t hangText="canonical URI with pointer fragment">
+                                        https://example.com/root.json#/$defs/A
+                                    </t>
+                                </list>
+                            </t>
+                            <t hangText="#/$defs/B">
+                                <list style="hanging">
+                                    <t hangText="base URI">https://example.com/other.json</t>
+                                    <t hangText="canonical URI with pointer fragment">
+                                        https://example.com/other.json#
+                                    </t>
+                                    <t hangText="non-canonical URI with fragment relative to root.json">
+                                        https://example.com/root.json#/$defs/B
+                                    </t>
+                                </list>
+                            </t>
+                            <t hangText="#/$defs/B/$defs/X">
+                                <list style="hanging">
+                                    <t hangText="base URI">https://example.com/other.json</t>
+                                    <t hangText="canonical URI with plain fragment">
+                                        https://example.com/other.json#bar
+                                    </t>
+                                    <t hangText="canonical URI with pointer fragment">
+                                        https://example.com/other.json#/$defs/X
+                                    </t>
+                                    <t hangText="non-canonical URI with fragment relative to root.json">
+                                        https://example.com/root.json#/$defs/B/$defs/X
+                                    </t>
+                                </list>
+                            </t>
+                            <t hangText="#/$defs/B/$defs/Y">
+                                <list style="hanging">
+                                    <t hangText="base URI">https://example.com/t/inner.json</t>
+                                    <t hangText="canonical URI with plain fragment">
+                                        https://example.com/t/inner.json#bar
+                                    </t>
+                                    <t hangText="canonical URI with pointer fragment">
+                                        https://example.com/t/inner.json#
+                                    </t>
+                                    <t hangText="non-canonical URI with fragment relative to other.json">
+                                        https://example.com/other.json#/$defs/Y
+                                    </t>
+                                    <t hangText="non-canonical URI with fragment relative to root.json">
+                                        https://example.com/root.json#/$defs/B/$defs/Y
+                                    </t>
+                                </list>
+                            </t>
+                            <t hangText="#/$defs/C">
+                                <list style="hanging">
+                                    <t hangText="base URI">
+                                        urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f
+                                    </t>
+                                    <t hangText="canonical URI with pointer fragment">
+                                        urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#
+                                    </t>
+                                    <t hangText="non-canonical URI with fragment relative to root.json">
+                                        https://example.com/root.json#/$defs/C
+                                    </t>
+                                </list>
+                            </t>
+                        </list>
+                    </t>
+                </section>
+
+                <section title="Best practices for vocabulary and meta-schema authors">
+                    <t>
+                        Vocabulary authors SHOULD
+                        take care to avoid keyword name collisions if the vocabulary is intended
+                        for broad use, and potentially combined with other vocabularies.  JSON
+                        Schema does not provide any formal namespacing system, but also does
+                        not constrain keyword names, allowing for any number of namespacing
+                        approaches.
+                    </t>
+                    <t>
+                        Vocabularies may build on each other, such as by defining the behavior
+                        of their keywords with respect to the behavior of keywords from another
+                        vocabulary, or by using a keyword from another vocabulary with
+                        a restricted or expanded set of acceptable values.  Not all such
+                        vocabulary re-use will result in a new vocabulary that is compatible
+                        with the vocabulary on which it is built.  Vocabulary authors SHOULD
+                        clearly document what level of compatibility, if any, is expected.
+                    </t>
+                    <t>
+                        Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple
+                        vocabularies that define conflicting syntax or semantics for the same
+                        keyword.  As semantic conflicts are not generally detectable through
+                        schema validation, implementations are not expected to detect such
+                        conflicts.  If conflicting vocabularies are declared, the resulting
+                        behavior is undefined.
+                    </t>
+                    <t>
+                        Vocabulary authors SHOULD provide a meta-schema that validates the
+                        expected usage of the vocabulary's keywords on their own.  Such meta-schemas
+                        SHOULD NOT forbid additional keywords, and MUST NOT forbid any
+                        keywords from the Core vocabulary.
+                    </t>
+                    <t>
+                        It is RECOMMENDED that meta-schema authors reference each vocabulary's
+                        meta-schema using the <xref target="allOf">"allOf"</xref> keyword,
+                        although other mechanisms for constructing the meta-schema may be
+                        appropriate for certain use cases.
+                    </t>
+                    <t>
+                        The recursive nature of meta-schemas makes the "$recursiveAnchor"
+                        and "$recursiveRef" keywords particularly useful for extending
+                        existing meta-schemas, as can be seen in the JSON Hyper-Schema meta-schema
+                        which extends the Validation meta-schema.
+                    </t>
+                    <t>
+                        Meta-schemas MAY impose additional constraints, including describing
+                        keywords not present in any vocabulary, beyond what the meta-schemas
+                        associated with the declared vocabularies describe.  This allows for
+                        restricting usage to a subset of a vocabulary, and for validating
+                        locally defined keywords not intended for re-use.
+                    </t>
+                    <t>
+                        However, meta-schemas SHOULD NOT contradict any vocabularies that
+                        they declare, such as by requiring a different JSON type than
+                        the vocabulary expects.  The resulting behavior is undefined.
+                    </t>
+                    <t>
+                        Meta-schemas intended for local use, with no need to test for
+                        vocabulary support in arbitrary implementations, can safely omit
+                        "$vocabulary" entirely.
+                    </t>
+                </section>
+
+                <section title="Example meta-schema with vocabulary declarations"
+                         anchor="example-meta-schema">
+                    <t>
+                        This meta-schema explicitly declares both the Core and Applicator vocabularies,
+                        together with an extension vocabulary, and combines their meta-schemas with
+                        an "allOf".  The extension vocabulary's meta-schema, which describes only the
+                        keywords in that vocabulary, is shown after the main example meta-schema.
+                    </t>
+                    <t>
+                        The main example meta-schema also restricts the usage of the Applicator
+                        vocabulary by forbidding the keywords prefixed with "unevaluated", which
+                        are particularly complex to implement.  This does not change the semantics
+                        or set of keywords defined by the Applicator vocabulary.  It just ensures
+                        that schemas using this meta-schema that attempt to use the keywords
+                        prefixed with "unevaluted" will fail validation against this meta-schema.
+                    </t>
+                    <t>
+                        Finally, this meta-schema describes the syntax of a keyword, "localKeyword",
+                        that is not part of any vocabulary.  Presumably, the implementors and users
+                        of this meta-schema will understand the semantics of "localKeyword".
+                        JSON Schema does not define any mechanism for expressing keyword semantics
+                        outside of vocabularies, making them unsuitable for use except in a
+                        specific environment in which they are understood.
+                    </t>
+                    <figure>
+                        <preamble>
+                            This meta-schema combines several vocabularies for general use.
+                        </preamble>
+                        <artwork>
+<![CDATA[
+{
+  "$schema": "https://json-schema.org/draft/2019-08/schema",
+  "$id": "https://example.com/meta/general-use-example",
+  "$recursiveAnchor": true,
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-08/vocab/core": true,
+    "https://json-schema.org/draft/2019-08/vocab/applicator": true,
+    "https://json-schema.org/draft/2019-08/vocab/validation": true,
+    "https://example.com/vocab/example-vocab": true
+  },
+  "allOf": [
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/core"},
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/applicator"},
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/validation"},
+    {"$ref": "https://example.com/meta/example-vocab",
+  ],
+  "patternProperties": {
+    "^unevaluated.*$": false
+  },
+  "properties": {
+    "localKeyword": {
+      "$comment": "Not in vocabulary, but validated if used",
+      "type": "string"
+    }
+  }
+}
+]]>
+                        </artwork>
+                    </figure>
+                    <figure>
+                        <preamble>
+                            This meta-schema describes only a single extension vocabulary.
+                        </preamble>
+                        <artwork>
+<![CDATA[
+{
+  "$schema": "https://json-schema.org/draft/2019-08/schema",
+  "$id": "https://example.com/meta/example-vocab",
+  "$recursiveAnchor": true,
+  "$vocabulary": {
+    "https://example.com/vocab/example-vocab": true,
+  },
+  "type": ["object", "boolean"],
+  "properties": {
+    "minDate": {
+      "type": "string",
+      "pattern": "\d\d\d\d-\d\d-\d\d",
+      "format": "date",
+    }
+  }
+}
+]]>
+                        </artwork>
+                    </figure>
+                    <t>
+                        As shown above, even though each of the single-vocabulary meta-schemas
+                        referenced in the general-use meta-schema's "allOf" declares its
+                        corresponding vocabulary, this new meta-schema must re-declare them.
+                    </t>
+                    <t>
+                        The standard meta-schemas that combine all vocabularies defined by
+                        the Core and Validation specification, and that combine all vocabularies
+                        defined by those specifications as well as the Hyper-Schema specification,
+                        demonstrate additional complex combinations.  These URIs for these
+                        meta-schemas may be found in the Validation and Hyper-Schema specifications,
+                        respectively.
+                    </t>
+                    <t>
+                        While the general-use meta-schema can validate the syntax of "minDate",
+                        it is the vocabulary that defines the logic behind the semantic meaning
+                        of "minDate".  Without an understanding of the semantics (in this example,
+                        that the instance value must be a date equal to or after the date
+                        provided as the keyword's value in the schema), an implementation can
+                        only validate the syntactic usage.  In this case, that means validating
+                        that it is a date-formatted string (using "pattern" to ensure that it is
+                        validated even when "format" functions purely as an annotation, as explained
+                        in the <xref target="json-schema-validation">Validation specification</xref>.
+                    </t>
+                </section>
             </section>
         </section>
 


### PR DESCRIPTION
_There are **no** content changes, just moved sections_

This improves the flow and will work better as we add a couple
more best practices sections before publishing.

The examples within core tend to rely on understanding more
of the core keywords than have necessarily been introduced.