### PR TITLE
The value of prefixItems MUST be non-empty

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2303,7 +2303,7 @@
                 <section title="Keywords for Applying Subschemas to Arrays">
                     <section title="prefixItems">
                         <t>
-                            The value of "prefixItems" MUST be an array of valid JSON Schemas.
+                            The value of "prefixItems" MUST be a non-empty array of valid JSON Schemas.
                         </t>
                         <t>
                             Validation succeeds if each element of the instance validates


### PR DESCRIPTION
A prefix of zero length makes no sense.

Fixes #975, thanks @karenetheridge!