### PR TITLE
add droppedAnnotations

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2915,8 +2915,9 @@ https://example.com/schemas/common#/$defs/allOf/1
                         validation result of the containing subschema was successful.
                     </t>
                     <t>
-                        Implementations that wish to include these annotations are encouraged
-                        to provide users with a configuration option to exclude them.
+                        Implementations that wish to provide these annotations MUST NOT provide
+                        them as their default behavior.  These annotations MUST only be included
+                        by explicitly configuring the implementation to do so.
                     </t>
                     <t>
                         The value for this property MUST be an object where the

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2888,11 +2888,14 @@ https://example.com/schemas/common#/$defs/allOf/1
 
                 <section title="Annotations">
                     <t>
-                        Any annotations produced by the validation.  This property MUST NOT
-                        be included if the validation was unsuccessful.  The value
-                        for this property MUST be an object where the keys are the names of
-                        keywords and the values are the annotations produced by the
-                        associated keyword.
+                        Any annotations produced by the evaluation.  This property MUST NOT
+                        be included if the validation result of the containing subschema was
+                        unsuccessful.
+                    </t>
+                    <t>
+                        The value for this property MUST be an object where the
+                        keys are the names of keywords and the values are the annotations
+                        produced by the associated keyword.
                     </t>
                     <t>
                         Each keyword defines its own annotation data type (e.g. "properties"
@@ -2900,6 +2903,32 @@ https://example.com/schemas/common#/$defs/allOf/1
                     </t>
                     <t>
                         The JSON key for this information is "annotations".
+                    </t>
+                </section>
+
+                <section title="Dropped Annotations">
+                    <t>
+                        Any annotations produced and subsequently dropped by the evaluation
+                        due to an unsuccessful validation result of the containing subschema.
+                        This property MAY be included if the validation result of the containing
+                        subschema was unsuccessful.  It MUST NOT be included if the local
+                        validation result of the containing subschema was successful.
+                    </t>
+                    <t>
+                        Implementations that wish to include these annotations are encouraged
+                        to provide users with a configuration option to exclude them.
+                    </t>
+                    <t>
+                        The value for this property MUST be an object where the
+                        keys are the names of keywords and the values are the annotations
+                        produced by the associated keyword.
+                    </t>
+                    <t>
+                        Each keyword defines its own annotation data type (e.g. "properties"
+                        produces a list of keywords, whereas "title" produces a string).
+                    </t>
+                    <t>
+                        The JSON key for this information is "droppedAnnotations".
                     </t>
                 </section>
 

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -3325,6 +3325,10 @@ https://example.com/schemas/common#/$defs/allOf/1
           "evaluationPath": "/properties/foo/allOf/1",
           "schemaLocation": "https://json-schema.org/schemas/example#/properties/foo/allOf/1",
           "instanceLocation": "/foo",
+          "droppedAnnotations": {
+            "properties": [ "foo-prop" ],
+            "title": "foo-title"
+          },
           "nested": [
             {
               "valid": false,
@@ -3333,6 +3337,9 @@ https://example.com/schemas/common#/$defs/allOf/1
               "instanceLocation": "/foo/foo-prop",
               "errors": {
                 "const": "Expected \"1\""
+              },
+              "droppedAnnotations": {
+                "title": "foo-prop-title"
               }
             },
             {
@@ -3356,6 +3363,10 @@ https://example.com/schemas/common#/$defs/allOf/1
           "evaluationPath": "/properties/bar/$ref",
           "schemaLocation": "https://json-schema.org/schemas/example#/$defs/bar",
           "instanceLocation": "/bar",
+          "droppedAnnotations": {
+            "properties": [ "bar-prop" ],
+            "title": "bar-title"
+          },
           "nested": [
             {
               "valid": false,
@@ -3364,6 +3375,9 @@ https://example.com/schemas/common#/$defs/allOf/1
               "instanceLocation": "/bar/bar-prop",
               "errors": {
                 "minimum": "2 is less than or equal to 10"
+              },
+              "droppedAnnotations": {
+                "title": "bar-prop-title"
               }
             }
           ]

--- a/output/schema.json
+++ b/output/schema.json
@@ -31,6 +31,10 @@
           "type": "object",
           "additionalProperties": true
         },
+        "droppedAnnotations": {
+          "type": "object",
+          "additionalProperties": true
+        },
         "errors": {
           "type": "object",
           "additionalProperties": { "type": "string" }
@@ -40,7 +44,14 @@
       "allOf": [
         {
           "if": {
-            "required": [ "errors" ]
+            "anyOf": [
+              {
+                "required": [ "errors" ]
+              },
+              {
+                "required": [ "droppedAnnotations" ]
+              }
+            ]
           },
           "then": {
             "properties": {


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->
Partially addresses #1319.

This adds `droppedAnnotations` to the output unit as an optional field.  While they can be useful for debugging, these annotations are usually just noise.