### PR TITLE
Allow the XML2RFC GNU Make variable to be overridden by the caller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-XML2RFC=xml2rfc
+XML2RFC ?= xml2rfc
 
 OUT = \
 	jsonschema-core.html jsonschema-core.txt \


### PR DESCRIPTION
It is a best practice to allow callers to override the value of these
program variables. For example, with this chance, you can do:

```sh
make XML2RFC=/opt/bin/xml2rfc
```

See: https://www.gnu.org/software/make/manual/make.html#Command-Variables
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->