### PR TITLE
Drop the initial resolve step for dynamic references

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1510,22 +1510,15 @@
                         <t>
                             Together with "$dynamicAnchor", "$dynamicRef" implements a cooperative
                             extension mechanism that is primarily useful with recursive schemas
-                            (schemas that reference themselves).  The extension point is defined with
-                            "$dynamicAnchor" and only exhibits runtime dynamic behavior when referenced
-                            with "$dynamicRef".
+                            (schemas that reference themselves).  The extension point is defined
+                            with "$dynamicAnchor", and only exhibits runtime dynamic behavior when
+                            referenced with "$dynamicRef".
                         </t>
                         <t>
-                            The value of the "$dynamicRef" property MUST be a string which is a
-                            IRI-Reference that contains a valid <xref target="anchor">plain name
-                            fragment</xref>.  Resolved against the current IRI base, it indicates
-                            the schema resource used as the starting point for runtime resolution.
-                            This initial resolution is safe to perform on schema load.
-                        </t>
-                        <t>
-                            The schema to apply is the outermost schema resource in the
-                            <xref target="scopes">dynamic scope</xref> that defines a
-                            "$dynamicAnchor" that matches the plain name fragment in the initially
-                            resolved IRI.
+                            The value of the "$dynamicRef" property MUST be a valid
+                            <xref target="anchor">plain name fragment</xref>. The schema to apply is
+                            the outermost schema resource in the <xref target="scopes">dynamic scope</xref>
+                            that defines a "$dynamicAnchor" matching the value of this keyword.
                         </t>
                         <t>
                             For a full example using these keyword, see appendix


### PR DESCRIPTION
Fixes #1140 

Without bookending or initial resolution, describing how dynamic references work becomes much more straightforward.

This is provided as a draft PR just to show what the change might look like if agreed upon. Any discussion about whether or not to make this change should happen in #1140.