### PR TITLE
Consolidate and clarify language around duplicate IRIs

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1353,8 +1353,8 @@
                     </t>
                     <t>
                         If present, the value for this keyword MUST be a string, and MUST represent a
-                        valid <xref target="RFC3987">IRI-reference</xref> with a non-empty non-fragment
-                        component.  This IRI-reference SHOULD be normalized, and MUST resolve to an
+                        valid <xref target="RFC3987">IRI-reference</xref>.  This IRI-reference
+                        SHOULD be normalized, and MUST resolve to an
                         <xref target="RFC3987">absolute-IRI</xref> (without a fragment),
                         or to a IRI with an empty fragment.
                     </t>
@@ -1392,7 +1392,10 @@
                         <xref target="RFC3986">RFC 3986 section 5.1.2</xref> regarding
                         encapsulating entities, if an "$id" in a subschema is a relative
                         IRI-reference, the base IRI for resolving that reference is the IRI of
-                        the parent schema resource.
+                        the parent schema resource.  Note that an "$id" consisting of an empty IRI or
+                        of the empty fragment only will result in the embedded resource having
+                        the same IRI as the encapsulating resource, which SHOULD be considered
+                        an error per section <xref target="duplicate-iris" format="counter"></xref>.
                     </t>
                     <t>
                         If no parent schema object explicitly identifies itself as a resource
@@ -1458,7 +1461,7 @@
                     </t>
                 </section>
 
-                <section title="Duplicate schema identifiers">
+                <section title="Duplicate schema identifiers" anchor="duplicate-iris">
                     <t>
                         A schema MAY (and likely will) have multiple IRIs, but there is no way
                         for an IRI to identify more than one schema. When multiple schemas

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1456,11 +1456,16 @@
                             fragment "#foo" when used in a IRI.  See below for full examples.
                         </cref>
                     </t>
+                </section>
+
+                <section title="Duplicate schema identifiers">
                     <t>
-                        The effect of specifying the same fragment name multiple times within
-                        the same resource, using any combination of "$anchor" and/or
-                        "$dynamicAnchor", is undefined.  Implementations MAY
-                        raise an error if such usage is detected.
+                        A schema MAY (and likely will) have multiple IRIs, but there is no way
+                        for an IRI to identify more than one schema. When multiple schemas
+                        attempt to identify as the same IRI through the use of "$id", "$anchor",
+                        "$dynamicAnchor", or any other mechanism, implementations SHOULD raise
+                        an error condition.  Otherwise the result is undefined, and even if
+                        documented will not be interoperable.
                     </t>
                 </section>
 
@@ -1670,11 +1675,6 @@
                         can be supplied to an implementation prior to processing instances, or may
                         be noted within a schema document as it is processed, producing associations
                         as shown in appendix <xref target="idExamples" format="counter"></xref>.
-                    </t>
-                    <t>
-                        A schema MAY (and likely will) have multiple IRIs, but there is no way for a
-                        IRI to identify more than one schema. When multiple schemas try to identify
-                        as the same IRI, validators SHOULD raise an error condition.
                     </t>
                 </section>
 

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1353,8 +1353,8 @@
                     </t>
                     <t>
                         If present, the value for this keyword MUST be a string, and MUST represent a
-                        valid <xref target="RFC3987">IRI-reference</xref>.  This IRI-reference
-                        SHOULD be normalized, and MUST resolve to an
+                        valid <xref target="RFC3987">IRI-reference</xref> with a non-empty non-fragment
+                        component.  This IRI-reference SHOULD be normalized, and MUST resolve to an
                         <xref target="RFC3987">absolute-IRI</xref> (without a fragment),
                         or to a IRI with an empty fragment.
                     </t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1467,6 +1467,11 @@
                         an error condition.  Otherwise the result is undefined, and even if
                         documented will not be interoperable.
                     </t>
+                    <t>
+                        Note that due to the semantics of JSON Pointer fragments, schema IRIs
+                        that differ only by the presence or absence of an empty fragment MUST
+                        be considered duplicates.
+                    </t>
                 </section>
 
                 <section title="Schema References" anchor="references">


### PR DESCRIPTION
Fixes issue #1271 and addresses one point mentioned in https://github.com/json-schema-org/json-schema-spec/issues/1059#issuecomment-1212726799 (but please do not drag the rest of that issue into this PR, thanks!)

The only actual changed requirement is the forbidding of `"$id": "#"`, and `"$id": ""` which are confusing and are either pointless (in a document root where they resolve to the retrieval IRI, exactly as if `$id` was not present) or problematic (in an embedded resource root, where they produce duplicate IRIs for the embedded and containing resource).

This also consolidates the two different places where duplicate IRIs were addressed.  Since the more general of the two paragraphs stated that this SHOULD be an error, I kept the SHOULD rather than the MAY that addressed only a subset of the cases.  The SHOULD technically covered the subset as well anyway.

I have emphasized that "undefined" here means that the result, whatever it is, will not be interoperable (most likely, implementations will just return the last-seen schema under that IRI, but who knows).

Note that we could continue to allow `"$id": "#"` and `"$id": ""` and just assume that the SHOULD regarding duplicate IRIs is enough to discourage that.  If that is the consensus then I can remove the commit that handles that part of the change.