### PR TITLE
Document minimal process necessary for the interim release

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -19,11 +19,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
 ## Canonical URLs
-There MUST be a stable canonical URL for referencing any specification that
-follows this process. If the specification is made available from any other
-URLs, they SHOULD redirect to the canonical URL. If the canonical URL is changed
-in the future, all previous canonical URLs MUST remain accessible as redirects
-to the current URL.
+There MUST be a canonical URL for referencing the current version of any
+specification that follows this process. If the specification is made available
+from any other URLs, they SHOULD redirect to the canonical URL. If the canonical
+URL is changed in the future, all previous canonical URLs MUST remain accessible
+as redirects to the current URL.
 
 ## Compatible Releases
 Everything in the specification is considered "stable" by default and subject to
@@ -34,6 +34,15 @@ NOT change in ways that could be problematic for forward compatibility.
 _Note: How, when, and how often the specification will be updated are all open
 questions that will be decided before any changes are issued following the
 initial release._
+
+Compatibility is defined with respect to the true/false validation result of a
+schema. If an instance is valid or invalid against a schema according to one
+release, all other releases including future releases MUST define the same
+validation result or be indeterminate. An indeterminate result is neither valid
+nor invalid.
+
+_Note: Additional compatibility constraints may be added in the future such as
+output format results._
 
 ### Experimental Behaviors
 The specification MAY include sections that introduce experimental behaviors.
@@ -49,18 +58,18 @@ evolution will always be compatible with previous versions of this document._
 
 ### Compliance
 An implementation is compliant with a given release if it implements all of the
-required stable behaviors defined in that release. Experimental behaviors are
-not required to be considered compliant, but implementing them is highly
-encouraged. An implementation that implements behaviors that are not compatible
-with the given release is considered compliant only if those behaviors are
-disabled by default.
+required stable behaviors in that release. Experimental behaviors are not
+required to be considered compliant, but implementing them is highly encouraged.
+An implementation that implements behaviors that are not compatible with the
+given release is considered compliant only if those behaviors are disabled by
+default.
 
-Because releases are compatible, expressing support for a given release implies
-support for all previous releases (excluding "draft" releases). Support for
-previous releases might have limitations if an implementation chooses not to
-support a deprecated behavior.
+Because releases using this process are compatible, expressing support for a
+given release implies support for all previous releases (excluding "draft"
+releases). Support for previous releases might have limitations if an
+implementation chooses not to support a deprecated behavior.
 
 ### Deprecation
-Stable behaviors MAY be marked as "deprecated". Implementations are expected to
-support these behaviors to maintain backward compatibility and schema authors
-should migrate away from using these behaviors.
+Behaviors MAY be marked as "deprecated". Implementations are expected to support
+stable deprecated behaviors to maintain backward compatibility and schema
+authors should migrate away from using these behaviors.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -26,7 +26,7 @@ URL is changed in the future, all previous canonical URLs MUST remain accessible
 as redirects to the current URL.
 
 ## Compatible Releases
-Everything in the specification is considered "stable" by default and subject to
+Any part of the specification that is considered "stable" is subject to
 compatibility guarantees. Any changes to stable behaviors in the specification
 MUST be backward-compatible with previous versions of the specification and MUST
 NOT change in ways that could be problematic for forward compatibility.
@@ -38,38 +38,8 @@ initial release._
 Compatibility is defined with respect to the true/false validation result of a
 schema. If an instance is valid or invalid against a schema according to one
 release, all other releases including future releases MUST define the same
-validation result or be indeterminate. An indeterminate result is neither valid
-nor invalid.
+validation result or define the result to be indeterminate. An indeterminate
+result is neither valid nor invalid.
 
 _Note: Additional compatibility constraints may be added in the future such as
 output format results._
