### PR TITLE
fixed regex for $id in core metaschema

### DIFF
--- a/meta/core.json
+++ b/meta/core.json
@@ -13,7 +13,7 @@
             "type": "string",
             "format": "uri-reference",
             "$comment": "Non-empty fragments not allowed.",
-            "pattern": "^[^#]#?$"
+            "pattern": "^[^#]*#?$"
         },
         "$schema": {
             "type": "string",


### PR DESCRIPTION
Found this while testing when the meta-schema didn't validate its own `$id`.  If we prefer something else, that's fine, just probably test that it works first.