### PR TITLE
[1044] Improve "maxContains" and "minContains" descriptions

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -413,12 +413,13 @@
                         then this keyword has no effect.
                     </t>
                     <t>
-                        An array instance is valid against "maxContains" if its
-                        value is less than or equal to, the array length of the annotation
-                        result from an adjacent
-                        <xref target="json-schema">"contains"</xref> keyword where the
-                        annotation is an array, or the length of the instance array
-                        where the annotation is "true".
+                        An instance array is valid against "maxContains" in two ways, depending on
+                        the form of the annotation result of an adjacent
+                        <xref target="json-schema">"contains"</xref> keyword. The first way is if
+                        the annotation result is an array and the length of that array is less than
+                        or equal to the "maxContains" value. The second way is if the annotation
+                        result is a boolean "true" and the instance array length is less than or
+                        equal to the "maxContains" value.
                     </t>
                 </section>
 
@@ -431,12 +432,13 @@
                         then this keyword has no effect.
                     </t>
                     <t>
-                        An array instance is valid against "minContains" if its
-                        value is greater than or equal to, the array length of the annotation
-                        result from an adjacent
-                        <xref target="json-schema">"contains"</xref> keyword where the
-                        annotation is an array, or the length of the instance array
-                        where the annotation is "true".
+                        An instance array is valid against "minContains" in two ways, depending on
+                        the form of the annotation result of an adjacent
+                        <xref target="json-schema">"contains"</xref> keyword. The first way is if
+                        the annotation result is an array and the length of that array is greater
+                        than or equal to the "minContains" value. The second way is if the
+                        annotation result is a boolean "true" and the instance array length is
+                        greater than or equal to the "minContains" value.
                     </t>
                     <t>
                         A value of 0 is allowed, but is only useful for setting a range


### PR DESCRIPTION
I feel this change makes the descriptions easier to parse and to digest. I also swapped "instance" and "array" because this is really an "array belonging to an instance" and not an "instance of an array."

Fixes #1044