-
-### Experimental Behaviors
-The specification MAY include sections that introduce experimental behaviors.
-These sections MUST be clearly marked and aren't subject to the compatibility
-guarantees of stable behaviors. Experimental behaviors MUST be compatible with
-all current stable behaviors.
-
-_Note: How and when experimental behaviors are promoted to stable behaviors is
-an open discussion and will be defined before a promotion is considered. The
-process of how an experimental behavior goes from proposal to stable will be
-defined in more detail and is likely to evolve as we learn what works best. Such
-evolution will always be compatible with previous versions of this document._
-
-### Compliance
-An implementation is compliant with a given release if it implements all of the
-required stable behaviors in that release. Experimental behaviors are not
-required to be considered compliant, but implementing them is highly encouraged.
-An implementation that implements behaviors that are not compatible with the
-given release is considered compliant only if those behaviors are disabled by
-default.
-
-Because releases using this process are compatible, expressing support for a
-given release implies support for all previous releases (excluding "draft"
-releases). Support for previous releases might have limitations if an
-implementation chooses not to support a deprecated behavior.
-
-### Deprecation
-Behaviors MAY be marked as "deprecated". Implementations are expected to support
-stable deprecated behaviors to maintain backward compatibility and schema
-authors should migrate away from using these behaviors.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,65 @@
+# JSON Schema Specification Development Process
+This document formally defines the process used to evolve the JSON Schema
+specification as of the first stable release in 2023. It applies to the core
+specification and the specifications for any dialects and vocabularies
+maintained by the JSON Schema Org, but it doesn't necessarily apply to
+everything the JSON Schema Org maintains. For example, media type registration
+follows the IETF process. Certain components used within JSON Schema, such as
+Relative JSON Pointer, may also follow a separate process.
+
+This process doesn't apply to third-party dialects, vocabularies, or other
+extensions. However, third-parties are welcome to use this as a basis for the
+process they use for their specifications.
+
+_**This process is under development. The details will evolve over time, but
+changes will remain compatible with previous versions of this document.**_
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Canonical URLs
+There MUST be a stable canonical URL for referencing any specification that
+follows this process. If the specification is made available from any other
+URLs, they SHOULD redirect to the canonical URL. If the canonical URL is changed
+in the future, all previous canonical URLs MUST remain accessible as redirects
+to the current URL.
+
+## Compatible Releases
+Everything in the specification is considered "stable" by default and subject to
+compatibility guarantees. Any changes to stable behaviors in the specification
+MUST be backward-compatible with previous versions of the specification and MUST
+NOT change in ways that could be problematic for forward-compatibility.
+Therefore, it's not necessary for implementations to support previous versions
+of the specification separately.
+
+_Note: How, when, and how often the specification will be updated are all open
+questions that will be decided before any changes are issued following the
+initial release. Because releases are compatible, these things shouldn't effect
+choices made by implementers or schema authors the same way the "draft" releases
+did._
+
+### Experimental Behaviors
+The specification MAY include sections that introduce experimental behaviors.
+These sections MUST be clearly marked and aren't subject to the compatibility
+guarantees of stable features. Experimental behaviors MUST be compatible with
+all current stable behaviors.
+
+_Note: How and when experimental behaviors are promoted to stable behaviors is
+an open discussion and will be defined before a promotion is considered. The
+process of how an experimental behavior goes from proposal to stable will be
+defined in more detail and is likely to evolve as we learn what works best. Such
+evolution will always be compatible with previous versions of this document._
+
+### Compliance
+Implementations that express support for a particular release MUST support all
+of that release's stable behaviors and SHOULD support any experimental
+behaviors. Because releases are compatible, expressing support for a given
+release implies support for all previous releases (excluding "draft" releases).
+
+### Deprecation
+Stable behaviors MAY be marked as "deprecated". Implementations SHOULD support
+these features to maintain backward compatibility. Deprecated features will
+never be removed from the spec, but schema authors SHOULD migrate away from
+using them as implementations may begin dropping support for these features at
+some point.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -31,18 +31,18 @@ compatibility guarantees. Any changes to stable behaviors in the specification
 MUST be backward-compatible with previous versions of the specification and MUST
 NOT change in ways that could be problematic for forward-compatibility.
 Therefore, it's not necessary for implementations to support previous versions
-of the specification separately.
+of the specification separately (excluding "draft" releases).
 
 _Note: How, when, and how often the specification will be updated are all open
 questions that will be decided before any changes are issued following the
-initial release. Because releases are compatible, these things shouldn't effect
+initial release. Because releases are compatible, these things shouldn't affect
 choices made by implementers or schema authors the same way the "draft" releases
 did._
 
 ### Experimental Behaviors
 The specification MAY include sections that introduce experimental behaviors.
 These sections MUST be clearly marked and aren't subject to the compatibility
-guarantees of stable features. Experimental behaviors MUST be compatible with
+guarantees of stable behaviors. Experimental behaviors MUST be compatible with
 all current stable behaviors.
 
 _Note: How and when experimental behaviors are promoted to stable behaviors is
