### PR TITLE
Support for IRI references (#59)

### DIFF
--- a/meta/core.json
+++ b/meta/core.json
@@ -10,14 +10,14 @@
     "type": ["object", "boolean"],
     "properties": {
         "$id": {
-            "$ref": "#/$defs/uriReferenceString",
+            "$ref": "#/$defs/iriReferenceString",
             "$comment": "Non-empty fragments not allowed.",
             "pattern": "^[^#]*#?$"
         },
         "$schema": { "$ref": "#/$defs/uriString" },
-        "$ref": { "$ref": "#/$defs/uriReferenceString" },
+        "$ref": { "$ref": "#/$defs/iriReferenceString" },
         "$anchor": { "$ref": "#/$defs/anchorString" },
-        "$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+        "$dynamicRef": { "$ref": "#/$defs/iriReferenceString" },
         "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
         "$vocabulary": {
             "type": "object",
@@ -47,6 +47,10 @@
         "uriReferenceString": {
             "type": "string",
             "format": "uri-reference"
+        },
+        "iriReferenceString": {
+            "type": "string",
+            "format": "iri-reference"
         }
     }
 }


### PR DESCRIPTION
This would add support for IRI references in `$id`, `$ref` and `$dynamicRef` as per https://github.com/json-schema-org/json-schema-spec/issues/59