### PR TITLE
Update the xrefs, which appear now to have underscores

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -511,7 +511,7 @@
             </t>
             <t>
                 Per the W3C's
-                <xref target="W3C.WD-fragid-best-practices-20121025">best practices for fragment identifiers</xref>,
+                <xref target="W3C_WD_fragid_best_practices_20121025">best practices for fragment identifiers</xref>,
                 plain name fragment identifiers in "application/schema+json" are reserved for referencing
                 locally named schemas.  All fragment identifiers that do
                 not match the JSON Pointer syntax MUST be interpreted as
@@ -2030,7 +2030,7 @@
                         <t>
                             It is RECOMMENDED that instances described by a schema provide a link to
                             a downloadable JSON Schema using the link relation "describedby", as defined by
-                            <xref target="W3C.REC-ldp-20150226">Linked Data Protocol 1.0, section 8.1</xref>.
+                            <xref target="W3C_REC_ldp_20150226">Linked Data Protocol 1.0, section 8.1</xref>.
                         </t>
 
                         <t>


### PR DESCRIPTION
Fixes the build errors -- I don't know how this stuff works and/or whether this has to do with upstream changes or some normalization that's happening, but this does seem to work here at least now.

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->