### PR TITLE
Plain name IRI fragments can use unicode

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -516,13 +516,34 @@
                 locally named schemas.
             </t>
             <t>
-                Plain name fragments MUST start with a letter ([A-Za-z]) or underscore ("_"),
-                followed by any number of letters, digits ([0-9]), hyphens ("-"),
-                underscores ("_"), and periods (".").  This matches the US-ASCII part of XML's
+                Plain name fragments MUST follow XML's 
                 <xref target="xml-names">NCName production</xref>, which allows for compatibility
                 with the recommended plain name <xref target="W3C.REC-xptr-framework-20030325">syntax</xref> for
-                XML-based media types.
+                XML-based media types.  For convenience, the NCName syntax is reproduced here in ABNF form, using
+                a minimal set of rules:
+                <cref>
+                    Note that the previous syntax for plain name fragment is a subset of this syntax,
+                    which used only the first line of each of the NCNameStartChar and NCNameChar rules.
+                </cref>
             </t>
+            <figure>
+                <artwork>
+<![CDATA[
+NCNameStartChar = [A-Z] / "_" / [a-z]
+NCNameStartChar =/ %xC0-%xD6 / %xD8-%xF6 / %xF8-%x2FF
+NCNameStartChar =/ %x370-%x37D / %x37F-%x1FFF
+NCNameStartChar =/ %x200C-%x200D / %x2070-%x218F
+NCNameStartChar =/ %x2C00-%x2FEF / %x3001-%xD7FF
+NCNameStartChar =/ %xF900-%xFDCF / %xFDF0-%xFFFD
+NCNameStartChar =/ %x10000-%xEFFFF
+
+NCNameChar      = NCNameStartChar / "-" / "." / 0-9
+NCNameChar      =/ %xB7 / %x0300-%x036F / %x203F-%x2040
+
+NCName          = NCNameStartChar *NCNameChar
+]]>
+                </artwork>
+            </figure>
             <t>
                 All fragment identifiers that do
                 not match the JSON Pointer syntax MUST be interpreted as

--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -526,24 +526,20 @@
                     which used only the first line of each of the NCNameStartChar and NCNameChar rules.
                 </cref>
             </t>
-            <figure>
-                <artwork>
-<![CDATA[
-NCNameStartChar = [A-Z] / "_" / [a-z]
-NCNameStartChar =/ %xC0-%xD6 / %xD8-%xF6 / %xF8-%x2FF
-NCNameStartChar =/ %x370-%x37D / %x37F-%x1FFF
-NCNameStartChar =/ %x200C-%x200D / %x2070-%x218F
-NCNameStartChar =/ %x2C00-%x2FEF / %x3001-%xD7FF
-NCNameStartChar =/ %xF900-%xFDCF / %xFDF0-%xFFFD
-NCNameStartChar =/ %x10000-%xEFFFF
-
-NCNameChar      = NCNameStartChar / "-" / "." / 0-9
-NCNameChar      =/ %xB7 / %x0300-%x036F / %x203F-%x2040
-
+            <sourcecode type="abnf"><![CDATA[
 NCName          = NCNameStartChar *NCNameChar
-]]>
-                </artwork>
-            </figure>
+
+NCNameStartChar = "_" / ALPHA
+                / %xC0-D6 / %xD8-F6 / %xF8-2FF
+                / %x370-37D / %x37F-1FFF
+                / %x200C-200D / %x2070-218F
+                / %x2C00-2FEF / %x3001-D7FF
+                / %xF900-FDCF / %xFDF0-FFFD
+                / %x10000-EFFFF
+
+NCNameChar      = NCNameStartChar / "-" / "." / DIGIT
+                / %xB7 / %x0300-036F / %x203F-2040
+]]></sourcecode>
             <t>
                 All fragment identifiers that do
                 not match the JSON Pointer syntax MUST be interpreted as


### PR DESCRIPTION
Fixes #1314 as discussed in yesterday's community call.  This just brings plain name fragment support into parity with the rest of our IRI support, and continues to rely on XML's NCName rule for the syntax.  NCName always supported unicode, we just excluded all of it except for the US-ASCII characters.

I *think* I converted the W3C's grammar notation into ABNF properly, but if anyone is comfortable with ABNF (@awwright ?) a check would be appreciated.  The W3C's grammar involves [NCName, NCNameChar, and NCStartNameChar](https://www.w3.org/TR/2006/REC-xml-names11-20060816/#NT-NCName), which are just [Name, NameChar, and StartNameChar](https://www.w3.org/TR/xml11/#NT-NameStartChar) minus the `:` character.  I simplified the ABNF since we did not need the `:` variation at all.