### PR TITLE
Remove erroneous use of "default base IRI"

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1626,7 +1626,7 @@
                     <t>
                         <xref target="RFC3987">RFC 3987 Section 6.5</xref> and 
                         <xref target="RFC3986">RFC 3986 Section 5.1</xref> defines how to determine the
-                        default base IRI of a document.
+                        base IRI of a document.
                     </t>
                     <t>
                         Informatively, the initial base IRI of a schema is the IRI at which it was


### PR DESCRIPTION
Whatever else happens with #1299 and #1322, this wording is incorrect.  I have filed this PR because it seems like the wording may be contributing to the confusion in those issues, so I am emphasizing that this wording error is orthogonal.  #1299 in particular should be read as if this change has already been made.

This should just say "base IRI", as a "default base IRI" is a specific kind of base IRI that does not make sense in the context of this paragraph.

The term is used correctly several paragraphs down where there is a RECOMMENDATION that if a default base IRI is defined (which is not in any way required) that it be documented.

I'm marking it as a draft b/c it will likely be superseded by other changes from #1299 and/or #1322.  I'm just posting it for clarity.