### PR TITLE
Initial base URI for embedded objects.

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1607,6 +1607,11 @@
                         that implementations document any default base URI that they assume.
                     </t>
                     <t>
+                        If a schema object is embedded in a document of another media type, then
+                        the initial base URI is determined according to the rules of that
+                        media type.
+                    </t>
+                    <t>
                         Unless the "$id" keyword described in the next section is present in the
                         root schema, this base URI SHOULD be considered the canonical URI of the
                         schema document's root schema resource.


### PR DESCRIPTION
Fixes #837.

This is to handle the case of schema objects embedded in
documents such as OAS documents, particularly when the object
is not an embedded schema resource.  This holds when the object
is a schema resource as well, but in that case the base URI is
immediately overridden by "$id".