### PR TITLE
Core#Dereferencing example schema: remove second dimension of array

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1741,10 +1741,8 @@
 <![CDATA[
 {
     "$id": "https://example.net/root.json",
-    "items": {
-        "type": "array",
-        "items": { "$ref": "#item" }
-    },
+    "type": "array",
+    "items": { "$ref": "#item" },
     "$defs": {
         "single": {
             "$anchor": "item",


### PR DESCRIPTION
I think this is probably what was intended - I don't see any reason for the arrays in this example to be nested. If I'm wrong and this is how the schema is supposed to be, the reference [here](https://github.com/json-schema-org/json-schema-spec/blob/draft-bhutton-json-schema-01/jsonschema-core.xml#L1747) to the schema containing the `#item` reference should be corrected from `#/items` to `#/items/items`.

Introduced [23ba42e1](https://github.com/json-schema-org/json-schema-spec/commit/23ba42e1#diff-bda51aab56b4b2e23fc9e7249e80fe6e262dcd552f35c5de69fd4a6bf3e96b50R417-R419) - ping @awwright, not that I expect you to remember these lines six years later.