### PR TITLE
Fix a lot of build warnings (only 7 lines of changes)

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="US-ASCII"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!DOCTYPE rfc [
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY RFC3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY RFC3987 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3987.xml">
@@ -22,7 +22,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-bhutton-json-schema-01" ipr="trust200902">
+<rfc category="info" docName="draft-bhutton-json-schema-01" ipr="trust200902" submissionType="IETF">
     <front>
         <title abbrev="JSON Schema">JSON Schema: A Media Type for Describing JSON Documents</title>
 

--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="US-ASCII"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!DOCTYPE rfc [
 <!ENTITY RFC1123 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1123.xml">
 <!ENTITY RFC2045 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2045.xml">
 <!ENTITY RFC2046 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2046.xml">
@@ -28,7 +28,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-bhutton-json-schema-validation-01" ipr="trust200902">
+<rfc category="info" docName="draft-bhutton-json-schema-validation-01" ipr="trust200902" submissionType="IETF">
     <front>
         <title abbrev="JSON Schema Validation">
             JSON Schema Validation: A Vocabulary for Structural Validation of JSON

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="US-ASCII"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!DOCTYPE rfc [
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY RFC6901 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6901.xml">
 <!ENTITY RFC8259 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8259.xml">
@@ -12,7 +12,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-bhutton-relative-json-pointer-00" ipr="trust200902">
+<rfc category="info" docName="draft-bhutton-relative-json-pointer-00" ipr="trust200902" submissionType="IETF">
     <front>
         <title abbrev="Relative JSON Pointers">Relative JSON Pointers</title>
 
@@ -107,7 +107,7 @@
                 </artwork>
                 <postamble>
                     where &lt;json-pointer&gt; follows the production defined in
-                    <xref target="RFC6901">RFC 6901, Section&nbsp;3</xref> ("Syntax").
+                    <xref target="RFC6901">RFC 6901, Section 3</xref> ("Syntax").
                 </postamble>
             </figure>
             <t>


### PR DESCRIPTION
This gets rid of all of the build warnings except the ones for the lines being too long, which aren't worth trying to fix as we're changing formats anyway.

But these are simple fixes to remove everything else. As of RFC 7749 (xml2rfc v2 vocabulary), the RFC 2629 DTD is no longer needed.  The submissionType was also added then.  It is supposed to default to "IETF" but apparently newer versions of xml2rfc no longer do this.

I don't know why xml2rfc did not like the no-breaking space in the xref, but it's happier with it gone.

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->