### PR TITLE
fix the type for $recursiveAnchor

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -46,7 +46,7 @@
         },
         "$recursiveAnchor": {
             "$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
-            "$ref": "meta/core#/$defs/anchorString",
+            "type": "boolean",
             "deprecated": true
         },
         "$recursiveRef": {


### PR DESCRIPTION
Keywords from draft2019-09 are intended to be silently accepted (with a deprecated annotation), not cause validation failure.