@@ -56,10 +56,11 @@ Implementations that express support for a particular release MUST support all
 of that release's stable behaviors and SHOULD support any experimental
 behaviors. Because releases are compatible, expressing support for a given
 release implies support for all previous releases (excluding "draft" releases).
+Support for previous releases might have limitations if an implementation
+chooses not to support a deprecated behavior.
 
 ### Deprecation
 Stable behaviors MAY be marked as "deprecated". Implementations SHOULD support
-these features to maintain backward compatibility. Deprecated features will
-never be removed from the spec, but schema authors SHOULD migrate away from
-using them as implementations may begin dropping support for these features at
-some point.
+these behaviors to maintain backward compatibility. Schema authors SHOULD
+migrate away from using deprecated behaviors as implementations MAY begin
+dropping support for these behaviors at some point.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -29,15 +29,11 @@ to the current URL.
 Everything in the specification is considered "stable" by default and subject to
 compatibility guarantees. Any changes to stable behaviors in the specification
 MUST be backward-compatible with previous versions of the specification and MUST
-NOT change in ways that could be problematic for forward-compatibility.
-Therefore, it's not necessary for implementations to support previous versions
-of the specification separately (excluding "draft" releases).
+NOT change in ways that could be problematic for forward compatibility.
 
 _Note: How, when, and how often the specification will be updated are all open
 questions that will be decided before any changes are issued following the
-initial release. Because releases are compatible, these things shouldn't affect
-choices made by implementers or schema authors the same way the "draft" releases
-did._
+initial release._
 
 ### Experimental Behaviors
 The specification MAY include sections that introduce experimental behaviors.
@@ -52,15 +48,19 @@ defined in more detail and is likely to evolve as we learn what works best. Such
 evolution will always be compatible with previous versions of this document._
 
 ### Compliance
-Implementations that express support for a particular release MUST support all
-of that release's stable behaviors and SHOULD support any experimental
-behaviors. Because releases are compatible, expressing support for a given
-release implies support for all previous releases (excluding "draft" releases).
-Support for previous releases might have limitations if an implementation
-chooses not to support a deprecated behavior.
+An implementation is compliant with a given release if it implements all of the
+required stable behaviors defined in that release. Experimental behaviors are
+not required to be considered compliant, but implementing them is highly
+encouraged. An implementation that implements behaviors that are not compatible
+with the given release is considered compliant only if those behaviors are
+disabled by default.
+
+Because releases are compatible, expressing support for a given release implies
+support for all previous releases (excluding "draft" releases). Support for
+previous releases might have limitations if an implementation chooses not to
+support a deprecated behavior.
 
 ### Deprecation
-Stable behaviors MAY be marked as "deprecated". Implementations SHOULD support
-these behaviors to maintain backward compatibility. Schema authors SHOULD
-migrate away from using deprecated behaviors as implementations MAY begin
-dropping support for these behaviors at some point.
+Stable behaviors MAY be marked as "deprecated". Implementations are expected to
+support these behaviors to maintain backward compatibility and schema authors
+should migrate away from using these behaviors.


### PR DESCRIPTION
Progress on defining a specification development and release process is blocked, but work is moving forward on producing the next release. However, since we've decoupled from IETF, we no longer have a definition of what it means to release a spec. This document is an attempt to define the bare minimum of what is necessary to release something. I tried to avoid anything I thought might be remotely controversial. If there's anything you aren't comfortable with let me know and I'll take it out, or make it more vague, or whatever is necessary. I'm not trying to push anything controversial.

I've used the word "experimental" to describe what we've been calling "unstable". At least one person has interpreted the word "unstable" in a way other than I intended, so I'm trying something else. Happy to take other suggestions.

I've used the word "behaviors", rather than what we've been calling "features" (including keywords). I'm hoping that makes it more clear that observable behaviors are what are subject to compatibility requirements. For example, when the spec prescribes a mechanism for something such as annotations for inter-keyword communications, that can be changed as long as the observable behavior is equivalent.

I included a super simple binary (stable or experimental) stability model. We heard at the last OCWM that not everyone is necessarily on board with including unstable behaviors in the spec. I figured defining it as a tool we can use doesn't hurt. If we decide we don't want to use that tool, we don't have to. Or, I can take it out.

Similarly, I included a definition for deprecation although there has been some discussion in that area and I'm not sure everyone agrees it's a tool we should use. I would have left it out as something we don't need to define for an initial release, but I included it because there was a suggestion in the OCWM of including behaviors in the next release as initially deprecated. We don't have to use it if we choose not to, but it's there. Or, I can take it out.