### PR TITLE
Changing property key names in output format

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2704,9 +2704,10 @@
 
                 <section title="Keyword Relative Location">
                     <t>
-                        The relative location of the validating keyword that follows the validation
-                        path.  The value MUST be expressed as a JSON Pointer, and it MUST include
-                        any by-reference applicators such as "$ref" or "$dynamicRef".
+                        The relative location of the validating keyword that follows the path
+                        traversed through the schema.  The value MUST be expressed as a JSON
+                        Pointer, and it MUST include any by-reference applicators such as
+                        "$ref" or "$dynamicRef".
                     </t>
                     <figure>
                         <artwork>
@@ -2720,7 +2721,7 @@
                     due to the inclusion of these by-reference applicator keywords.
                     </t>
                     <t>
-                        The JSON key for this information is "keywordLocation".
+                        The JSON key for this information is "evaluationPath".
                     </t>
                 </section>
 
@@ -2752,7 +2753,7 @@ https://example.com/schemas/common#/$defs/count/minimum
                         over a reference or if the schema does not declare an absolute IRI as its "$id".
                     </t>
                     <t>
-                        The JSON key for this information is "absoluteKeywordLocation".
+                        The JSON key for this information is "schemaLocation".
                     </t>
                 </section>
 
@@ -2786,13 +2787,15 @@ https://example.com/schemas/common#/$defs/count/minimum
 
                 <section title="Nested Results">
                     <t>
-                        For the two hierarchical structures, this property will hold nested errors
-                        and annotations.
+                        For "basic", this property will appear only at the root node and will hold
+                        all errors or annotations in a list.
                     </t>
                     <t>
-                        The JSON key for nested results in failed validations is "errors"; for
-                        successful validations it is "annotations".  Note the plural forms, as
-                        a keyword with nested results can also have a local error or annotation.
+                        For "detailed" and "verbose", this property will hold nested errors
+                        and annotations in a tree structure, mimicking that of the schema.
+                    </t>
+                    <t>
+                        The JSON key for nested results is "nested".
                     </t>
                 </section>
 
@@ -2802,19 +2805,14 @@ https://example.com/schemas/common#/$defs/count/minimum
                 <t>
                     The output MUST be an object containing a boolean property named "valid".  When
                     additional information about the result is required, the output MUST also contain
-                    "errors" or "annotations" as described below.
+                    "nested" as described below.
                     <list>
                         <t>
                             "valid" - a boolean value indicating the overall validation success or
                             failure
                         </t>
                         <t>
