### PR TITLE
Fix 988 - Inconsistencies with schema uri and empty fragment URIs

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1916,7 +1916,7 @@
                         <figure>
                             <artwork>
         <![CDATA[
-        Link: <https://example.com/my-hyper-schema#>; rel="describedby"
+        Link: <https://example.com/my-hyper-schema>; rel="describedby"
         ]]>
                             </artwork>
                         </figure>
@@ -1962,7 +1962,7 @@
                             <artwork>
         <![CDATA[
         Content-Type: application/schema-instance+json;
-                  schema="https://example.com/my-hyper-schema#"
+                  schema="https://example.com/my-hyper-schema"
         ]]>
                             </artwork>
                         </figure>

--- a/jsonschema-hyperschema.xml
+++ b/jsonschema-hyperschema.xml
@@ -282,7 +282,7 @@
         <section title="Meta-Schemas and Output Schema">
             <t>
                 The current URI for the JSON Hyper-Schema meta-schema is
-                <eref target="https://json-schema.org/draft/2019-09/hyper-schema#"/>.
+                <eref target="https://json-schema.org/draft/2019-09/hyper-schema"/>.
             </t>
             <t>
                 The current URI for this vocabulary, known as the Hyper-Schema vocabulary, is:
@@ -299,7 +299,7 @@
                 Schema, and use of this format can be declared by referencing the normative
                 link description schema as the schema for the data structure that uses the links.
                 The URI of the normative link description schema is:
-                <eref target="https://json-schema.org/draft/2019-09/links#"/>.
+                <eref target="https://json-schema.org/draft/2019-09/links"/>.
             </t>
             <t>
                 JSON Hyper-Schema implementations are free to provide output in any format.
@@ -310,7 +310,7 @@
                 It is RECOMMENDED that implementations be capable of producing output
                 in this format to facilitated testing.  The URI of the JSON Schema
                 describing the recommended output format is
-                <eref target="https://json-schema.org/draft/2019-09/output/hyper-schema#"/>.
+                <eref target="https://json-schema.org/draft/2019-09/output/hyper-schema"/>.
             </t>
             <t>
                 Updated vocabulary and meta-schema URIs MAY be published between

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -178,7 +178,7 @@
         <section title="Meta-Schema" anchor="meta-schema">
             <t>
                 The current URI for the default JSON Schema meta-schema is
-                <eref target="http://json-schema.org/draft/2019-09/schema"/>.
+                <eref target="https://json-schema.org/draft/2019-09/schema"/>.
                 For schema author convenience, this meta-schema describes all vocabularies
                 defined in this specification and the JSON Schema Core specification,
                 as well as two former keywords which are reserved for a transitional period.


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

Fixes #988 and other inconsistencies regarding empty fragments.

@Relequestual regarding the issue and empty fragments you [wrote](https://github.com/json-schema-org/json-schema-spec/issues/988#issuecomment-688483240)

> The spec says "MUST NOT have an empty fragment".

The exact wording of the [spec](https://github.com/json-schema-org/json-schema-spec/blob/2747ab4a506af937117a92cf35acce3880438a53/jsonschema-core.xml#L1330) with respect to `$id` (not `$schema`) currently is

>  "$id" MUST NOT contain a non-empty fragment, and SHOULD NOT contain an empty fragment.

I guess you referred to this part of the spec since I could not find any other mentioning of empty fragments. I read this as

- `http://example.com/my-schema-id#non-empty` must not be used
- `http://example.com/my-schema-id#` should not be used

I am only writing this because this PR picks up on your original comment and also removes some empty fragments which I assume are very likely unintended while not being totally against the spec itself, though.
