### PR TITLE
Fix $anchor pattern in core.json

### DIFF
--- a/meta/core.json
+++ b/meta/core.json
@@ -21,7 +21,7 @@
         },
         "$anchor": {
             "type": "string",
-            "pattern": "^[A-Za-z][-A-Za-z0-9.:_]*$"
+            "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
         },
         "$ref": {
             "type": "string",


### PR DESCRIPTION
This was missed in the $anchor specification update.