### PR TITLE
 Move core examples/best practices to appendixes

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3481,7 +3481,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     all cases can require relatively complex schema manipulations.  It is beyond
                     the scope of this specification to determine or provide a set of safe "$ref"
                     removal transformations, as they depend not only on the schema structure
-                    but also on the intende usage.
+                    but also on the intended usage.
                 </t>
             </section>
         </section>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3610,6 +3610,68 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
             </section>
         </section>
 
+        <section title="References and generative use cases">
+            <t>
+                While the presence of references is expected to be transparent
+                to validation results, generative use cases such as code generators
+                and UI renderers often consider references to be semantically significant.
+            </t>
+            <t>
+                To make such use case-specific semantics explicit, the best practice
+                is to create an annotation keyword can be created for use in the same
+                schema object alongside of a reference keyword such as "$ref".
+            </t>
+            <figure>
+                <preamble>
+                    For example, here is a hypothetical keyword for determining
+                    whether a code generator should consider the reference
+                    target to be a distinct class, and how those classes are related.
+                    Note that this example is solely for illustrative purposes, and is
+                    not intended to propose a functional code generation keyword.
+                </preamble>
+                <artwork>
+<![CDATA[
+{
+    "allOf": [
+        {
+            "classRelation": "is-a",
+            "$ref": "classes/base.json"
+        },
+        {
+            "$ref": "fields/common.json"
+        }
+    ],
+    "properties": {
+        "foo": {
+            "classRelation": "has-a",
+            "$ref": "classes/foo.json"
+        },
+        "date": {
+            "$ref": "types/dateStruct.json",
+        }
+    }
+}
+]]>
+                </artwork>
+            </figure>
+            <t>
+                Here, this schema represents some sort of object-oriented class.
+                The first reference in the "allOf" is noted as the base class.
+                The second is not assigned a class relationship, meaning that the
+                code generator should combine the target's definition with this
+                one as if no reference were involved.
+            </t>
+            <t>
+                Looking at the properties, "foo" is flagged as object composition,
+                while the "date" property is not.  It is simply a field with
+                sub-fields, rather than an instance of a distinct class.
+            </t>
+            <t>
+                This style of usage requires the annotation to be in the same object
+                as the reference, which must be recognizable as a reference.
+            </t>
+        </section>
+
         <section title="Acknowledgments">
             <t>
                 Thanks to

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1502,7 +1502,7 @@
                         </t>
                         <t>
                             Further examples of such non-canonical URIs, as well as the appropriate
-                            canonical URIs to use instead, are provided in section
+                            canonical URIs to use instead, are provided in appendix
                             <xref target="idExamples" format="counter"></xref>.
                         </t>
                     </section>
@@ -1839,7 +1839,7 @@
                             on the trust that the validator has in the schema.  Such URIs and schemas
                             can be supplied to an implementation prior to processing instances, or may
                             be noted within a schema document as it is processed, producing associations
-                            as shown in section <xref target="idExamples" format="counter"></xref>.
+                            as shown in appendix <xref target="idExamples" format="counter"></xref>.
                         </t>
                         <t>
                             A schema MAY (and likely will) have multiple URIs, but there is no way for a
@@ -3351,8 +3351,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                 Pointers</xref> (relative to the root schema) have the following
                 base URIs, and are identifiable by any listed URI in accordance with
                 sections <xref target="fragments" format="counter"></xref> and
-                <xref target="embedded" format="counter"></xref> above.  As previously
-                noted, support for non-canonical URIs is OPTIONAL.
+                <xref target="embedded" format="counter"></xref> above.
             </t>
             <t>
                 <list style="hanging">
@@ -3439,7 +3438,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
         <section title="Working with vocabularies">
             <section title="Best practices for vocabulary and meta-schema authors">
                 <t>
-                    Vocabulary authors SHOULD
+                    Vocabulary authors should
                     take care to avoid keyword name collisions if the vocabulary is intended
                     for broad use, and potentially combined with other vocabularies.  JSON
                     Schema does not provide any formal namespacing system, but also does
