### PR TITLE
proposal to add keyword metadata to vocabularies by defining a new vocabulary

### DIFF
--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/applicator",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/applicator": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/applicator",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/applicator": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/applicator": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/applicator",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/applicator": true
+        "https://json-schema.org/draft/next/vocab/applicator": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -47,11 +48,103 @@
         "oneOf": { "$ref": "#/$defs/schemaArray" },
         "not": { "$dynamicRef": "#meta" }
     },
+    "applicators": {
+        "prefixItems": "arrayChild",
+        "items": "arrayChild",
+        "contains": [ "objectChild", "arrayChild" ],
+        "additionalProperties": "objectChild",
+        "properties": "objectChild",
+        "patternProperties": "objectChild",
+        "dependentSchemas": "inPlace",
+        "propertyDependencies": "inPlace",
+        "propertyNames": "objectChild",
+        "if": "inPlace",
+        "then": "inPlace",
+        "else": "inPlace",
+        "allOf": "inPlace",
+        "anyOf": "inPlace",
+        "oneOf": "inPlace",
+        "not": "inPlace"
+    },
+    "assertions": [
+        "prefixItems",
+        "items",
+        "contains",
+        "additionalProperties",
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+        "propertyDependencies",
+        "propertyNames",
+        "then",
+        "else",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "not"
+    ],
+    "annotations": {
+        "prefixItems": {
+            "kind": [ "producer", "collector" ],
+            "producedValue": {
+                "oneOf": [
+                    { "$ref": "#/$defs/nonNegativeInteger" },
+                    { "type": "boolean" }
+                ]
+            }
+        },
+        "items": {
+            "kind": [ "producer", "collector" ],
+            "producedValue": { "const": true }
+        },
+        "contains": {
+            "kind": [ "producer", "collector" ],
+            "producedValue": {
+                "type": "array",
+                "items": { "$ref": "#/$defs/nonNegativeInteger" }
+            }
+        },
+        "additionalProperties": {
+            "kind": [ "producer", "collector" ],
+            "producedValue": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        },
+        "properties": {
+            "kind": [ "producer", "collector" ],
+            "producedValue": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        },
+        "patternProperties": {
+            "kind": [ "producer", "collector" ],
+            "producedValue": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        },
+        "dependentSchemas": { "kind": "collector" },
+        "propertyDependencies": { "kind": "collector" },
+        "propertyNames": { "kind": "collector" },
+        "if": { "kind": "collector" },
+        "then": { "kind": "collector" },
+        "else": { "kind": "collector" },
+        "allOf": { "kind": "collector" },
+        "anyOf": { "kind": "collector" },
+        "oneOf": { "kind": "collector" },
+        "not": { "kind": "collector" }
+    },
     "$defs": {
         "schemaArray": {
             "type": "array",
             "minItems": 1,
             "items": { "$dynamicRef": "#meta" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
         }
     }
 }

--- a/meta/content.json
+++ b/meta/content.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/content",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/content": true
+        "https://json-schema.org/draft/next/vocab/content": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -13,5 +14,10 @@
         "contentEncoding": { "type": "string" },
         "contentMediaType": { "type": "string" },
         "contentSchema": { "$dynamicRef": "#meta" }
+    },
+    "annotations": {
+        "contentEncoding": { "kind": "producer" },
+        "contentMediaType": { "kind": "producer" },
+        "contentSchema": { "kind": "producer" }
     }
 }

--- a/meta/content.json
+++ b/meta/content.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/content",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/content": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/content": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/content.json
+++ b/meta/content.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/content",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/content": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/format-annotation.json
+++ b/meta/format-annotation.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/format-annotation",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/format-annotation": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/format-annotation": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/format-annotation.json
+++ b/meta/format-annotation.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/format-annotation",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/format-annotation": true
+        "https://json-schema.org/draft/next/vocab/format-annotation": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -10,5 +11,8 @@
     "type": ["object", "boolean"],
     "properties": {
         "format": { "type": "string" }
+    },
+    "annotations": {
+        "format": { "kind": "producer" }
     }
 }

--- a/meta/format-annotation.json
+++ b/meta/format-annotation.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/format-annotation",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/format-annotation": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/format-assertion.json
+++ b/meta/format-assertion.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/format-assertion",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/format-assertion": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/format-assertion": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/format-assertion.json
+++ b/meta/format-assertion.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/format-assertion",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/format-assertion": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/format-assertion.json
+++ b/meta/format-assertion.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/format-assertion",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/format-assertion": true
+        "https://json-schema.org/draft/next/vocab/format-assertion": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -10,5 +11,9 @@
     "type": ["object", "boolean"],
     "properties": {
         "format": { "type": "string" }
+    },
+    "assertions": [ "format" ],
+    "annotations": {
+        "format": { "kind": "producer" }
     }
 }

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/meta-data",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/meta-data": true
+        "https://json-schema.org/draft/next/vocab/meta-data": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -33,5 +34,14 @@
             "type": "array",
             "items": true
         }
