### PR TITLE
Simplify tarball creation GNU Make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,8 @@ all: $(OUT)
 	$(XML2RFC) --html $< -o $@
 
 json-schema.tar.gz: $(OUT)
-	mkdir json-schema
 	git clone . json-schema
-	(cd json-schema && make)
+	make -C json-schema
 	tar -czf json-schema.tar.gz --exclude '.*' json-schema
 	rm -rf json-schema
 


### PR DESCRIPTION
- There is no need to `mkdir json-schema` as the `git clone` command
  will create the target out of the box
- We can pass `-C` to `make` to set a base directory instead of doing a
  `cd`

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->