### PR TITLE
Allow contains to apply to objects as well as arrays

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3851,6 +3851,10 @@ https://example.com/schemas/common#/$defs/count/minimum
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-bhutton-json-schema-next">
+                        <list style="symbols">
+                        </list>
+                    </t>
                     <t hangText="draft-bhutton-json-schema-00">
                         <list style="symbols">
                             <t>"$schema" MAY change for embedded resources</t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2343,17 +2343,25 @@
                             This is to ensure that all possible annotations are collected.
                         </t>
                         <t>
-                            Logically, the validation result of applying the value subschema to each
-                            item in the array MUST be ORed with "false", resulting in an overall
-                            validation result.
+                            An object instance is valid against "contains" if at least one of
+                            its property values is valid against the given schema. The subschema
+                            MUST be applied to every property value even after the first match has
+                            been found, in order to collect annotations for use by other keywords.
+                            This is to ensure that all possible annotations are collected.
                         </t>
                         <t>
-                            This keyword produces an annotation value which is an array of
-                            the indexes to which this keyword validates successfully when applying
-                            its subschema, in ascending order. The value MAY be a boolean "true" if
-                            the subschema validates successfully when applied to every index of the
-                            instance. The annotation MUST be present if the instance array to which
-                            this keyword's schema applies is empty.
+                            Logically, the validation result of applying the value subschema to each
+                            item in the array or property in the object MUST be ORed with "false",
+                            resulting in an overall validation result.
+                        </t>
+                        <t>
+                            This keyword produces an annotation value which is an array of the
+                            indexes or property names to which this keyword validates successfully
+                            when applying its subschema, in ascending order. The value MAY be a
+                            boolean "true" if the subschema validates successfully when applied to
+                            every index or property value of the instance. The annotation MUST be
+                            present if the instance array or object to which this keyword's schema
+                            applies is empty.
                         </t>
                     </section>
                 </section>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3853,6 +3853,7 @@ https://example.com/schemas/common#/$defs/count/minimum
                 <list style="hanging">
                     <t hangText="draft-bhutton-json-schema-next">
                         <list style="symbols">
+                            <t>"contains" now applies to objects as well as arrays</t>
                         </list>
                     </t>
                     <t hangText="draft-bhutton-json-schema-00">

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2330,40 +2330,6 @@
                             Implementations that do not support annotation collection MUST do so.
                         </t>
                     </section>
-
-                    <section title="contains">
-                        <t>
-                            The value of this keyword MUST be a valid JSON Schema.
-                        </t>
-                        <t>
-                            An array instance is valid against "contains" if at least one of
-                            its elements is valid against the given schema. The subschema MUST be
-                            applied to every array element even after the first match has
-                            been found, in order to collect annotations for use by other keywords.
-                            This is to ensure that all possible annotations are collected.
-                        </t>
-                        <t>
-                            An object instance is valid against "contains" if at least one of
-                            its property values is valid against the given schema. The subschema
-                            MUST be applied to every property value even after the first match has
-                            been found, in order to collect annotations for use by other keywords.
-                            This is to ensure that all possible annotations are collected.
-                        </t>
-                        <t>
-                            Logically, the validation result of applying the value subschema to each
-                            item in the array or property in the object MUST be ORed with "false",
-                            resulting in an overall validation result.
-                        </t>
-                        <t>
-                            This keyword produces an annotation value which is an array of the
-                            indexes or property names to which this keyword validates successfully
-                            when applying its subschema, in ascending order. The value MAY be a
-                            boolean "true" if the subschema validates successfully when applied to
-                            every index or property value of the instance. The annotation MUST be
-                            present if the instance array or object to which this keyword's schema
-                            applies is empty.
-                        </t>
-                    </section>
                 </section>
 
                 <section title="Keywords for Applying Subschemas to Objects">
@@ -2455,6 +2421,42 @@
                         </t>
                         <t>
                             Omitting this keyword has the same behavior as an empty schema.