+    },
+    "annotations": {
+        "title": { "kind": "producer" },
+        "description": { "kind": "producer" },
+        "default": { "kind": "producer" },
+        "deprecated": { "kind": "producer" },
+        "readOnly": { "kind": "producer" },
+        "writeOnly": { "kind": "producer" },
+        "examples": { "kind": "producer" }
     }
 }

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/meta-data",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/meta-data": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/meta-data": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/meta-data",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/meta-data": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/unevaluated.json
+++ b/meta/unevaluated.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/unevaluated",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/unevaluated": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/unevaluated.json
+++ b/meta/unevaluated.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/unevaluated",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/unevaluated": true
+        "https://json-schema.org/draft/next/vocab/unevaluated": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -11,5 +12,17 @@
     "properties": {
         "unevaluatedItems": { "$dynamicRef": "#meta" },
         "unevaluatedProperties": { "$dynamicRef": "#meta" }
+    },
+    "applicators": {
+        "unevaluatedItems": "arrayChild",
+        "unevaluatedProperties": "objectChild"
+    },
+    "assertions": [
+        "unevaluatedItems",
+        "unevaluatedProperties"
+    ],
+    "annotations": {
+        "unevaluatedItems": { "kind": "collector" },
+        "unevaluatedProperties": { "kind": "collector" }
     }
 }

--- a/meta/unevaluated.json
+++ b/meta/unevaluated.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/unevaluated",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/unevaluated": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/unevaluated": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "https://json-schema.org/draft/next/meta/validation",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/validation": true
+        "https://json-schema.org/draft/next/vocab/validation": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true
     },
     "$dynamicAnchor": "meta",
 
@@ -68,6 +69,27 @@
             }
         }
     },
+    "assertions": [
+        "type",
+        "const",
+        "multipleOf",
+        "maximum",
+        "exclusiveMaximum",
+        "minimum",
+        "exclusiveMinimum",
+        "maxLength",
+        "minLength",
+        "pattern",
+        "maxItems",
+        "minItems",
+        "uniqueItems",
+        "maxContains",
+        "minContains",
+        "maxProperties",
+        "minProperties",
+        "required",
+        "dependentRequired"
+    ],
     "$defs": {
         "nonNegativeInteger": {
             "type": "integer",

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/validation",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/validation": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -1,9 +1,8 @@
 {
-    "$schema": "https://json-schema.org/draft/next/schema",
+    "$schema": "https://json-schema.org/draft/next/meta/vocabulary",
     "$id": "https://json-schema.org/draft/next/meta/validation",
     "$vocabulary": {
-        "https://json-schema.org/draft/next/vocab/validation": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": false
+        "https://json-schema.org/draft/next/vocab/validation": true
     },
     "$dynamicAnchor": "meta",
 

--- a/meta/vocabulary.json
+++ b/meta/vocabulary.json
@@ -3,6 +3,12 @@
     "$id": "https://json-schema.org/draft/next/meta/vocabulary",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/applicator": true,
+        "https://json-schema.org/draft/next/vocab/unevaluated": true,
+        "https://json-schema.org/draft/next/vocab/validation": true,
+        "https://json-schema.org/draft/next/vocab/meta-data": true,
+        "https://json-schema.org/draft/next/vocab/format-annotation": true,
+        "https://json-schema.org/draft/next/vocab/content": true,
         "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
 

--- a/meta/vocabulary.json
+++ b/meta/vocabulary.json
@@ -3,7 +3,7 @@
     "$id": "https://json-schema.org/draft/next/meta/vocabulary",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/core": true,
-        "https://json-schema.org/draft/next/vocab/vocabulary": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": false
     },
 
     "title": "Vocabulary meta-data vocabulary meta-schema",

--- a/meta/vocabulary.json
+++ b/meta/vocabulary.json
@@ -21,7 +21,7 @@
                         "minItems": 1,
                         "uniqueItems": true
                     }
-                ],
+                ]
             }
         },
         "assertions": {
@@ -42,7 +42,7 @@
                                 "minItems": 1,
                                 "uniqueItems": true
                             }
-                        ],
+                        ]
                     }
                 },
                 "producedValue": { "$dynamicRef": "#meta" }

--- a/meta/vocabulary.json
+++ b/meta/vocabulary.json
@@ -45,7 +45,7 @@
                         ],
                     }
                 },
