### PR TITLE
Fix ambuguity in RFC 3339 reference.

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -732,7 +732,7 @@
                     </t>
                     <t>
                         Implementations MAY support additional attributes using the other
-                        production names defined in that section.  If "full-date" or "full-time"
+                        production names defined anywhere in that RFC.  If "full-date" or "full-time"
                         are implemented, the corresponding short form ("date" or "time"
                         respectively) MUST be implemented, and MUST behave identically.
                         Implementations SHOULD NOT define extension attributes


### PR DESCRIPTION
Fixes #959.

Don't say "that section" when we referenced two sections.