### PR TITLE
fix relative-json-pointer xml character entities used in CDATA

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -91,7 +91,7 @@
                 </preamble>
                 <artwork>
 <![CDATA[
-   relative-json-pointer =  non-negative-integer &lt;json-pointer&gt;
+   relative-json-pointer =  non-negative-integer <json-pointer>
    relative-json-pointer =/ non-negative-integer "#"
    non-negative-integer      =  %x30 / %x31-39 *( %x30-39 )
            ; "0", or digits without a leading "0"


### PR DESCRIPTION
hi friends,
the content I've changed here is showing up incorrectly on the web site
https://json-schema.org/draft/2019-09/relative-json-pointer.html as `non-negative-integer &lt;json-pointer&gt;`

I don't know XML too well - whether literal `<` is allowed in CDATA, or if I've just made an invalid change, but the current output is incorrect.