### PR TITLE
Keywords may look at instance data

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1093,7 +1093,7 @@
                 </t>
                 <t>
                     Keywords MAY be defined to use JSON Pointers or Relative JSON Pointers to examine
-                    parts of an instance outside the current scope.
+                    parts of an instance outside the current evaluation location.
                 </t>
                 <t>
                     Keywords that allow adjusting the location using a Relative JSON Pointer SHOULD

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1085,6 +1085,21 @@
                     undesirable interactions with references in certain circumstances.
                 </t>
             </section>
+            <section title="Loading Instance Data">
+                <t>
+                    While none of the vocabularies defined as part of this or the associated documents
+                    define a keyword which may target and / or load instance data, it is possible that
+                    other vocabularies may wish to do so.
+                </t>
+                <t>
+                    Keywords MAY be defined to use JSON Pointers or Relative JSON Pointers to examine
+                    parts of an instance outside the current scope.
+                </t>
+                <t>
+                    Keywords that allow adjusting the location using a Relative JSON Pointer SHOULD
+                    default to using the current location if a default is desireable.
+                </t>
+            </section>
         </section>
         <section title="The JSON Schema Core Vocabulary">
             <t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1088,7 +1088,7 @@
             <section title="Loading Instance Data">
                 <t>
                     While none of the vocabularies defined as part of this or the associated documents
-                    define a keyword which may target and / or load instance data, it is possible that
+                    define a keyword which may target and/or load instance data, it is possible that
                     other vocabularies may wish to do so.
                 </t>
                 <t>


### PR DESCRIPTION
Specify that other keywords may load or inspect instance data in other locations

Fixes #855 