### PR TITLE
[suggestion] don't link vocabulary URIs; they are not retrievable

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1099,7 +1099,7 @@
             </t>
             <t>
                 The current URI for the Core vocabulary is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/core"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/core&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -1918,7 +1918,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Applicator vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/applicator"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/applicator&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -286,7 +286,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Hyper-Schema vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/hyper-schema"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/hyper-schema&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema, which differs from the

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -206,7 +206,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Validation vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/validation"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/validation&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -548,7 +548,7 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Format vocabulary, is:
-                    <eref target="https://json-schema.org/draft/2019-09/vocab/format"/>.
+                    &lt;https://json-schema.org/draft/2019-09/vocab/format&gt;.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
@@ -926,7 +926,7 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Content vocabulary, is:
-                    <eref target="https://json-schema.org/draft/2019-09/vocab/content"/>.
+                    &lt;https://json-schema.org/draft/2019-09/vocab/content&gt;.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
@@ -1123,7 +1123,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Meta-Data vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/meta-data"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/meta-data&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:


### PR DESCRIPTION
it doesn't seem to me to make sense that these are links. there is no document to retrieve. if you follow the link, it just links back to the same sections of the spec the link came from.