### PR TITLE
Strengthen requirements on optional vocabularies and unknown keywords

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -620,8 +620,9 @@
 
                 <section title="Handling of unrecognized or unsupported keywords" anchor="unrecognized">
                     <t>
-                        Implementations SHOULD treat keywords they do not recognize, or that
-                        they recognize but do not support, as annotations, where the value of
+                        If annotation collection is supported and not disabled, implementations
+                        MUST treat keywords they do not recognize, or that they recognize but
+                        do not support, as annotations, where the collected value of
                         the keyword is the value of the annotation.  Whether an implementation
                         collects these annotations or not, they MUST otherwise ignore the keywords.
                     </t>
@@ -1298,7 +1299,7 @@
                         </t>
                         <t>
                             Implementations that do not support a vocabulary that is optionally used
-                            by a schema SHOULD proceed with processing the schema.  The keywords will
+                            by a schema MUST proceed with processing the schema.  The keywords will
                             be considered to be unrecognized keywords as addressed by
                             <xref target="unrecognized"></xref>.  Note that since
                             the recommended behavior for such keywords is to collect them as


### PR DESCRIPTION
This fixes #1300, and has been posted to clear up confusion over the difference between it and #1294 / #1295.

_The explanation is in #1300, and if there is any controversy over this, or a desire to split the the two SHOULD-to-MUST changes to accept one and reject the other, then this draft PR should be closed unmerged and the discussion should take place in issue #1300.  If this happens, anyone should feel free to close this- there is no need to check with me first._

This strengthens two SHOULDs to MUSTS:

* Implementations MUST proceed with processing schemas using unrecognized optional vocabularies
* Implementations MUST collect unknown keywords as annotations if such collection is supported and not disabled