### PR TITLE
reserve dollar keywords for core vocab

### DIFF
--- a/jsonschema-core.xml
+++ b/jsonschema-core.xml
@@ -1157,9 +1157,8 @@
                 <eref target="https://json-schema.org/draft/next/meta/core"/>.
             </t>
             <t>
-                While the "$" prefix is not formally reserved for the Core vocabulary,
-                it is RECOMMENDED that extension keywords (in vocabularies or otherwise)
-                begin with a character other than "$" to avoid possible future collisions.
+                The "$" prefix is reserved for use by the Core vocabulary.
+                Vocabulary extensions MUST NOT define new keywords that begin with "$".
             </t>
 
             <section title="Meta-Schemas and Vocabularies" anchor="vocabulary">


### PR DESCRIPTION
Resolves #1321

I'm not sure how far we want to take this.  Should implementations check vocabulary extensions to ensure they don't define `$` keywords and throw an error if they do?