### PR TITLE
Fix applicator meta-schema for unevaluatedProperties

### DIFF
--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -18,12 +18,7 @@
         },
         "contains": { "$recursiveRef": "#" },
         "additionalProperties": { "$recursiveRef": "#" },
-        "unevaluatedProperties": {
-            "type": "object",
-            "additionalProperties": {
-                "$recursiveRef": "#"
-            }
-        },
+        "unevaluatedProperties": { "$recursiveRef": "#" },
         "properties": {
             "type": "object",
             "additionalProperties": { "$recursiveRef": "#" },


### PR DESCRIPTION
While doing meta validation of the proposed OAS 3.1 meta-schema, I got an unexpected error that turned out to be caused by an error in the Draft 2019-09 applicator meta-schema for `unevaluatedProperties`. The OAS 3.1 meta-schema uses `"unevaluatedProperties": false`, which failed meta-validation because `false` is not an object.