### PR TITLE
Clarify how to use "contentSchema"

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -960,7 +960,10 @@
                 </t>
                 <t>
                     The value of this property MUST be a valid JSON schema. It SHOULD be ignored if
-                    "contentMediaType" is not present.
+                    "contentMediaType" is not present.  Accessing the schema through the schema location
+                    IRI included as part of the annotation will ensure that it is correctly processed
+                    as a subschema.  Using the extracted annotation value directly is only safe if
+                    the schema is an embedded resource with both "$schema" and an absolute-IRI "$id".
                 </t>
             </section>
 


### PR DESCRIPTION
* Minimally fixes #1288 (as [noted](https://github.com/json-schema-org/json-schema-spec/issues/1288#issuecomment-1322612454), other ideas in that issue can be filed separately for further discussion).
* Fixes #1307 

[note: The fix is shorter than this description]

The value of `"contentSchema"` is a normal subschema, and using it out of context can fail in ways schema users are unlikely to automatically consider.  Since `"contentSchema"` has to be applied separately from the evaluation process in which it was collected as an annotation, it is schema authors and users (rather than implementers) who need to be aware of this.  In particular, users need to know the safe way to access the schema.

We know that many schema users find base URIs/IRIs confusing, and that the behavior of implementations in the absence of "$schema" is inconsistent.  Without delving into those topics (which are addressed in core, or in RFC 3986), this clarification shows how to use "contentSchema" as a normal subschema from an annotation.

It also explains the circumstances under which the extracted annotation value is safe to use.  The language attempts to balance the likelihood that readers will not be familiar enough with the restrictions to note this on their own with the desire to minimize re-stating schema processing rules documented in the core specification.  This should be enough to encourage readers to check the relevant core specification sections.

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->