### PR TITLE
Make sure xref is wrapped in `t` tag to fix #814

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -133,9 +133,12 @@
                         the new referenced value is that object.
                     </t>
                 </list>
+            </t>
+            <t>
                 If the remainder of the Relative JSON Pointer is a JSON Pointer, then
-                evaluation proceeds as per <xref target="RFC6901">RFC 6901, Section 4</xref>
-                ("Evaluation"), with the modification that the initial reference
+                evaluation proceeds as per
+                <xref target="RFC6901">RFC 6901, Section 5</xref>
+                with the modification that the initial reference
                 being used is the reference currently being held (which may not be
                 root of the document).
             </t>


### PR DESCRIPTION
Looks like if you have a `t` tag with a `list` tag, you're not expected to have other tags at the same level.

I couldn't find the documentation to confirm this, but this change does seem to fix the issue.