### PR TITLE
Fix missed "$id" that should be "$anchor", and other minor fixes

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1692,18 +1692,18 @@
                     <artwork>
 <![CDATA[
 {
-"$id": "https://example.net/root.json",
-"items": {
-"type": "array",
-"items": { "$ref": "#item" }
-},
-"$defs": {
-"single": {
-    "$anchor": "item",
-    "type": "object",
-    "additionalProperties": { "$ref": "other.json" }
-}
-}
+    "$id": "https://example.net/root.json",
+    "items": {
+        "type": "array",
+        "items": { "$ref": "#item" }
+    },
+    "$defs": {
+        "single": {
+            "$anchor": "item",
+            "type": "object",
+            "additionalProperties": { "$ref": "other.json" }
+        }
+    }
 }
 ]]>
                     </artwork>
@@ -1764,11 +1764,11 @@
                         <artwork>
 <![CDATA[
 {
-  "$id": "https://example.com/foo",
-  "items": {
-"$id": "https://example.com/bar",
-"additionalProperties": { }
-  }
+    "$id": "https://example.com/foo",
+    "items": {
+        "$id": "https://example.com/bar",
+        "additionalProperties": { }
+    }
 }
 ]]>
                         </artwork>
@@ -1787,15 +1787,15 @@
                         <artwork>
 <![CDATA[
 {
-  "$id": "https://example.com/foo",
-  "items": {
-"$ref": "bar"
-  }
+    "$id": "https://example.com/foo",
+    "items": {
+        "$ref": "bar"
+    }
 }
 
 {
-  "$id": "https://example.com/bar",
-  "additionalProperties": { }
+    "$id": "https://example.com/bar",
+    "additionalProperties": { }
 }
 ]]>
                         </artwork>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -314,7 +314,7 @@
                     <t>
                         Object properties that are applied to the instance are called keywords,
                         or schema keywords.  Broadly speaking, keywords fall into one
-                        of four categories:
+                        of five categories:
                         <list style="hanging">
                             <t hangText="identifiers:">
                                 control schema identification through setting the schema's

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1710,8 +1710,8 @@
                 </figure>
                 <t>
                     When an implementation encounters the &lt;#/$defs/single&gt; schema,
-                    it resolves the "$id" URI reference against the current base URI to form
-                    &lt;https://example.net/root.json#item&gt;.
+                    it resolves the "$anchor" value as a fragment name against the current
+                    base URI to form &lt;https://example.net/root.json#item&gt;.
                 </t>
                 <t>
                     When an implementation then looks inside the &lt;#/items&gt; schema, it


### PR DESCRIPTION
Fixes #990, plus other minor cleanups in separate commits.

* Fix missed "$id" to "$anchor" change and related wording
* Fix indentation
* Make the number in the text match the number of items in the list of keyword classifications