### PR TITLE
add pr-dependencies-check workflow

### DIFF
--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,8 +1,6 @@
 name: Check PR Dependencies
 
-on:
-  pull_request:
-  workflow_dispatch:
+on: pull_request
 
 jobs:
   check_dependencies:

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,0 +1,14 @@
+name: Check PR Dependencies
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+    - uses: gregsdennis/dependencies-action@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I use this on my `json-everything` repo (and I've used in it a few other places) to track when PRs are dependent upon each other.  For example, how #1285 is dependent upon #1085.

https://github.com/marketplace/actions/pr-dependency-check