### PR TITLE
feat: add period format

### DIFF
--- a/jsonschema-validation.xml
+++ b/jsonschema-validation.xml
@@ -643,14 +643,14 @@
 
             <section title="Defined Formats">
 
-                <section title="Dates, Times, and Duration">
+                <section title="Dates, Times, Duration, and Period">
                     <t>
                         These attributes apply to string instances.
                     </t>
                     <t>
                         Date and time format names are derived from
                         <xref target="RFC3339">RFC 3339, section 5.6</xref>.
-                        The duration format is from the ISO 8601 ABNF as given
+                        The duration and period formats are from the ISO 8601 ABNF as given
                         in Appendix A of RFC 3339.
                     </t>
                     <t>
@@ -675,6 +675,11 @@
                             <t hangText="duration:">
                                 A string instance is valid against this attribute if it is
                                 a valid representation according to the "duration" ABNF rule
+                                (referenced above)
+                            </t>
+                            <t hangText="period:">
+                                A string instance is valid against this attribute if it is
+                                a valid representation according to the "period" ABNF rule
                                 (referenced above)
                             </t>
                         </list>


### PR DESCRIPTION
Similar to https://github.com/json-schema-org/json-schema-spec/pull/718 — this proposal completes the set by adding the `period` format — as specific in RFC3339 Appendix A

Snippet:
```
Periods:

   period-explicit   = iso-date-time "/" iso-date-time
   period-start      = iso-date-time "/" duration
   period-end        = duration "/" iso-date-time

   period            = period-explicit / period-start / period-end
```
— https://datatracker.ietf.org/doc/html/rfc3339#appendix-A