### PR TITLE
Fix "dynamic" keywords in core vocabulary meta-schema

### DIFF
--- a/meta/core.json
+++ b/meta/core.json
@@ -27,13 +27,13 @@
             "type": "string",
             "format": "uri-reference"
         },
-        "$recursiveRef": {
+        "$dynamicRef": {
             "type": "string",
             "format": "uri-reference"
         },
-        "$recursiveAnchor": {
-            "type": "boolean",
-            "default": false
+        "$dynamicAnchor": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
         },
         "$vocabulary": {
             "type": "object",


### PR DESCRIPTION
I appears this was missed when updating the meta-schemas to use `$dynamicRef` and `$dynamicAnchor`.