### PR TITLE
Fix ECMA-262 link

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3296,7 +3296,7 @@ https://example.com/schemas/common#/$defs/count/minimum
             &RFC8259;
             &ldp;
             <reference anchor="ecma262"
-            target="https://www.ecma-international.org/ecma-262/11.0">
+            target="https://www.ecma-international.org/ecma-262/11.0/index.html">
                 <front>
                     <title>ECMA-262, 11th edition specification</title>
                     <author/>


### PR DESCRIPTION
According to the main ECMA-262 page, the link needs an "index.html" suffix.
There's no guarantee that linking to the raw "11.0/" directory will lead to
the correct place, even if it does. This updates to the correct well-known
link. Not all sites necessarily support a default page for an empty path
suffix; it is not correct to remove the last part.

Ref: https://www.ecma-international.org/publications/standards/Ecma-262.htm