### PR TITLE
Missed a "schema document" -> "schema resource"

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1273,10 +1273,10 @@
                     </t>
                     <t>
                         The "$vocabulary" keyword SHOULD be used in the root schema of any schema
-                        document intended for use as a meta-schema.  It MUST NOT appear in subschemas.
+                        resource intended for use as a meta-schema.  It MUST NOT appear in subschemas.
                     </t>
                     <t>
-                        The "$vocabulary" keyword MUST be ignored in schema documents that
+                        The "$vocabulary" keyword MUST be ignored in schema resources that
                         are not being processed as a meta-schema.  This allows validating
                         a meta-schema M against its own meta-schema M' without requiring
                         the validator to understand the vocabularies declared by M.


### PR DESCRIPTION
This was just an oversight regarding where $vocabualry is legal. It should have always been "schema resource root."

Fixes #1129.