### PR TITLE
Fix accidental ABNF omission for Relative JSON Pointer

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -92,27 +92,19 @@
                 length or start with a '/' (%x2F).  Similarly, a JSON Pointer will
                 never be ambiguous with the '#'.
             </t>
-            <figure align="center">
-                <preamble>
-                    The ABNF syntax of a Relative JSON Pointer is:
-                </preamble>
-                <artwork>
-<![CDATA[
-   relative-json-pointer =  origin-specification <json-pointer>
-   relative-json-pointer =/ origin-specification "#"
-   origin-specification  =  non-negative-integer [index-manipulation]
-   index-manipulation    =  ("+" / "-") non-negative-integer
-   non-negative-integer  =  %x30 / %x31-39 *( %x30-39 )
-           ; "0", or digits without a leading "0"
-]]>
-                </artwork>
-                <postamble>
-                    where &lt;json-pointer&gt; follows the production defined in
-                    <xref target="RFC6901">RFC 6901, Section 3</xref> ("Syntax").
-                </postamble>
-            </figure>
             <t>
+                The ABNF syntax of a Relative JSON Pointer is:
             </t>
+            <sourcecode type="abnf9110"><![CDATA[
+  relative-json-pointer = origin-specification json-pointer
+                        / origin-specification "#"
+                        ; json-pointer from RFC 6901
+
+  origin-specification  = non-negative-integer [ index-manipulation ]
+  index-manipulation    = ( "+" / "-" ) non-negative-integer
+  non-negative-integer  = "0" / %x31-39 *DIGIT
+                        ; zero, or digits without a leading zero
+]]></sourcecode>
         </section>
 
         <section title="Evaluation">

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -12,7 +12,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-bhutton-relative-json-pointer-00" ipr="trust200902" submissionType="IETF">
+<rfc category="info" docName="draft-handrews-relative-json-pointer-03" ipr="trust200902" submissionType="IETF">
     <front>
         <title abbrev="Relative JSON Pointers">Relative JSON Pointers</title>
 

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -98,10 +98,11 @@
                 </preamble>
                 <artwork>
 <![CDATA[
-   relative-json-pointer =  non-negative-integer [index-manipulation] <json-pointer>
-   relative-json-pointer =/ non-negative-integer "#"
+   relative-json-pointer =  origin-specification <json-pointer>
+   relative-json-pointer =/ origin-specification "#"
+   origin-specification  =  non-negative-integer [index-manipulation]
    index-manipulation    =  ("+" / "-") non-negative-integer
-   non-negative-integer      =  %x30 / %x31-39 *( %x30-39 )
+   non-negative-integer  =  %x30 / %x31-39 *( %x30-39 )
            ; "0", or digits without a leading "0"
 ]]>
                 </artwork>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -322,6 +322,12 @@
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-relative-json-pointer-03">
+                        <list style="symbols">
+                            <t>Fix ABNF omission for using # with index manipulation</t>
+                            <t>Clarify handling of leading "0"</t>
+                        </list>
+                    </t>
                     <t hangText="draft-bhutton-relative-json-pointer-00">
                         <list style="symbols">
                             <t>Add array forward and backward index manipulation</t>


### PR DESCRIPTION
Fixes #1175 (doing another RJP draft was discussed and agreed to [several months ago](https://github.com/orgs/json-schema-org/discussions/225)).

Taking the index of the result of an index manipulation was shown in the example and intended to work, but left out of the ABNF apparently by accident.

Also, rework the ABNF to keep it within the text RFC line width.
