### PR TITLE
Issue-949: Fixing inconsistencies in output schema

### DIFF
--- a/output/schema.json
+++ b/output/schema.json
@@ -44,7 +44,7 @@
             }
           },
           "then": {
-            "oneOf": [
+            "anyOf": [
               {
                 "required": [ "error" ]
               },

--- a/output/schema.json
+++ b/output/schema.json
@@ -3,7 +3,7 @@
   "$id": "https://json-schema.org/draft/2019-09/output/schema",
   "description": "A schema that validates the minimum requirements for validation output",
 
-  "oneOf": [
+  "anyOf": [
     { "$ref": "#/$defs/flag" },
     { "$ref": "#/$defs/basic" },
     { "$ref": "#/$defs/detailed" },
@@ -25,6 +25,9 @@
           "type": "string",
           "format": "uri-reference"
         },
+        "error": {
+          "type": "string"
+        },
         "errors": {
           "$ref": "#/$defs/outputUnitArray"
         },
@@ -41,7 +44,14 @@
             }
           },
           "then": {
-            "required": [ "errors" ]
+            "oneOf": [
+              {
+                "required": [ "error" ]
+              },
+              {
+                "required": [ "errors" ]
+              }
+            ]
           }
         },
         {


### PR DESCRIPTION
1. Changing "oneOf" to "anyOf", because basic, detailed and verbose have the same definition, oneOf would fail validation.
2. Adding "error" keyword and making either "error" or "errors" required in case "valid" is false.

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->