### PR TITLE
fix the type for $recursiveAnchor

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -46,7 +46,7 @@
         },
         "$recursiveAnchor": {
             "$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
-            "$ref": "meta/core#/$defs/anchorString",
+            "type": "boolean",
             "deprecated": true
         },
         "$recursiveRef": {


### PR DESCRIPTION
This replaces https://github.com/json-schema-org/json-schema-spec/pull/1200, as it was decided the change cannot go into the patch release.