### PR TITLE
Make targets for a virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ jsonschema-*.txt
 relative-json-pointer.html
 relative-json-pointer.pdf
 relative-json-pointer.txt
+
+# For the Python enviornment
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 XML2RFC ?= xml2rfc
+VENV ?= .venv
 
 OUT = \
 	jsonschema-core.html jsonschema-core.txt \
 	jsonschema-validation.html jsonschema-validation.txt \
 	relative-json-pointer.html relative-json-pointer.txt
-
 
 all: $(OUT)
 
@@ -24,6 +24,16 @@ json-schema.tar.gz: $(OUT)
 	(cd json-schema && make)
 	tar -czf json-schema.tar.gz --exclude '.*' json-schema
 	rm -rf json-schema
+
+venv: $(VENV)
+
+$(VENV):
+	python -m venv .venv
+	. .venv/bin/activate && python -m pip install --upgrade pip setuptools wheel
+	. .venv/bin/activate && python -m pip install -r requirements.txt
+
+venv-clean:
+	rm -rf .venv
 
 clean:
 	rm -f $(OUT) json-schema.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OUT = \
 	jsonschema-validation.html jsonschema-validation.txt \
 	relative-json-pointer.html relative-json-pointer.txt
 
-all: $(OUT)
+all: $(VENV) $(OUT)
 
 %.txt: %.xml
 	$(XML2RFC) --text $< -o $@
@@ -25,17 +25,15 @@ json-schema.tar.gz: $(OUT)
 	tar -czf json-schema.tar.gz --exclude '.*' json-schema
 	rm -rf json-schema
 
-venv: $(VENV)
+$(VENV): requirements.txt
+	python -m venv $@
+	$@/bin/python -m pip install --upgrade pip
+	$@/bin/python -m pip install -r requirements.txt
 
-$(VENV):
-	python -m venv .venv
-	. .venv/bin/activate && python -m pip install --upgrade pip setuptools wheel
-	. .venv/bin/activate && python -m pip install -r requirements.txt
-
-venv-clean:
-	rm -rf .venv
-
-clean:
+spec-clean:
 	rm -f $(OUT) json-schema.tar.gz
 
-.PHONY: clean all
+clean: spec-clean
+	rm -rf $(VENV)
+
+.PHONY: spec-clean clean all

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ json-schema.tar.gz: $(OUT)
 $(VENV): requirements.txt
 	python -m venv $@
 	$@/bin/python -m pip install --upgrade pip
-	$@/bin/python -m pip install -r requirements.txt
+	$@/bin/python -m pip install -r $<
 
 spec-clean:
 	rm -f $(OUT) json-schema.tar.gz

--- a/README.md
+++ b/README.md
@@ -35,19 +35,16 @@ Labels are assigned based on [Sensible Github Labels](https://github.com/Releque
     * links.json - JSON Hyper-Schema's Link Description Object meta-schema
     * hyper-schema-output.json - The recommended output format for JSON Hyper-Schema links
 
-The Makefile can create the necessary Python virtual environment for you:
+The Makefile will create the necessary Python venv for you as part of the regular make target.
+
+`make clean` will remove all output including the venv.  To clean just the spec output and
+keep the venv, use `make spec-clean`.
+
+If you want to run `xml2rfc` manually after running make for the first time, you will
+need to activate the virtual environment:
 
 ```sh
-make venv
 source .venv/bin/activate
-make
-```
-
-Or you can manually install "xml2rfc" using "pip" (https://pypi.org/project/xml2rfc/) and type "make" at a shell to build the .txt and .html spec files:
-
-```sh
-pip install --requirement requirements.txt
-make 
 ```
 
 The version of "xml2rfc" that this project uses is updated by modifying `requirements.in` and running `pip-compile requirements.in`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ Labels are assigned based on [Sensible Github Labels](https://github.com/Releque
     * links.json - JSON Hyper-Schema's Link Description Object meta-schema
     * hyper-schema-output.json - The recommended output format for JSON Hyper-Schema links
 
-Install "xml2rfc" using "pip" (https://pypi.org/project/xml2rfc/) and type "make" at a shell to build the .txt and .html spec files:
+The Makefile can create the necessary Python virtual environment for you:
+
+```sh
+make venv
+source .venv/bin/activate
+make
+```
+
+Or you can manually install "xml2rfc" using "pip" (https://pypi.org/project/xml2rfc/) and type "make" at a shell to build the .txt and .html spec files:
 
 ```sh
 pip install --requirement requirements.txt


### PR DESCRIPTION
It's common to make a virtualenv inside of your cloned repo
to ensure that you have the right enviornment for that repository,
and .venv is a common convention for that virtualenv.

This adds targets to create and clean a .venv virtual env using
the checked-in requirements.txt file.  It also adds the .venv
to the .gitignore, and updates the README.
