### PR TITLE
Collect unknown keywords as annotations

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -150,9 +150,9 @@
             <t>
                 JSON Schema can be extended either by defining additional vocabularies,
                 or less formally by defining additional keywords outside of any vocabulary.
-                Unrecognized individual keywords are ignored, while the behavior with respect
-                to an unrecognized vocabulary can be controlled when declaring which
-                vocabularies are in use.
+                Unrecognized individual keywords simply have their values collected as annotations,
+                while the behavior with respect to an unrecognized vocabulary can be controlled
+                when declaring which vocabularies are in use.
             </t>
             <t>
                 This document defines a core vocabulary that MUST be supported by any
@@ -351,7 +351,8 @@
                     </t>
                     <t>
                         A JSON Schema MAY contain properties which are not schema keywords.
-                        Unknown keywords SHOULD be treated as annotations.
+                        Unknown keywords SHOULD be treated as annotations, where the value
+                        of the keyword is the value of the annotation.
                     </t>
                     <t>
                         An empty schema is a JSON Schema with no properties, or only unknown
@@ -575,7 +576,8 @@
                     by any entity.  Save for explicit agreement, schema authors SHALL NOT
                     expect these additional keywords and vocabularies to be supported by
                     implementations that do not explicitly document such support.
-                    Implementations SHOULD ignore keywords they do not support.
+                    Implementations SHOULD treat keywords they do not support as annotations,
+                    where the value of the keyword is the value of the annotation.
                 </t>
                 <t>
                     Implementations MAY provide the ability to register or load handlers
@@ -1237,7 +1239,8 @@
                     </t>
                     <t>
                         Per <xref target="extending" format="counter"></xref>, unrecognized
-                        keywords SHOULD be ignored.  This remains the case for keywords defined
+                        keywords SHOULD be treated as annotations.
+                        This remains the case for keywords defined
                         by unrecognized vocabularies.  It is not currently possible to distinguish
                         between unrecognized keywords that are defined in vocabularies from
                         those that are not part of any vocabulary.

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -351,7 +351,7 @@
                     </t>
                     <t>
                         A JSON Schema MAY contain properties which are not schema keywords.
-                        Unknown keywords SHOULD be ignored.
+                        Unknown keywords SHOULD be treated as annotations.
                     </t>
                     <t>
                         An empty schema is a JSON Schema with no properties, or only unknown
@@ -3089,6 +3089,11 @@ https://example.com/schemas/common#/$defs/count/minimum
                 Validators should take care that the parsing and validating against schemas doesn't consume excessive
                 system resources.
                 Validators MUST NOT fall into an infinite loop.
+            </t>
+            <t>
+                A malicious party could cause an implementation to repeatedly collect a copy
+                of a very large value as an annotation.  Implementations SHOULD guard against
+                excessive consumption of system resources in such a scenario.
             </t>
             <t>
                 Servers MUST ensure that malicious parties can't change the functionality of


### PR DESCRIPTION
And try to avoid memory exhaustion attacks, which were possible
even with out this change but potentially more likely to happen
by accident with it (e.g. unrecognized applicator with a very
large subschema).

Fixes #698.
