### PR TITLE
xref format changed again - fix broken build

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -511,7 +511,7 @@
             </t>
             <t>
                 Per the W3C's
-                <xref target="W3C_WD_fragid_best_practices_20121025">best practices for fragment identifiers</xref>,
+                <xref target="W3C.WD-fragid-best-practices-20121025">best practices for fragment identifiers</xref>,
                 plain name fragment identifiers in "application/schema+json" are reserved for referencing
                 locally named schemas.  All fragment identifiers that do
                 not match the JSON Pointer syntax MUST be interpreted as
@@ -2045,7 +2045,7 @@
                         <t>
                             It is RECOMMENDED that instances described by a schema provide a link to
                             a downloadable JSON Schema using the link relation "describedby", as defined by
-                            <xref target="W3C_REC_ldp_20150226">Linked Data Protocol 1.0, section 8.1</xref>.
+                            <xref target="W3C.REC-ldp-20150226">Linked Data Protocol 1.0, section 8.1</xref>.
                         </t>
 
                         <t>


### PR DESCRIPTION
Now there's a dot between W3C and the rest, and the underscores are back to hyphens.  Apparently.

Previously changed in PR #1268 