### PR TITLE
Clarify what "absolute" means for keyword absolute location

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2705,11 +2705,18 @@
                 <section title="Keyword Absolute Location">
                     <t>
                         The absolute, dereferenced location of the validating keyword.  The value MUST
-                        be expressed as an absolute URI using the canonical URI of the relevant
+                        be expressed as a full URI using the canonical URI of the relevant
                         schema object, and it MUST NOT include by-reference applicators
                         such as "$ref" or "$dynamicRef" as non-terminal path components.
                         It MAY end in such keywords if the error or annotation is for that
                         keyword, such as an unresolvable reference.
+                        <cref>
+                            Note that "absolute" here is in the sense of "absolute filesystem path"
+                            (meaning the complete location) rather than the "absolute-URI"
+                            terminology from RFC 3986 (meaning with scheme but without fragment).
+                            Keyword absolute locations will always have a fragment in order to
+                            identify the keyword.
+                        </cref>
                     </t>
                     <figure>
                         <artwork>


### PR DESCRIPTION
It is like absolute filesystem paths, not like absolute-URI
from RFC 3986.  In fact, an absolute keyword location can
never be an RFC 3986 absolute-URI because a fragment must always
be present to identify the keyword.

_**NOTE**: this PR is **not** for any discussion of renaming fields in the output format, since someone always wants to rename something.  If you want to rename something, get consensus around it and file it as a new issue/PR.  Do not raise it here._