-                            "errors" - the collection of errors or annotations produced by a failed
-                            validation
-                        </t>
-                        <t>
-                            "annotations" - the collection of errors or annotations produced by a
-                            successful validation
+                            "nested" - the collection of errors or annotations produced by a keyword
                         </t>
                     </list>
                     For these examples, the following schema and instance will be used.

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2908,35 +2908,35 @@ https://example.com/schemas/common#/$defs/count/minimum
 <![CDATA[
 {
   "valid": false,
-  "errors": [
+  "nested": [
     {
-      "keywordLocation": "",
+      "evaluationPath": "",
       "instanceLocation": "",
       "error": "A subschema had errors."
     },
     {
-      "keywordLocation": "/items/$ref",
-      "absoluteKeywordLocation":
+      "evaluationPath": "/items/$ref",
+      "schemaLocation":
         "https://example.com/polygon#/$defs/point",
       "instanceLocation": "/1",
       "error": "A subschema had errors."
     },
     {
-      "keywordLocation": "/items/$ref/required",
-      "absoluteKeywordLocation":
+      "evaluationPath": "/items/$ref/required",
+      "schemaLocation":
         "https://example.com/polygon#/$defs/point/required",
       "instanceLocation": "/1",
       "error": "Required property 'y' not found."
     },
     {
-      "keywordLocation": "/items/$ref/additionalProperties",
-      "absoluteKeywordLocation":
+      "evaluationPath": "/items/$ref/additionalProperties",
+      "schemaLocation":
         "https://example.com/polygon#/$defs/point/additionalProperties",
       "instanceLocation": "/1/z",
       "error": "Additional property 'z' found but was invalid."
     },
     {
-      "keywordLocation": "/minItems",
+      "evaluationPath": "/minItems",
       "instanceLocation": "",
       "error": "Expected at least 3 items but found 2"
     }
@@ -2977,28 +2977,28 @@ https://example.com/schemas/common#/$defs/count/minimum
 <![CDATA[
 {
   "valid": false,
-  "keywordLocation": "",
+  "evaluationPath": "",
   "instanceLocation": "",
-  "errors": [
+  "nested": [
     {
       "valid": false,
-      "keywordLocation": "/items/$ref",
-      "absoluteKeywordLocation":
+      "evaluationPath": "/items/$ref",
+      "schemaLocation":
         "https://example.com/polygon#/$defs/point",
       "instanceLocation": "/1",
-      "errors": [
+      "nested": [
         {
           "valid": false,
-          "keywordLocation": "/items/$ref/required",
-          "absoluteKeywordLocation":
+          "evaluationPath": "/items/$ref/required",
+          "schemaLocation":
             "https://example.com/polygon#/$defs/point/required",
           "instanceLocation": "/1",
           "error": "Required property 'y' not found."
         },
         {
           "valid": false,
-          "keywordLocation": "/items/$ref/additionalProperties",
-          "absoluteKeywordLocation":
+          "evaluationPath": "/items/$ref/additionalProperties",
+          "schemaLocation":
             "https://example.com/polygon#/$defs/point/additionalProperties",
           "instanceLocation": "/1/z",
           "error": "Additional property 'z' found but was invalid."
@@ -3007,7 +3007,7 @@ https://example.com/schemas/common#/$defs/count/minimum
     },
     {
       "valid": false,
-      "keywordLocation": "/minItems",
+      "evaluationPath": "/minItems",
       "instanceLocation": "",
       "error": "Expected at least 3 items but found 2"
     }
@@ -3060,27 +3060,27 @@ https://example.com/schemas/common#/$defs/count/minimum
 // result
 {
   "valid": false,
-  "keywordLocation": "",
+  "evaluationPath": "",
   "instanceLocation": "",
-  "errors": [
+  "nested": [
     {
       "valid": true,
-      "keywordLocation": "/type",
+      "evaluationPath": "/type",
       "instanceLocation": ""
     },
     {
       "valid": true,
-      "keywordLocation": "/properties",
+      "evaluationPath": "/properties",
       "instanceLocation": ""
     },
     {
       "valid": false,
-      "keywordLocation": "/additionalProperties",
+      "evaluationPath": "/additionalProperties",
       "instanceLocation": "",
-      "errors": [
+      "nested": [
         {
           "valid": false,
-          "keywordLocation": "/additionalProperties",
+          "evaluationPath": "/additionalProperties",
           "instanceLocation": "/disallowedProp",
           "error": "Additional property 'disallowedProp' found but was invalid."
         }

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2705,9 +2705,14 @@
                 <section title="Keyword Relative Location">
                     <t>
                         The relative location of the validating keyword that follows the path
-                        traversed through the schema.  The value MUST be expressed as a JSON
+                        traversed through the schema. The value MUST be expressed as a JSON
                         Pointer, and it MUST include any by-reference applicators such as
                         "$ref" or "$dynamicRef".
+                        <cref>
+                            The schema may not actually have a value at the location indicated
+                            by this pointer. It is provided as an indication of the traversal
+                            path only.
+                        </cref>
                     </t>
                     <figure>
                         <artwork>

--- a/output/verbose-example.json
+++ b/output/verbose-example.json
@@ -1,62 +1,62 @@
 {
   "valid": false,
-  "keywordLocation": "",
+  "evaluationPath": "",
   "instanceLocation": "",
-  "errors": [
+  "nested": [
     {
       "valid": true,
-      "keywordLocation": "/$defs",
+      "evaluationPath": "/$defs",
       "instanceLocation": ""
     },
     {
       "valid": true,
-      "keywordLocation": "/type",
+      "evaluationPath": "/type",
       "instanceLocation": ""
     },
     {
       "valid": false,
-      "keywordLocation": "/items",
+      "evaluationPath": "/items",
       "instanceLocation": "",
-      "errors": [
+      "nested": [
         {
           "valid": true,
-          "keywordLocation": "/items/$ref",
-          "absoluteKeywordLocation":
+          "evaluationPath": "/items/$ref",
+          "schemaLocation":
             "https://example.com/polygon#/items/$ref",
           "instanceLocation": "/0",
-          "annotations": [
+          "nested": [
             {
               "valid": true,
-              "keywordLocation": "/items/$ref",
-              "absoluteKeywordLocation":
+              "evaluationPath": "/items/$ref",
+              "schemaLocation":
                 "https://example.com/polygon#/$defs/point",
               "instanceLocation": "/0",
-              "annotations": [
+              "nested": [
                 {
                   "valid": true,
-                  "keywordLocation": "/items/$ref/type",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/type",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/type",
                   "instanceLocation": "/0"
                 },
                 {
                   "valid": true,
-                  "keywordLocation": "/items/$ref/properties",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/properties",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/properties",
                   "instanceLocation": "/0"
                 },
                 {
                   "valid": true,
-                  "keywordLocation": "/items/$ref/required",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/required",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/required",
                   "instanceLocation": "/0"
                 },
                 {
                   "valid": true,
-                  "keywordLocation": "/items/$ref/additionalProperties",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/additionalProperties",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/additionalProperties",
                   "instanceLocation": "/0"
                 }
@@ -66,50 +66,50 @@
         },
         {
           "valid": false,
-          "keywordLocation": "/items/$ref",
-          "absoluteKeywordLocation":
+          "evaluationPath": "/items/$ref",
+          "schemaLocation":
             "https://example.com/polygon#/items/$ref",
           "instanceLocation": "/1",
-          "errors": [
+          "nested": [
             {
               "valid": false,
-              "keywordLocation": "/items/$ref",
-              "absoluteKeywordLocation":
+              "evaluationPath": "/items/$ref",
+              "schemaLocation":
                 "https://example.com/polygon#/$defs/point",
               "instanceLocation": "/1",
-              "errors": [
+              "nested": [
                 {
                   "valid": true,
-                  "keywordLocation": "/items/$ref/type",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/type",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/type",
                   "instanceLocation": "/1"
                 },
                 {
                   "valid": true,
-                  "keywordLocation": "/items/$ref/properties",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/properties",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/properties",
                   "instanceLocation": "/1"
                 },
                 {
                   "valid": false,
-                  "keywordLocation": "/items/$ref/required",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/required",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/required",
                   "instanceLocation": "/1"
                 },
                 {
                   "valid": false,
-                  "keywordLocation": "/items/$ref/additionalProperties",
-                  "absoluteKeywordLocation":
+                  "evaluationPath": "/items/$ref/additionalProperties",
+                  "schemaLocation":
                     "https://example.com/polygon#/$defs/point/additionalProperties",
                   "instanceLocation": "/1",
-                  "errors": [
+                  "nested": [
                     {
                       "valid": false,
-                      "keywordLocation": "/items/$ref/additionalProperties",
-                      "absoluteKeywordLocation":
+                      "evaluationPath": "/items/$ref/additionalProperties",
+                      "schemaLocation":
                         "https://example.com/polygon#/$defs/point/additionalProperties",
                       "instanceLocation": "/1/z"
                     }
@@ -123,7 +123,7 @@
     },
     {
       "valid": false,
-      "keywordLocation": "/minItems",
+      "evaluationPath": "/minItems",
       "instanceLocation": ""
     }
   ]


### PR DESCRIPTION
This PR is the start of changes to the output format as discussed [here](https://github.com/json-schema-org/community/discussions/63).

It covers changing property names:

- `keywordLocation` -> `evaluationPath`
- `absoluteSchemaLocation` -> `schemaLocation`
- `errors`/`annotations` -> `nested`

(In making these edits, I began to see why so many people were asking for examples with annotations.  I expected that to be a trivial exercise given the error examples, but I get it now.)