### PR TITLE
Replace defunct Travis CI integration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: JSON Schema
+on:
+  - push
+jobs:
+  specs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install --requirement requirements.txt
+      - run: xml2rfc --version
+      - run: make all
+      - uses: actions/upload-artifact@v2
+        with:
+          path: *.(html|txt)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,6 @@ jobs:
       - run: make all
       - uses: actions/upload-artifact@v2
         with:
-          path: *.(html|txt)
+          path: |
+              *.(html|txt)
+              !requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-install:
-- pip install "xml2rfc~=2.20"
-before_script:
-- TAG=$(git tag -l --points-at HEAD)
-script:
-- xml2rfc -V
-- make all


### PR DESCRIPTION
The GitHub Actions setup is equivalent to the Travis CI configuration
with two differences:

- The GitHub Action setup does not set the `TAG` environment variable,
  as it didn't seem like `xml2rfc` would consume that at all (unless I'm
  missing something)

- The GitHub Action preserves the spec output (txt and html) as
  artifacts that can be downloaded after a successful run (to see the
  changes without having to locally render the specs)

Fixes: https://github.com/json-schema-org/json-schema-spec/issues/1262
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->