### PR TITLE
Add month to Relative JSON Pointer's spec <date/>

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -40,7 +40,7 @@
             </address>
         </author>
 
-        <date year="2021"/>
+        <date year="2022"/>
         <workgroup>Internet Engineering Task Force</workgroup>
         <keyword>JSON</keyword>
         <keyword>JavaScript</keyword>


### PR DESCRIPTION
It is currently not possible to build the Relative JSON Pointer's spec.
`xml2rfc` will complain about the date tag not being the current year
while not having a month set either.

This is the error I get:

```
xml2rfc --html relative-json-pointer.xml -o relative-json-pointer.html
json-schema-spec/relative-json-pointer.xml(16): Error: Expected <date> to have the current year when month is missing, but found '2021'
Unable to complete processing relative-json-pointer.xml
```

This PR changes the `<date/>` year to the current year.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->