### PR TITLE
Placeholder changelog

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3765,6 +3765,21 @@ https://example.com/schemas/common#/$defs/count/minimum
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-json-schema-03">
+                        <list style="symbols">
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                        </list>
+                    </t>
                     <t hangText="draft-handrews-json-schema-02">
                         <list style="symbols">
                             <t>Update to RFC 8259 for JSON specification</t>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1432,6 +1432,15 @@
                         <list style="symbols">
                             <t>Correct email format RFC reference to 5321 instead of 5322</t>
                             <t>Clarified the set and meaning of "contentEncoding" values</t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
+                            <t></t>
                         </list>
                     </t>
                     <t hangText="draft-handrews-json-schema-validation-02">


### PR DESCRIPTION
This will allow submitting multiple PRs that edit the changelog
without causing merge conflicts as long as they each add their
log entry to different list items.  We'll remove any leftover
empty items before publication.