### PR TITLE
Remove repetitiously redundant paragraphs

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2061,13 +2061,6 @@
                 The current URI for the corresponding meta-schema is:
                 <eref target="https://json-schema.org/draft/2020-12/meta/applicator"/>.
             </t>
-            <t>
-                Updated vocabulary and meta-schema URIs MAY be published between
-                specification drafts in order to correct errors.  Implementations
-                SHOULD consider URIs dated after this specification draft and
-                before the next to indicate the same syntax and semantics
-                as those listed here.
-            </t>
             <section title="Keyword Independence">
                 <t>
                     Schema keywords typically operate independently, without
@@ -2496,13 +2489,6 @@
             <t>
                 The current URI for the corresponding meta-schema is:
                 <eref target="https://json-schema.org/draft/2020-12/meta/unevaluated"/>.
-            </t>
-            <t>
-                Updated vocabulary and meta-schema URIs MAY be published between
-                specification drafts in order to correct errors.  Implementations
-                SHOULD consider URIs dated after this specification draft and
-                before the next to indicate the same syntax and semantics
-                as those listed here.
             </t>
 
             <section title="Keyword Independence">


### PR DESCRIPTION
Per #1089 we don't need to repeat this in every vocabulary section, just in the opening sections (8.1.3).  Also includes a separate commit updating the year in all of the active specs.