### PR TITLE
Clarify how "deprecated" works w/arrays & objects

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1083,7 +1083,7 @@
     "contentSchema": {
         "type": "array",
         "minItems": 2,
-        "items": [
+        "prefixItems": [
             {
                 "const": {
                     "typ": "JWT",
@@ -1177,10 +1177,10 @@
                     the entire resource being described MAY be removed in the future.
                 </t>
                 <t>
-                    When the "deprecated" keyword is applied to an item in an array by means of 
-                    "items", if "items" is a single schema, the deprecation relates to the whole 
-                    array, while if "items" is an array of schemas, the deprecation relates to 
-                    the corresponding item according to the subschemas position.
+                    The "deprecated" keyword applies to each instance location to which the
+                    schema object containing the keyword successfully applies.  This can
+                    result in scenarios where every array item or object property
+                    is deprecated even though the containing array or object is not.
                 </t>
                 <t>
                     Omitting this keyword has the same behavior as a value of false.


### PR DESCRIPTION
Fixes #948.

Also updates a missing `prefixItems`.  Fix this by just not being so detailed about special cases and make the general usage more clear, noting that it can produce some odd scenarios.

`deprecated`, like all annotations, is intended to be handled by applications rather than JSON Schema implementations so there's not a ton of practical impact with this.