### PR TITLE
add minimum open time action for PRs

### DIFF
--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -4,7 +4,7 @@ on:
   pull_request
   workflow_dispatch
   schedule
-    - cron: '0 0 * * *'
+  - cron: '0 0 * * *'
 
 jobs:
   require-minimum-open-time:

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -2,12 +2,13 @@ name: PR Policy
 on:
   - pull_request
   - workflow_dispatch
-  # not sure about scheduling only on PRs.  See https://github.com/orgs/community/discussions/49960
-  # - schedule
-  #   - cron: '0 * * * *'
+  # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
+  - schedule
+    - cron: '0 0 * * *' # once daily
 
 jobs:
   require-minimum-open-time:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     name: Require Minimum Open Time
     steps:

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,10 +1,10 @@
 name: PR Policy
 on:
-  - pull_request
-  - workflow_dispatch
+  pull_request
+  workflow_dispatch
   # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
-  - schedule:
-    - cron: '0 0 * * *' # once daily
+  schedule:
+  - cron: '0 0 * * *' # once daily
 
 jobs:
   require-minimum-open-time:

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,9 +1,9 @@
 name: PR Policy
 on:
-  - pull_request
-  - workflow_dispatch
+  pull_request
+  workflow_dispatch
   # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
-  - schedule
+  schedule
     - cron: '0 0 * * *'
 
 jobs:

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -4,7 +4,6 @@ on:
   - workflow_dispatch
   # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
   - schedule
-    # once daily
     - cron: '0 0 * * *'
 
 jobs:

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,7 +1,7 @@
 name: PR Policy
 on:
-  pull_request
-  workflow_dispatch
+  pull_request:
+  workflow_dispatch:
   # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
   schedule:
   - cron: '0 0 * * *' # once daily

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,3 +1,4 @@
+name: PR Policy
 on:
   - pull_request
   - workflow_dispatch

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,8 +1,8 @@
 name: PR Policy
+# scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
 on:
   pull_request
   workflow_dispatch
-  # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
   schedule
     - cron: '0 0 * * *'
 

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,10 +1,10 @@
 name: PR Policy
-# scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
 on:
-  pull_request
-  workflow_dispatch
-  schedule
-  - cron: '0 0 * * *'
+  - pull_request
+  - workflow_dispatch
+  # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
+  - schedule:
+    - cron: '0 0 * * *' # once daily
 
 jobs:
   require-minimum-open-time:

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -1,0 +1,18 @@
+on:
+  - pull_request
+  - workflow_dispatch
+  # not sure about scheduling only on PRs.  See https://github.com/orgs/community/discussions/49960
+  # - schedule
+  #   - cron: '0 * * * *'
+
+jobs:
+  require-minimum-open-time:
+    runs-on: ubuntu-latest
+    name: Require Minimum Open Time
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gregsdennis/minimum-open-time@main
+      with:
+        time: 2w # see below for options
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/minimum-open-time.yml
+++ b/.github/workflows/minimum-open-time.yml
@@ -4,7 +4,8 @@ on:
   - workflow_dispatch
   # scheduling only on PRs is not directly supported.  See https://github.com/orgs/community/discussions/49960
   - schedule
-    - cron: '0 0 * * *' # once daily
+    # once daily
+    - cron: '0 0 * * *'
 
 jobs:
   require-minimum-open-time:


### PR DESCRIPTION
Currently, this needs to be manually re-run.  It'll run automatically on new commits, though.

- [x] I'm [looking into](https://github.com/orgs/community/discussions/49960) running scheduled actions only on PRs.  We don't want this running if it's not targeting a PR.