### PR TITLE
Fix 2019-09 hyperschema meta-schemas

### DIFF
--- a/links.json
+++ b/links.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/hyper-schema",
+    "$schema": "https://json-schema.org/draft/2019-09",
     "$id": "https://json-schema.org/draft/2019-09/links",
     "title": "Link Description Object",
     "allOf": [
@@ -36,7 +36,7 @@
                     "format": "uri-template"
                 },
                 "hrefSchema": {
-                    "$recursiveRef": "https://json-schema.org/draft/2019-09/hyper-schema",
+                    "$ref": "https://json-schema.org/draft/2019-09/hyper-schema",
                     "default": false
                 },
                 "templatePointers": {
@@ -63,7 +63,7 @@
                     "type": "string"
                 },
                 "targetSchema": {
-                    "$recursiveRef": "https://json-schema.org/draft/2019-09/hyper-schema",
+                    "$ref": "https://json-schema.org/draft/2019-09/hyper-schema",
                     "default": true
                 },
                 "targetMediaType": {
@@ -71,7 +71,7 @@
                 },
                 "targetHints": { },
                 "headerSchema": {
-                    "$recursiveRef": "https://json-schema.org/draft/2019-09/hyper-schema",
+                    "$ref": "https://json-schema.org/draft/2019-09/hyper-schema",
                     "default": true
                 },
                 "submissionMediaType": {
@@ -79,7 +79,7 @@
                     "default": "application/json"
                 },
                 "submissionSchema": {
-                    "$recursiveRef": "https://json-schema.org/draft/2019-09/hyper-schema",
+                    "$ref": "https://json-schema.org/draft/2019-09/hyper-schema",
                     "default": true
                 },
                 "$comment": {


### PR DESCRIPTION
Related to #1120 

The links.json schema uses `$recursiveRef` wrong. In fact, `$recursiveRef` is not capable of expressing the relationship that was
intended. With this version, schemas in the `links` keyword are pinned to the 2019-09 hyperschema dialect even if `$recursiveRef` is used to extend the 2019-09 hyperschema dialect. While not exactly what was intended, this covers all but advanced use-cases.