### PR TITLE
Shorten long section heading.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2160,7 +2160,7 @@
                     or modifying the subschema results in various ways.
                 </t>
 
-                <section title="Keywords for Applying Subschemas With Boolean Logic" anchor="logic">
+                <section title="Keywords for Applying Subschemas With Logic" anchor="logic">
                     <t>
                         These keywords correspond to logical operators for combining or modifying
                         the boolean assertion results of the subschemas.  They have no direct


### PR DESCRIPTION
Closes #809 (technically only 1/3, the other 2/3 are fixed in #930, which is mostly about other things)

"Boolean Logic" is a better heading than "Logic" but its too long and breaks the table of contents link in the IETF HTML rendering.