@@ -3452,11 +3451,11 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     vocabulary, or by using a keyword from another vocabulary with
                     a restricted or expanded set of acceptable values.  Not all such
                     vocabulary re-use will result in a new vocabulary that is compatible
-                    with the vocabulary on which it is built.  Vocabulary authors SHOULD
+                    with the vocabulary on which it is built.  Vocabulary authors should
                     clearly document what level of compatibility, if any, is expected.
                 </t>
                 <t>
-                    Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple
+                    Meta-schema authors should not use "$vocabulary" to combine multiple
                     vocabularies that define conflicting syntax or semantics for the same
                     keyword.  As semantic conflicts are not generally detectable through
                     schema validation, implementations are not expected to detect such
@@ -3464,13 +3463,13 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     behavior is undefined.
                 </t>
                 <t>
-                    Vocabulary authors SHOULD provide a meta-schema that validates the
+                    Vocabulary authors should provide a meta-schema that validates the
                     expected usage of the vocabulary's keywords on their own.  Such meta-schemas
-                    SHOULD NOT forbid additional keywords, and MUST NOT forbid any
+                    should not forbid additional keywords, and must not forbid any
                     keywords from the Core vocabulary.
                 </t>
                 <t>
-                    It is RECOMMENDED that meta-schema authors reference each vocabulary's
+                    It is recommended that meta-schema authors reference each vocabulary's
                     meta-schema using the <xref target="allOf">"allOf"</xref> keyword,
                     although other mechanisms for constructing the meta-schema may be
                     appropriate for certain use cases.
@@ -3482,14 +3481,14 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                     which extends the Validation meta-schema.
                 </t>
                 <t>
-                    Meta-schemas MAY impose additional constraints, including describing
+                    Meta-schemas may impose additional constraints, including describing
                     keywords not present in any vocabulary, beyond what the meta-schemas
                     associated with the declared vocabularies describe.  This allows for
                     restricting usage to a subset of a vocabulary, and for validating
                     locally defined keywords not intended for re-use.
                 </t>
                 <t>
-                    However, meta-schemas SHOULD NOT contradict any vocabularies that
+                    However, meta-schemas should not contradict any vocabularies that
                     they declare, such as by requiring a different JSON type than
                     the vocabulary expects.  The resulting behavior is undefined.
                 </t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3618,7 +3618,7 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
             </t>
             <t>
                 To make such use case-specific semantics explicit, the best practice
-                is to create an annotation keyword can be created for use in the same
+                is to create an annotation keyword for use in the same
                 schema object alongside of a reference keyword such as "$ref".
             </t>
             <figure>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3435,6 +3435,57 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
             </t>
         </section>
 
+        <section title="Manipulating schema documents and references">
+            <t>
+                Various tools have been created to rearrange schema documents
+                based on how and where references ("$ref") appear.  This appendix discusses
+                which use cases and actions are compliant with this specification.
+            </t>
+            <section title="Bundling schema resources into a single document">
+                <t>
+                    A set of schema resources intended for use together can be organized
+                    with each in its own schema document, all in the same schema document,
+                    or any granularity of document grouping in between.
+                </t>
+                <t>
+                    Numerous tools exist to perform various sorts of reference removal.
+                    A common case of this is producing a single file where all references
+                    can be resolved within that file.  This is typically done to simplify
+                    distribution, or to simplify coding so that various invocations
+                    of JSON Schema libraries do not have to keep track of and load
+                    a large number of resources.
+                </t>
+                <t>
+                    This transformation can be safely and reversibly done as long as
+                    all static references (e.g. "$ref") use URI-references that resolve
+                    to canonical URIs, and all schema resources have an absolute-URI
+                    as the "$id" in their root schema.
+                </t>
+                <t>
+                    With these conditions met, each external resource can be copied
+                    under "$defs", without breaking any references among the resources'
+                    schema objects, and without changing any aspect of validation or
+                    annotation results.  The names of the schemas under "$defs" do
+                    not affect behavior, assuming they are each unique, as they
+                    do not appear in canonical URIs for the embedded resources.
+                </t>
+            </section>
+            <section title="Reference removal is not always safe">
+                <t>
+                    Attempting to remove all references and produce a single schema document does not,
+                    in all cases, produce a schema with identical behavior to the original form.
+                </t>
+                <t>
+                    Since "$ref" is now treated like any other keyword, with other keywords allowed
+                    in the same schema objects, fully supporting non-recursive "$ref" removal in
+                    all cases can require relatively complex schema manipulations.  It is beyond
+                    the scope of this specification to determine or provide a set of safe "$ref"
+                    removal transformations, as they depend not only on the schema structure
+                    but also on the intende usage.
+                </t>
+            </section>
+        </section>
+
         <section title="Working with vocabularies">
             <section title="Best practices for vocabulary and meta-schema authors">
                 <t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1308,177 +1308,6 @@
                         interoperable across implementations.
                     </t>
                 </section>
