### PR TITLE
use tag uris for vocabularies

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -2,13 +2,13 @@
     "$schema": "https://json-schema.org/draft/2019-09/hyper-schema",
     "$id": "https://json-schema.org/draft/2019-09/hyper-schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/core": true,
-        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-09/vocab/validation": true,
-        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-09/vocab/format": false,
-        "https://json-schema.org/draft/2019-09/vocab/content": true,
-        "https://json-schema.org/draft/2019-09/vocab/hyper-schema": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/core": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/applicator": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/validation": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/meta-data": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/format": false,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/content": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/hyper-schema": true
     },
     "$recursiveAnchor": true,
 

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1099,7 +1099,7 @@
             </t>
             <t>
                 The current URI for the Core vocabulary is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/core"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/core&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -1918,7 +1918,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Applicator vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/applicator"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/applicator&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1099,7 +1099,7 @@
             </t>
             <t>
                 The current URI for the Core vocabulary is:
-                &lt;https://json-schema.org/draft/2019-09/vocab/core&gt;.
+                &lt;tag:json-schema.org,2019:draft/2019-09/vocab/core&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -1918,7 +1918,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Applicator vocabulary, is:
-                &lt;https://json-schema.org/draft/2019-09/vocab/applicator&gt;.
+                &lt;tag:json-schema.org,2019:draft/2019-09/vocab/applicator&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -3581,9 +3581,9 @@ User-Agent: product-name/5.4.1 so-cool-json-schema/1.0.2 curl/7.43.0
   "$id": "https://example.com/meta/general-use-example",
   "$recursiveAnchor": true,
   "$vocabulary": {
-    "https://json-schema.org/draft/2019-09/vocab/core": true,
-    "https://json-schema.org/draft/2019-09/vocab/applicator": true,
-    "https://json-schema.org/draft/2019-09/vocab/validation": true,
+    "tag:json-schema.org,2019:draft/2019-09/vocab/core": true,
+    "tag:json-schema.org,2019:draft/2019-09/vocab/applicator": true,
+    "tag:json-schema.org,2019:draft/2019-09/vocab/validation": true,
     "https://example.com/vocab/example-vocab": true
   },
   "allOf": [

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -286,7 +286,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Hyper-Schema vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/hyper-schema"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/hyper-schema&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema, which differs from the

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -286,7 +286,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Hyper-Schema vocabulary, is:
-                &lt;https://json-schema.org/draft/2019-09/vocab/hyper-schema&gt;.
+                &lt;tag:json-schema.org,2019:draft/2019-09/vocab/hyper-schema&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema, which differs from the

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -206,7 +206,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Validation vocabulary, is:
-                &lt;https://json-schema.org/draft/2019-09/vocab/validation&gt;.
+                &lt;tag:json-schema.org,2019:draft/2019-09/vocab/validation&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -548,7 +548,7 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Format vocabulary, is:
-                    &lt;https://json-schema.org/draft/2019-09/vocab/format&gt;.
+                    &lt;tag:json-schema.org,2019:draft/2019-09/vocab/format&gt;.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
@@ -926,7 +926,7 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Content vocabulary, is:
-                    &lt;https://json-schema.org/draft/2019-09/vocab/content&gt;.
+                    &lt;tag:json-schema.org,2019:draft/2019-09/vocab/content&gt;.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
@@ -1123,7 +1123,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Meta-Data vocabulary, is:
-                &lt;https://json-schema.org/draft/2019-09/vocab/meta-data&gt;.
+                &lt;tag:json-schema.org,2019:draft/2019-09/vocab/meta-data&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -206,7 +206,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Validation vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/validation"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/validation&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:
@@ -548,7 +548,7 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Format vocabulary, is:
-                    <eref target="https://json-schema.org/draft/2019-09/vocab/format"/>.
+                    &lt;https://json-schema.org/draft/2019-09/vocab/format&gt;.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
@@ -926,7 +926,7 @@
                 </t>
                 <t>
                     The current URI for this vocabulary, known as the Content vocabulary, is:
-                    <eref target="https://json-schema.org/draft/2019-09/vocab/content"/>.
+                    &lt;https://json-schema.org/draft/2019-09/vocab/content&gt;.
                 </t>
                 <t>
                     The current URI for the corresponding meta-schema is:
@@ -1123,7 +1123,7 @@
             </t>
             <t>
                 The current URI for this vocabulary, known as the Meta-Data vocabulary, is:
-                <eref target="https://json-schema.org/draft/2019-09/vocab/meta-data"/>.
+                &lt;https://json-schema.org/draft/2019-09/vocab/meta-data&gt;.
             </t>
             <t>
                 The current URI for the corresponding meta-schema is:

--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/applicator",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/applicator": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/applicator": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/content.json
+++ b/meta/content.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/content",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/content": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/content": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/core.json
+++ b/meta/core.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/core",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/core": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/core": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/format.json
+++ b/meta/format.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/format",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/format": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/format": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/hyper-schema.json
+++ b/meta/hyper-schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/hyper-schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/hyper-schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/hyper-schema": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/hyper-schema": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/meta-data",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/meta-data": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/meta-data": true
     },
     "$recursiveAnchor": true,
 

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/validation",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/validation": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/validation": true
     },
     "$recursiveAnchor": true,
 

--- a/schema.json
+++ b/schema.json
@@ -2,12 +2,12 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/schema",
     "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/core": true,
-        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-09/vocab/validation": true,
-        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-09/vocab/format": false,
-        "https://json-schema.org/draft/2019-09/vocab/content": true
+        "tag:json-schema.org,2019:draft/2019-09/vocab/core": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/applicator": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/validation": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/meta-data": true,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/format": false,
+        "tag:json-schema.org,2019:draft/2019-09/vocab/content": true
     },
     "$recursiveAnchor": true,
 


### PR DESCRIPTION
this follows #874 (which is included in the diff). 

instead of using a transport protocol for vocabularies, which have no document to transport, why not use a uri that is simply an identifier? the tag URI seems like it was built for this. (I think most of the json schema members are familiar, but a tag URI is described at [taguri.org](https://www.taguri.org/), [wikipedia](https://en.wikipedia.org/wiki/Tag_URI), [its RFC](https://tools.ietf.org/html/rfc4151).)

this would help alleviate confusion on the part of people looking for retrievable resources at vocabulary URIs (#815).
