### PR TITLE
Ignore unknown keywords or treat as annotations

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -350,7 +350,7 @@
                         and its companions, are free to define other behaviors as well.
                     </t>
                     <t>
-                        A JSON Schema MAY contain properties which are not, or are not recognized as, schema keywords.
+                        A JSON Schema MAY contain properties which are not schema keywords or are not recognized as schema keywords.
                         The behavior of such keywords is governed by section
                         <xref target="unrecognized" format="counter"></xref>.
                     </t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -350,9 +350,9 @@
                         and its companions, are free to define other behaviors as well.
                     </t>
                     <t>
-                        A JSON Schema MAY contain properties which are not schema keywords.
-                        Unknown keywords SHOULD be treated as annotations, where the value
-                        of the keyword is the value of the annotation.
+                        A JSON Schema MAY contain properties which are not, or are not recognized as, schema keywords.
+                        The behavior of such keywords is governed by section
+                        <xref target="unrecognized" format="counter"></xref>.
                     </t>
                     <t>
                         An empty schema is a JSON Schema with no properties, or only unknown
@@ -600,14 +600,21 @@
                     by any entity.  Save for explicit agreement, schema authors SHALL NOT
                     expect these additional keywords and vocabularies to be supported by
                     implementations that do not explicitly document such support.
-                    Implementations SHOULD treat keywords they do not support as annotations,
-                    where the value of the keyword is the value of the annotation.
                 </t>
                 <t>
                     Implementations MAY provide the ability to register or load handlers
                     for vocabularies that they do not support directly.  The exact mechanism
                     for registering and implementing such handlers is implementation-dependent.
                 </t>
+
+                <section title="Handling of unrecognized or unsupported keywords" anchor="unrecognized">
+                    <t>
+                        Implementations SHOULD treat keywords they do not recognize, or that
+                        they recognize but do not support, as annotations, where the value of
+                        the keyword is the value of the annotation.  Whether an implementation
+                        collects these annotations or not, they MUST otherwise ignore the keywords.
+                    </t>
+                </section>
             </section>
 
         </section>


### PR DESCRIPTION
This is just a bug fix for an accidental oversight.  I'm hoping it's non-controversial as I don't think any of us meant to allow arbitrary behaviors for unrecognized keywords.

When we added the "SHOULD collect as annotations" behavior for
unknown keywords, we forgot to retain the MUST directive to ignore
them if the SHOULD is not followed.  Which also ensures that
no other behavior than collecting as a annotations is performed.

This also consolidates the behavioral specification in one place
as it appeared in two places before.

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->