### PR TITLE
Update `properties` and `patternProperties` annotation language

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2404,7 +2404,7 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names which are also present in this keyword.
+                            property names which are also present under this keyword.
                             This annotation affects the behavior of "additionalProperties" (in
                             this vocabulary) and "unevaluatedProperties" in the Unevaluated vocabulary.
                         </t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2404,7 +2404,7 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names matched by this keyword.
+                            property names which are present in both this keyword and the instance.
                             This annotation affects the behavior of "additionalProperties" (in
                             this vocabulary) and "unevaluatedProperties" in the Unevaluated vocabulary.
                         </t>
@@ -2430,7 +2430,7 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names matched by this keyword.
+                            property names matched by at least one key in this keyword.
                             This annotation affects the behavior of "additionalProperties" (in this
                             vocabulary) and "unevaluatedProperties" (in the Unevaluated vocabulary).
                         </t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2430,7 +2430,7 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names matched by at least one key in this keyword.
+                            property names matched by at least one property under this keyword.
                             This annotation affects the behavior of "additionalProperties" (in this
                             vocabulary) and "unevaluatedProperties" (in the Unevaluated vocabulary).
                         </t>

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -2404,7 +2404,7 @@
                         </t>
                         <t>
                             The annotation result of this keyword is the set of instance
-                            property names which are present in both this keyword and the instance.
+                            property names which are also present in this keyword.
                             This annotation affects the behavior of "additionalProperties" (in
                             this vocabulary) and "unevaluatedProperties" in the Unevaluated vocabulary.
                         </t>


### PR DESCRIPTION
Resolves #1310 

Improves the annotation definition language for `properties` and `patternProperties`.

`properties` - replaced "match" language to be more explicit
`patternProperties` - clarified "match" language