### PR TITLE
Add missing closing curly brace to D.2. example

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3672,7 +3672,7 @@ https://example.com/schemas/common#/$defs/count/minimum
     {"$ref": "https://json-schema.org/draft/2020-12/meta/core"},
     {"$ref": "https://json-schema.org/draft/2020-12/meta/applicator"},
     {"$ref": "https://json-schema.org/draft/2020-12/meta/validation"},
-    {"$ref": "https://example.com/meta/example-vocab",
+    {"$ref": "https://example.com/meta/example-vocab"}
   ],
   "patternProperties": {
     "^unevaluated": false


### PR DESCRIPTION
We also remove the trailing comma.

See: https://github.com/json-schema-org/json-schema-spec/pull/1162
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->