### PR TITLE
fix invalid JSON in 7.7.1.1. Distinguishing Among Multiple Values

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -891,29 +891,28 @@
 {
     "title": "Feature list",
     "type": "array",
-        "items": [
-            {
-                "title": "Feature A",
-                "properties": {
-                    "enabled": {
-                        "$ref": "#/$defs/enabledToggle",
-                        "default": true
-                    }
-                }
-            },
-            {
-                "title": "Feature B",
-                "properties": {
-                    "enabled": {
-                        "description": "If set to null, Feature B
-                                        inherits the enabled
-                                        value from Feature A",
-                        "$ref": "#/$defs/enabledToggle"
-                    }
+    "items": [
+        {
+            "title": "Feature A",
+            "properties": {
+                "enabled": {
+                    "$ref": "#/$defs/enabledToggle",
+                    "default": true
                 }
             }
-        ]
-    },
+        },
+        {
+            "title": "Feature B",
+            "properties": {
+                "enabled": {
+                    "description": "If set to null, Feature B
+                                    inherits the enabled
+                                    value from Feature A",
+                    "$ref": "#/$defs/enabledToggle"
+                }
+            }
+        }
+    ],
     "$defs": {
         "enabledToggle": {
             "title": "Enabled",


### PR DESCRIPTION
fix nesting and structure of JSON example. the existing JSON is indented incorrectly, contains a closing `}` with no corresponding `{` and doesn't parse.