-                <section title="Best Practices for Vocabulary and Meta-Schema Authors">
-                    <t>
-                        Vocabulary authors SHOULD
-                        take care to avoid keyword name collisions if the vocabulary is intended
-                        for broad use, and potentially combined with other vocabularies.  JSON
-                        Schema does not provide any formal namespacing system, but also does
-                        not constrain keyword names, allowing for any number of namespacing
-                        approaches.
-                    </t>
-                    <t>
-                        Vocabularies may build on each other, such as by defining the behavior
-                        of their keywords with respect to the behavior of keywords from another
-                        vocabulary, or by using a keyword from another vocabulary with
-                        a restricted or expanded set of acceptable values.  Not all such
-                        vocabulary re-use will result in a new vocabulary that is compatible
-                        with the vocabulary on which it is built.  Vocabulary authors SHOULD
-                        clearly document what level of compatibility, if any, is expected.
-                    </t>
-                    <t>
-                        Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple
-                        vocabularies that define conflicting syntax or semantics for the same
-                        keyword.  As semantic conflicts are not generally detectable through
-                        schema validation, implementations are not expected to detect such
-                        conflicts.  If conflicting vocabularies are declared, the resulting
-                        behavior is undefined.
-                    </t>
-                    <t>
-                        Vocabulary authors SHOULD provide a meta-schema that validates the
-                        expected usage of the vocabulary's keywords on their own.  Such meta-schemas
-                        SHOULD NOT forbid additional keywords, and MUST NOT forbid any
-                        keywords from the Core vocabulary.
-                    </t>
-                    <t>
-                        It is RECOMMENDED that meta-schema authors reference each vocabulary's
-                        meta-schema using the <xref target="allOf">"allOf"</xref> keyword,
-                        although other mechanisms for constructing the meta-schema may be
-                        appropriate for certain use cases.
-                    </t>
-                    <t>
-                        The recursive nature of meta-schemas makes the "$recursiveAnchor"
-                        and "$recursiveRef" keywords particularly useful for extending
-                        existing meta-schemas, as can be seen in the JSON Hyper-Schema meta-schema
-                        which extends the Validation meta-schema.
-                    </t>
-                    <t>
-                        Meta-schemas MAY impose additional constraints, including describing
-                        keywords not present in any vocabulary, beyond what the meta-schemas
-                        associated with the declared vocabularies describe.  This allows for
-                        restricting usage to a subset of a vocabulary, and for validating
-                        locally defined keywords not intended for re-use.
-                    </t>
-                    <t>
-                        However, meta-schemas SHOULD NOT contradict any vocabularies that
-                        they declare, such as by requiring a different JSON type than
-                        the vocabulary expects.  The resulting behavior is undefined.
-                    </t>
-                    <t>
-                        Meta-schemas intended for local use, with no need to test for
-                        vocabulary support in arbitrary implementations, can safely omit
-                        "$vocabulary" entirely.
-                    </t>
-                </section>
-                <section title="Example Meta-Schema With Vocabulary Declarations"
-                         anchor="example-meta-schema">
-                    <t>
-                        This meta-schema explicitly declares both the Core and Applicator vocabularies,
-                        together with an extension vocabulary, and combines their meta-schemas with
-                        an "allOf".  The extension vocabulary's meta-schema, which describes only the
-                        keywords in that vocabulary, is shown after the main example meta-schema.
-                    </t>
-                    <t>
-                        The main example meta-schema also restricts the usage of the Applicator
-                        vocabulary by forbidding the keywords prefixed with "unevaluated", which
-                        are particularly complex to implement.  This does not change the semantics
-                        or set of keywords defined by the Applicator vocabulary.  It just ensures
-                        that schemas using this meta-schema that attempt to use the keywords
-                        prefixed with "unevaluated" will fail validation against this meta-schema.
-                    </t>
-                    <t>
-                        Finally, this meta-schema describes the syntax of a keyword, "localKeyword",
-                        that is not part of any vocabulary.  Presumably, the implementors and users
-                        of this meta-schema will understand the semantics of "localKeyword".
-                        JSON Schema does not define any mechanism for expressing keyword semantics
-                        outside of vocabularies, making them unsuitable for use except in a
-                        specific environment in which they are understood.
-                    </t>
-                    <figure>
-                        <preamble>
-                            This meta-schema combines several vocabularies for general use.
-                        </preamble>
-                        <artwork>
-<![CDATA[
-{
-  "$schema": "https://json-schema.org/draft/2019-08/schema",
-  "$id": "https://example.com/meta/general-use-example",
-  "$recursiveAnchor": true,
-  "$vocabulary": {
-    "https://json-schema.org/draft/2019-08/vocab/core": true,
-    "https://json-schema.org/draft/2019-08/vocab/applicator": true,
-    "https://json-schema.org/draft/2019-08/vocab/validation": true,
-    "https://example.com/vocab/example-vocab": true
-  },
-  "allOf": [
-    {"$ref": "https://json-schema.org/draft/2019-08/meta/core"},
-    {"$ref": "https://json-schema.org/draft/2019-08/meta/applicator"},
-    {"$ref": "https://json-schema.org/draft/2019-08/meta/validation"},
-    {"$ref": "https://example.com/meta/example-vocab",
-  ],
-  "patternProperties": {
-    "^unevaluated.*$": false
-  },
-  "properties": {
-    "localKeyword": {
-      "$comment": "Not in vocabulary, but validated if used",
-      "type": "string"
-    }
-  }
-}
-]]>
-                        </artwork>
-                    </figure>
-                    <figure>
-                        <preamble>
-                            This meta-schema describes only a single extension vocabulary.
-                        </preamble>
-                        <artwork>
-<![CDATA[
-{
-  "$schema": "https://json-schema.org/draft/2019-08/schema",
-  "$id": "https://example.com/meta/example-vocab",
-  "$recursiveAnchor": true,
-  "$vocabulary": {
-    "https://example.com/vocab/example-vocab": true,
-  },
-  "type": ["object", "boolean"],
-  "properties": {
-    "minDate": {
-      "type": "string",
-      "pattern": "\d\d\d\d-\d\d-\d\d",
-      "format": "date",
-    }
-  }
-}
-]]>
-                        </artwork>
-                    </figure>
-                    <t>
-                        As shown above, even though each of the single-vocabulary meta-schemas
-                        referenced in the general-use meta-schema's "allOf" declares its
-                        corresponding vocabulary, this new meta-schema must re-declare them.
-                    </t>
-                    <t>
-                        The standard meta-schemas that combine all vocabularies defined by
-                        the Core and Validation specification, and that combine all vocabularies
-                        defined by those specifications as well as the Hyper-Schema specification,
-                        demonstrate additional complex combinations.  These URIs for these
-                        meta-schemas may be found in the Validation and Hyper-Schema specifications,
-                        respectively.
-                    </t>
-                    <t>
-                        While the general-use meta-schema can validate the syntax of "minDate",
-                        it is the vocabulary that defines the logic behind the semantic meaning
-                        of "minDate".  Without an understanding of the semantics (in this example,
-                        that the instance value must be a date equal to or after the date
-                        provided as the keyword's value in the schema), an implementation can
-                        only validate the syntactic usage.  In this case, that means validating
-                        that it is a date-formatted string (using "pattern" to ensure that it is
-                        validated even when "format" functions purely as an annotation, as explained
-                        in the <xref target="json-schema-validation">Validation specification</xref>.
-                    </t>
-                </section>
             </section>
 
             <section title="Base URI, Anchors, and Dereferencing">
@@ -1708,126 +1537,6 @@
                         will be distinct.  However, the effect of two "$anchor" keywords with the
                         same value and the same base URI is undefined.  Implementations MAY
                         raise an error if such usage is detected.
-                    </t>
-                </section>
-                <section title="Schema identification examples" anchor="idExamples">
-                    <figure>
-                        <preamble>
-                            Consider the following schema, which shows "$id" being used to identify
-                            both the root schema and various subschemas, and "$anchor" being used
-                            to define plain name fragment identifiers.
-                        </preamble>
-                        <artwork>
-<![CDATA[
-{
-    "$id": "https://example.com/root.json",
-    "$defs": {
-        "A": { "$anchor": "foo" },
-        "B": {
-            "$id": "other.json",
-            "$defs": {
-                "X": { "$anchor": "bar" },
-                "Y": {
-                    "$id": "t/inner.json",
-                    "$anchor": "bar"
-                }
-            }
-        },
-        "C": {
-            "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
-        }
-    }
-}
-]]>
-                        </artwork>
-                    </figure>
-                    <t>
-                        The schemas at the following URI-encoded <xref target="RFC6901">JSON
-                        Pointers</xref> (relative to the root schema) have the following
-                        base URIs, and are identifiable by any listed URI in accordance with
-                        sections <xref target="fragments" format="counter"></xref> and
-                        <xref target="embedded" format="counter"></xref> above.  As previously
-                        noted, support for non-canonical URIs is OPTIONAL.
-                    </t>
-                    <t>
-                        <list style="hanging">
-                            <t hangText="# (document root)">
-                                <list style="hanging">
-                                    <t hangText="canonical absolute-URI (and also base URI)">
-                                        https://example.com/root.json
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/root.json#
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/A">
-                                <list>
-                                    <t hangText="base URI">https://example.com/root.json</t>
-                                    <t hangText="canonical URI with plain fragment">
-                                        https://example.com/root.json#foo
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/root.json#/$defs/A
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/B">
-                                <list style="hanging">
-                                    <t hangText="base URI">https://example.com/other.json</t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/other.json#
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/B
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/B/$defs/X">
-                                <list style="hanging">
-                                    <t hangText="base URI">https://example.com/other.json</t>
-                                    <t hangText="canonical URI with plain fragment">
-                                        https://example.com/other.json#bar
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/other.json#/$defs/X
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/B/$defs/X
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/B/$defs/Y">
-                                <list style="hanging">
-                                    <t hangText="base URI">https://example.com/t/inner.json</t>
-                                    <t hangText="canonical URI with plain fragment">
-                                        https://example.com/t/inner.json#bar
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        https://example.com/t/inner.json#
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to other.json">
-                                        https://example.com/other.json#/$defs/Y
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/B/$defs/Y
-                                    </t>
-                                </list>
-                            </t>
-                            <t hangText="#/$defs/C">
-                                <list style="hanging">
-                                    <t hangText="base URI">
-                                        urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f
-                                    </t>
-                                    <t hangText="canonical URI with pointer fragment">
-                                        urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#
-                                    </t>
-                                    <t hangText="non-canonical URI with fragment relative to root.json">
-                                        https://example.com/root.json#/$defs/C
-                                    </t>
-                                </list>
-                            </t>
-                        </list>
                     </t>
                 </section>
 
@@ -3605,6 +3314,302 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
                 <seriesInfo name="Internet-Draft" value="draft-handrews-json-schema-hyperschema-02" />
             </reference>
         </references>
+
+        <section title="Schema identification examples" anchor="idExamples">
+            <figure>
+                <preamble>
+                    Consider the following schema, which shows "$id" being used to identify
+                    both the root schema and various subschemas, and "$anchor" being used
+                    to define plain name fragment identifiers.
+                </preamble>
+                <artwork>
+<![CDATA[
+{
+    "$id": "https://example.com/root.json",
+    "$defs": {
+        "A": { "$anchor": "foo" },
+        "B": {
+            "$id": "other.json",
+            "$defs": {
+                "X": { "$anchor": "bar" },
+                "Y": {
+                    "$id": "t/inner.json",
+                    "$anchor": "bar"
+                }
+            }
+        },
+        "C": {
+            "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+        }
+    }
+}
+]]>
+                </artwork>
+            </figure>
+            <t>
+                The schemas at the following URI-encoded <xref target="RFC6901">JSON
+                Pointers</xref> (relative to the root schema) have the following
+                base URIs, and are identifiable by any listed URI in accordance with
+                sections <xref target="fragments" format="counter"></xref> and
+                <xref target="embedded" format="counter"></xref> above.  As previously
+                noted, support for non-canonical URIs is OPTIONAL.
+            </t>
+            <t>
+                <list style="hanging">
+                    <t hangText="# (document root)">
+                        <list style="hanging">
+                            <t hangText="canonical absolute-URI (and also base URI)">
+                                https://example.com/root.json
+                            </t>
+                            <t hangText="canonical URI with pointer fragment">
+                                https://example.com/root.json#
+                            </t>
+                        </list>
+                    </t>
+                    <t hangText="#/$defs/A">
+                        <list>
+                            <t hangText="base URI">https://example.com/root.json</t>
+                            <t hangText="canonical URI with plain fragment">
+                                https://example.com/root.json#foo
+                            </t>
+                            <t hangText="canonical URI with pointer fragment">
+                                https://example.com/root.json#/$defs/A
+                            </t>
+                        </list>
+                    </t>
+                    <t hangText="#/$defs/B">
+                        <list style="hanging">
+                            <t hangText="base URI">https://example.com/other.json</t>
+                            <t hangText="canonical URI with pointer fragment">
+                                https://example.com/other.json#
+                            </t>
+                            <t hangText="non-canonical URI with fragment relative to root.json">
+                                https://example.com/root.json#/$defs/B
+                            </t>
+                        </list>
+                    </t>
+                    <t hangText="#/$defs/B/$defs/X">
+                        <list style="hanging">
+                            <t hangText="base URI">https://example.com/other.json</t>
+                            <t hangText="canonical URI with plain fragment">
+                                https://example.com/other.json#bar
+                            </t>
+                            <t hangText="canonical URI with pointer fragment">
+                                https://example.com/other.json#/$defs/X
+                            </t>
+                            <t hangText="non-canonical URI with fragment relative to root.json">
+                                https://example.com/root.json#/$defs/B/$defs/X
+                            </t>
+                        </list>
+                    </t>
+                    <t hangText="#/$defs/B/$defs/Y">
+                        <list style="hanging">
+                            <t hangText="base URI">https://example.com/t/inner.json</t>
+                            <t hangText="canonical URI with plain fragment">
+                                https://example.com/t/inner.json#bar
+                            </t>
+                            <t hangText="canonical URI with pointer fragment">
+                                https://example.com/t/inner.json#
+                            </t>
+                            <t hangText="non-canonical URI with fragment relative to other.json">
+                                https://example.com/other.json#/$defs/Y
+                            </t>
+                            <t hangText="non-canonical URI with fragment relative to root.json">
+                                https://example.com/root.json#/$defs/B/$defs/Y
+                            </t>
+                        </list>
+                    </t>
+                    <t hangText="#/$defs/C">
+                        <list style="hanging">
+                            <t hangText="base URI">
+                                urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f
+                            </t>
+                            <t hangText="canonical URI with pointer fragment">
+                                urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#
+                            </t>
+                            <t hangText="non-canonical URI with fragment relative to root.json">
+                                https://example.com/root.json#/$defs/C
+                            </t>
+                        </list>
+                    </t>
+                </list>
+            </t>
+        </section>
+
+        <section title="Working with vocabularies">
+            <section title="Best practices for vocabulary and meta-schema authors">
+                <t>
+                    Vocabulary authors SHOULD
+                    take care to avoid keyword name collisions if the vocabulary is intended
+                    for broad use, and potentially combined with other vocabularies.  JSON
+                    Schema does not provide any formal namespacing system, but also does
+                    not constrain keyword names, allowing for any number of namespacing
+                    approaches.
+                </t>
+                <t>
+                    Vocabularies may build on each other, such as by defining the behavior
+                    of their keywords with respect to the behavior of keywords from another
+                    vocabulary, or by using a keyword from another vocabulary with
+                    a restricted or expanded set of acceptable values.  Not all such
+                    vocabulary re-use will result in a new vocabulary that is compatible
+                    with the vocabulary on which it is built.  Vocabulary authors SHOULD
+                    clearly document what level of compatibility, if any, is expected.
+                </t>
+                <t>
+                    Meta-schema authors SHOULD NOT use "$vocabulary" to combine multiple
+                    vocabularies that define conflicting syntax or semantics for the same
+                    keyword.  As semantic conflicts are not generally detectable through
+                    schema validation, implementations are not expected to detect such
+                    conflicts.  If conflicting vocabularies are declared, the resulting
+                    behavior is undefined.
+                </t>
+                <t>
+                    Vocabulary authors SHOULD provide a meta-schema that validates the
+                    expected usage of the vocabulary's keywords on their own.  Such meta-schemas
+                    SHOULD NOT forbid additional keywords, and MUST NOT forbid any
+                    keywords from the Core vocabulary.
+                </t>
+                <t>
+                    It is RECOMMENDED that meta-schema authors reference each vocabulary's
+                    meta-schema using the <xref target="allOf">"allOf"</xref> keyword,
+                    although other mechanisms for constructing the meta-schema may be
+                    appropriate for certain use cases.
+                </t>
+                <t>
+                    The recursive nature of meta-schemas makes the "$recursiveAnchor"
+                    and "$recursiveRef" keywords particularly useful for extending
+                    existing meta-schemas, as can be seen in the JSON Hyper-Schema meta-schema
+                    which extends the Validation meta-schema.
+                </t>
+                <t>
+                    Meta-schemas MAY impose additional constraints, including describing
+                    keywords not present in any vocabulary, beyond what the meta-schemas
+                    associated with the declared vocabularies describe.  This allows for
+                    restricting usage to a subset of a vocabulary, and for validating
+                    locally defined keywords not intended for re-use.
+                </t>
+                <t>
+                    However, meta-schemas SHOULD NOT contradict any vocabularies that
+                    they declare, such as by requiring a different JSON type than
+                    the vocabulary expects.  The resulting behavior is undefined.
+                </t>
+                <t>
+                    Meta-schemas intended for local use, with no need to test for
+                    vocabulary support in arbitrary implementations, can safely omit
+                    "$vocabulary" entirely.
+                </t>
+            </section>
+
+            <section title="Example meta-schema with vocabulary declarations"
+                     anchor="example-meta-schema">
+                <t>
+                    This meta-schema explicitly declares both the Core and Applicator vocabularies,
+                    together with an extension vocabulary, and combines their meta-schemas with
+                    an "allOf".  The extension vocabulary's meta-schema, which describes only the
+                    keywords in that vocabulary, is shown after the main example meta-schema.
+                </t>
+                <t>
+                    The main example meta-schema also restricts the usage of the Applicator
+                    vocabulary by forbidding the keywords prefixed with "unevaluated", which
+                    are particularly complex to implement.  This does not change the semantics
+                    or set of keywords defined by the Applicator vocabulary.  It just ensures
+                    that schemas using this meta-schema that attempt to use the keywords
+                    prefixed with "unevaluted" will fail validation against this meta-schema.
+                </t>
+                <t>
+                    Finally, this meta-schema describes the syntax of a keyword, "localKeyword",
+                    that is not part of any vocabulary.  Presumably, the implementors and users
+                    of this meta-schema will understand the semantics of "localKeyword".
+                    JSON Schema does not define any mechanism for expressing keyword semantics
+                    outside of vocabularies, making them unsuitable for use except in a
+                    specific environment in which they are understood.
+                </t>
+                <figure>
+                    <preamble>
+                        This meta-schema combines several vocabularies for general use.
+                    </preamble>
+                    <artwork>
+<![CDATA[
+{
+  "$schema": "https://json-schema.org/draft/2019-08/schema",
+  "$id": "https://example.com/meta/general-use-example",
+  "$recursiveAnchor": true,
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-08/vocab/core": true,
+    "https://json-schema.org/draft/2019-08/vocab/applicator": true,
+    "https://json-schema.org/draft/2019-08/vocab/validation": true,
+    "https://example.com/vocab/example-vocab": true
+  },
+  "allOf": [
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/core"},
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/applicator"},
+    {"$ref": "https://json-schema.org/draft/2019-08/meta/validation"},
+    {"$ref": "https://example.com/meta/example-vocab",
+  ],
+  "patternProperties": {
+    "^unevaluated.*$": false
+  },
+  "properties": {
+    "localKeyword": {
+      "$comment": "Not in vocabulary, but validated if used",
+      "type": "string"
+    }
+  }
+}
+]]>
+                    </artwork>
+                </figure>
+                <figure>
+                    <preamble>
+                        This meta-schema describes only a single extension vocabulary.
+                    </preamble>
+                    <artwork>
+<![CDATA[
+{
+  "$schema": "https://json-schema.org/draft/2019-08/schema",
+  "$id": "https://example.com/meta/example-vocab",
+  "$recursiveAnchor": true,
+  "$vocabulary": {
+    "https://example.com/vocab/example-vocab": true,
+  },
+  "type": ["object", "boolean"],
+  "properties": {
+    "minDate": {
+      "type": "string",
+      "pattern": "\d\d\d\d-\d\d-\d\d",
+      "format": "date",
+    }
+  }
+}
+]]>
+                    </artwork>
+                </figure>
+                <t>
+                    As shown above, even though each of the single-vocabulary meta-schemas
+                    referenced in the general-use meta-schema's "allOf" declares its
+                    corresponding vocabulary, this new meta-schema must re-declare them.
+                </t>
+                <t>
+                    The standard meta-schemas that combine all vocabularies defined by
+                    the Core and Validation specification, and that combine all vocabularies
+                    defined by those specifications as well as the Hyper-Schema specification,
+                    demonstrate additional complex combinations.  These URIs for these
+                    meta-schemas may be found in the Validation and Hyper-Schema specifications,
+                    respectively.
+                </t>
+                <t>
+                    While the general-use meta-schema can validate the syntax of "minDate",
+                    it is the vocabulary that defines the logic behind the semantic meaning
+                    of "minDate".  Without an understanding of the semantics (in this example,
+                    that the instance value must be a date equal to or after the date
+                    provided as the keyword's value in the schema), an implementation can
+                    only validate the syntactic usage.  In this case, that means validating
+                    that it is a date-formatted string (using "pattern" to ensure that it is
+                    validated even when "format" functions purely as an annotation, as explained
+                    in the <xref target="json-schema-validation">Validation specification</xref>.
+                </t>
+            </section>
+        </section>
 
         <section title="Acknowledgments">
             <t>


### PR DESCRIPTION
***NOTE**: The first commit is just a move, the second changes the RFC 2119 terms.  They should be examined separately.*

These sections are not normative, and moving them to an
appendix reduces the length of the sizable normative
portion of the spec.  And also improves flow, I think.

The examples within core tend to rely on understanding more
of the core keywords than have necessarily been introduced,
so they work better after the entire vocabulary has been
introduced.

Vocabulary authorship is not part of the JSON Schema specification,
so this guidance should not use RFC 2119 terms.