### PR TITLE
it is no longer valid to treat $comment as an unknown keyword

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1578,8 +1578,7 @@
                     properties are present is implementation-dependent.
                 </t>
                 <t>
-                    Implementations SHOULD treat "$comment" identically to an unknown extension
-                    keyword.  They MAY strip "$comment" values at any point during processing.
+                    Implementations MAY strip "$comment" values at any point during processing.
                     In particular, this allows for shortening schemas when the size of deployed
                     schemas is a concern.
                 </t>


### PR DESCRIPTION
..because now, we collect unknown keywords as annotations, and this behaviour
is explicitly prohibited for $comment.

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->