-                "producedValue": true
+                "producedValue": { "$dynamicRef": "#meta" }
             },
             "required": [ "kind" ]
         }

--- a/meta/vocabulary.json
+++ b/meta/vocabulary.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$id": "https://json-schema.org/draft/next/meta/vocabulary",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/vocabulary": true,
+    },
+
+    "title": "Vocabulary meta-data vocabulary meta-schema",
+    "description": "Defines keywords for use in vocabulary meta-schemas to provide additional information for their keywords",
+    "type": [ "object", "boolean" ],
+    "properties": {
+        "applicators": {
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {"$ref": "#/$defs/applicatorKind"},
+                    {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/applicatorKind" },
+                        "minItems": 1,
+                        "uniqueItems": true
+                    }
+                ],
+            }
+        },
+        "assertions": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "annotations": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            { "$ref": "#/$defs/annotationKind" },
+                            {
+                                "type": "array",
+                                "items": { "$ref": "#/$defs/annotationKind" },
+                                "minItems": 1,
+                                "uniqueItems": true
+                            }
+                        ],
+                    }
+                },
+                "producedValue": true
+            },
+            "required": [ "kind" ]
+        }
+    },
+    "annotations": {
+        "applicators": { "kind": "producer" },
+        "assertions": { "kind": "producer" },
+        "annotations": { "kind": "producer" }
+    },
+    "$defs": {
+        "applicatorKind": {
+            "enum": [ "objectChild", "arrayChild", "inPlace" ]
+        },
+        "annotationKind": {
+            "enum": [ "producer", "collector" ]
+        }
+    }
+}


### PR DESCRIPTION
_This will likely be of most interest to @handrews and maybe @jdesrosiers._

Since the introduction of vocabularies, the idea of them being self-descriptive has been tossed around with abstract ideas but not much in the concrete space.  This is a proposal that provides some of that meta-data that we've been looking for via a new vocabulary specifically designed _for_ vocabulary meta-schemas.

This proposal adds three new keywords:

### `applicators`

The value of this keyword is an object whose keys are all of the keywords defined in the vocab which have applicator behavior.

The values of each property is the kind of applicator that keyword is: `objectChild`, `arrayChild`, or `inPlace`.

This references #602, in which @handrews classified applicators as being "object-child" (meaning they look at the children of an object instance), "array-child" (they look at the children of an array instance), or "in-place" (they look at the instance itself).

### `assertions`

The value of this keyword is an array which contains the names of all keywords defined in the vocab which provide assertion behavior.

### `annotations`

The value of this keyword is an object whose keys are all of the keywords defined in the vocab which either produce annotations or collects them from subschemas.

The value of each property is an object with two properties:

- `kind` identifies whether the keyword produces annotations, collects them, or both.  The value is `producer`, `collector`, or an array of these values (much like the array format we use for `type`).  This property is required.
- `producedAnnotation` provides a schema for the annotation value if the keyword is an annotation producer.  This property is optional.  If the keyword is an annotation producer and this property is missing, then the annotation produced by the keyword is expected to be the value of the keyword itself (e.g. `title` produces an annotation equal to its value).

---

I've also updated all of the existing meta-schemas to use this new vocab so that you can see how it works.  Interestingly _[nods to @jdesrosiers]_, the core keywords don't have _any_ behavior.  They are informative only and are self-descriptive rather than instance-descriptive.

I plan on writing up an actual vocabulary for this, but I wanted to get what I had in front of people before I put in that effort.

I know that previous discussions on doing something like this had wanted the vocab URI to actually function as a URL to point to some separate machine-readable document, but I rather like the idea of a vocab-describing vocab and having everything just embedded directly into the meta-schemas.

I think that these keywords go a long way toward building a generic validator.  For instance `unevaluated*` depends on annotation results from in-place applicators.  With the definition provided in this proposal, a validator can now know what all of the in-place applicators are just from knowing the vocabularies.  The implementation of `unevaluated*` doesn't need to change to _also_ know to wait for the results from new in-place applicator keywords defined by extra vocabularies.  (This is something that my implementation can't currently handle.  I'd need to have code for new in-place applicators specifically, which is really awkward.)

That brings me to the other thing that could be included that I haven't added yet: annotation dependencies.  For example, `additionalProperties` depends upon the annotation result from `properties` and `patternProperties`.

---

I had started with an alternate design of adding this information to the subschemas under the `properties` keyword, but I realized that doesn't really work for the same reason that `required` was moved out of the subschema into the parent schema going from draft 3 to draft 4.

I think introducing these aggregate keywords is more in line with what we already have, even though it _can_ feel somewhat redundant to list the keywords multiple times.