### PR TITLE
Improve wording for the type keyword in the spec

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -225,8 +225,11 @@
                         or "integer" which matches any number with a zero fractional part.
                     </t>
                     <t>
-                        An instance validates if and only if the instance is in any of the sets listed
-                        for this keyword.
+                        If the value of "type" is a string, then an instance validates successfully if
+                        its type matches the type represented by the value of the string.
+
+                        If the value of "type" is an array, then an instance validates successfully if
+                        its type matches any of the types indicated by the strings in the array.
                     </t>
                 </section>
 


### PR DESCRIPTION
Fixes https://github.com/json-schema-org/json-schema-spec/issues/1080

I adjusted the wording suggested in the issue, so let me know if anyone thinks it doesn't read clearly enough.