### PR TITLE
[954] Fix $recursiveAnchor in schema to match spec

### DIFF
--- a/meta/core.json
+++ b/meta/core.json
@@ -33,7 +33,6 @@
         },
         "$recursiveAnchor": {
             "type": "boolean",
-            "const": true,
             "default": false
         },
         "$vocabulary": {


### PR DESCRIPTION
The spec allows values of false. This fixes the schema to match the spec.

Closes #954