+                        </t>
+                    </section>
+                </section>
+
+                <section title="Other Keywords for Applying Subschemas">
+                    <section title="contains">
+                        <t>
+                            The value of this keyword MUST be a valid JSON Schema.
+                        </t>
+                        <t>
+                            An array instance is valid against "contains" if at least one of
+                            its elements is valid against the given schema. The subschema MUST be
+                            applied to every array element even after the first match has
+                            been found, in order to collect annotations for use by other keywords.
+                            This is to ensure that all possible annotations are collected.
+                        </t>
+                        <t>
+                            An object instance is valid against "contains" if at least one of
+                            its property values is valid against the given schema. The subschema
+                            MUST be applied to every property value even after the first match has
+                            been found, in order to collect annotations for use by other keywords.
+                            This is to ensure that all possible annotations are collected.
+                        </t>
+                        <t>
+                            Logically, the validation result of applying the value subschema to each
+                            item in the array or property in the object MUST be ORed with "false",
+                            resulting in an overall validation result.
+                        </t>
+                        <t>
+                            This keyword produces an annotation value which is an array of the
+                            indexes or property names to which this keyword validates successfully
+                            when applying its subschema, in ascending order. The value MAY be a
+                            boolean "true" if the subschema validates successfully when applied to
+                            every index or property value of the instance. The annotation MUST be
+                            present if the instance array or object to which this keyword's schema
+                            applies is empty.
                         </t>
                     </section>
                 </section>

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -410,13 +410,13 @@
                         then this keyword has no effect.
                     </t>
                     <t>
-                        An instance array is valid against "maxContains" in two ways, depending on
-                        the form of the annotation result of an adjacent
+                        An instance array or object is valid against "maxContains" in two ways,
+                        depending on the form of the annotation result of an adjacent
                         <xref target="json-schema">"contains"</xref> keyword. The first way is if
                         the annotation result is an array and the length of that array is less than
                         or equal to the "maxContains" value. The second way is if the annotation
-                        result is a boolean "true" and the instance array length is less than or
-                        equal to the "maxContains" value.
+                        result is a boolean "true" and the instance length is less than or equal to
+                        the "maxContains" value.
                     </t>
                 </section>
 
@@ -429,13 +429,13 @@
                         then this keyword has no effect.
                     </t>
                     <t>
-                        An instance array is valid against "minContains" in two ways, depending on
-                        the form of the annotation result of an adjacent
+                        An instance array or object is valid against "minContains" in two ways,
+                        depending on the form of the annotation result of an adjacent
                         <xref target="json-schema">"contains"</xref> keyword. The first way is if
                         the annotation result is an array and the length of that array is greater
                         than or equal to the "minContains" value. The second way is if the
-                        annotation result is a boolean "true" and the instance array length is
-                        greater than or equal to the "minContains" value.
+                        annotation result is a boolean "true" and the instance length is greater
+                        than or equal to the "minContains" value.
                     </t>
                     <t>
                         A value of 0 is allowed, but is only useful for setting a range

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -415,8 +415,8 @@
                         <xref target="json-schema">"contains"</xref> keyword. The first way is if
                         the annotation result is an array and the length of that array is less than
                         or equal to the "maxContains" value. The second way is if the annotation
-                        result is a boolean "true" and the instance length is less than or equal to
-                        the "maxContains" value.
+                        result is a boolean "true" and the instance length (number of items or
+                        properties) is less than or equal to the "maxContains" value.
                     </t>
                 </section>
 
@@ -434,8 +434,8 @@
                         <xref target="json-schema">"contains"</xref> keyword. The first way is if
                         the annotation result is an array and the length of that array is greater
                         than or equal to the "minContains" value. The second way is if the
-                        annotation result is a boolean "true" and the instance length is greater
-                        than or equal to the "minContains" value.
+                        annotation result is a boolean "true" and the instance length (number of
+                        items or properties) is greater than or equal to the "minContains" value.
                     </t>
                     <t>
                         A value of 0 is allowed, but is only useful for setting a range


### PR DESCRIPTION
Resolves https://github.com/json-schema-org/json-schema-spec/issues/1077

The two ways to go with this were to have `contains`/`minContains`/`maxContains` apply to objects, or to introduce three new keywords that apply to objects. I went with the first option because that was the only one anyone expressed a preference for and no one objected.