### PR TITLE
further specify the format of uri-references throughout

### DIFF
--- a/meta/core.json
+++ b/meta/core.json
@@ -10,14 +10,15 @@
     "type": ["object", "boolean"],
     "properties": {
         "$id": {
-            "$ref": "#/$defs/uriReferenceString",
+            "type": "string",
+            "format": "uri-reference",
             "$comment": "Non-empty fragments not allowed.",
             "pattern": "^[^#]*#?$"
         },
         "$schema": { "$ref": "#/$defs/uriString" },
-        "$ref": { "$ref": "#/$defs/uriReferenceString" },
+        "$ref": { "$ref": "#/$defs/uriReferenceToSchemaString" },
         "$anchor": { "$ref": "#/$defs/anchorString" },
-        "$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+        "$dynamicRef": { "$ref": "#/$defs/uriReferenceToSchemaString" },
         "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
         "$vocabulary": {
             "type": "object",
@@ -43,9 +44,11 @@
             "type": "string",
             "format": "uri"
         },
-        "uriReferenceString": {
+        "uriReferenceToSchemaString": {
             "type": "string",
-            "format": "uri-reference"
+            "format": "uri-reference",
+            "$comment": "any fragment must be empty, or match anchor or json-pointer syntax",
+            "pattern": "^[^#]*(|#([A-Za-z_][-A-Za-z0-9.:_]*|/([^~]|~[01])*))$"
         }
     }
 }

--- a/output/schema.json
+++ b/output/schema.json
@@ -19,7 +19,9 @@
         },
         "absoluteKeywordLocation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "$comment": "any fragment must be non-empty, and use json-pointer syntax",
+          "pattern": "^[^#]*(#/([^~]|~[01])*)$"
         },
         "instanceLocation": {
           "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -51,7 +51,7 @@
         },
         "$recursiveRef": {
             "$comment": "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
-            "$ref": "meta/core#/$defs/uriReferenceString",
+            "$ref": "meta/core#/$defs/uriReferenceToSchemaString",
             "deprecated": true
         }
     }


### PR DESCRIPTION
- $id cannot have a fragment at all, so separate it from the common definiiion
- $ref, $dynamicRef, $recursiveRef must be a uri-reference to a schema
location: when the fragment is non-empty, it must refer to an $anchor or a
json-pointer
- absoluteKeywordLocation in result outputs must use canonical
URIs/uri-references: either there is no fragment, or it is non-empty and
encodes a json pointer

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->