### PR TITLE
Fix output schema impossible validation

### DIFF
--- a/output/schema.json
+++ b/output/schema.json
@@ -3,7 +3,7 @@
   "$id": "https://json-schema.org/draft/2019-09/output/schema",
   "description": "A schema that validates the minimum requirements for validation output",
 
-  "oneOf": [
+  "anyOf": [
     { "$ref": "#/$defs/flag" },
     { "$ref": "#/$defs/basic" },
     { "$ref": "#/$defs/detailed" },


### PR DESCRIPTION
basic, detailed and verbose output can't be valid against exactly one subschema because they share the same definition

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->