### PR TITLE
Add dialect schema for hyperschema 2019-09 with schema 2020-12

### DIFF
--- a/hyper-schema.json
+++ b/hyper-schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/hyper-schema",
+    "$id": "https://json-schema.org/draft/2020-12/hyper-schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-schema.org/draft/2020-12/vocab/content": true,
+        "https://json-schema.org/draft/2019-09/vocab/hyper-schema": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "JSON Hyper-Schema",
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/schema" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/hyper-schema" }
+    ],
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+%24id}"
+        }
+    ]
+}

--- a/links.json
+++ b/links.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/links",
+    "title": "Link Description Object",
+
+    "type": "object",
+    "properties": {
+        "anchor": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "anchorPointer": {
+            "type": "string",
+            "anyOf": [
+                { "format": "json-pointer" },
+                { "format": "relative-json-pointer" }
+            ]
+        },
+        "rel": {
+            "anyOf": [
+                { "type": "string" },
+                {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1
+                }
+            ]
+        },
+        "href": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "hrefSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": false
+        },
+        "templatePointers": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "anyOf": [
+                    { "format": "json-pointer" },
+                    { "format": "relative-json-pointer" }
+                ]
+            }
+        },
+        "templateRequired": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "targetSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": true
+        },
+        "targetMediaType": {
+            "type": "string"
+        },
+        "targetHints": {},
+        "headerSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": true
+        },
+        "submissionMediaType": {
+            "type": "string",
+            "default": "application/json"
+        },
+        "submissionSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": true
+        },
+        "$comment": {
+            "type": "string"
+        }
+    },
+    "required": [ "rel", "href" ]
+}

--- a/meta/hyper-schema.json
+++ b/meta/hyper-schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/hyper-schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/hyper-schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/hyper-schema": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "JSON Hyper-Schema Vocabulary Schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "base": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "$ref": "https://json-schema.org/draft/2020-12/links"
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+%24id}"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #1120 
Related to #1132 

This is more complicated than it normally would be because 2019-09 and 2020-12 use different dynamic scope keywords and `$recrusiveRef` doesn't do everything it needs to do. In the future, we would only need to write the dialect schema and can reuse the vocabulary and links schemas.