### PR TITLE
Fixing Wording in Annotation Section

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -859,8 +859,8 @@
                     on behalf of applications.
                 </t>
                 <t>
-                    Unless otherwise specified, the value of an annotation keyword's
-                    annotation is the keyword's value.  However, other behaviors are possible.
+                    Unless otherwise specified, the value of an annotation keyword
+                    is the keyword's value.  However, other behaviors are possible.
                     For example, <xref target="json-hyper-schema">JSON Hyper-Schema's</xref>
                     "links" keyword is a complex annotation that produces a value based
                     in part on the instance data.


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->
This commit fixes wording in Annotation section in json-schema-core.

**(Before)**
Unless otherwise specified, **the value of an annotation keyword's annotation** is the keyword's value. However, other behaviors are possible.

**(After)**
Unless otherwise specified, *the value of an annotation keyword* is the keyword's value. However, other behaviors are possible.