### PR TITLE
Updates for Relative JSON Pointer

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -92,27 +92,19 @@
                 length or start with a '/' (%x2F).  Similarly, a JSON Pointer will
                 never be ambiguous with the '#'.
             </t>
-            <figure align="center">
-                <preamble>
-                    The ABNF syntax of a Relative JSON Pointer is:
-                </preamble>
-                <artwork>
-<![CDATA[
-   relative-json-pointer =  origin-specification <json-pointer>
-   relative-json-pointer =/ origin-specification "#"
-   origin-specification  =  non-negative-integer [index-manipulation]
-   index-manipulation    =  ("+" / "-") non-negative-integer
-   non-negative-integer  =  %x30 / %x31-39 *( %x30-39 )
-           ; "0", or digits without a leading "0"
-]]>
-                </artwork>
-                <postamble>
-                    where &lt;json-pointer&gt; follows the production defined in
-                    <xref target="RFC6901">RFC 6901, Section 3</xref> ("Syntax").
-                </postamble>
-            </figure>
             <t>
+                The ABNF syntax of a Relative JSON Pointer is:
             </t>
+            <sourcecode type="abnf9110"><![CDATA[
+  relative-json-pointer = origin-specification json-pointer
+                        / origin-specification "#"
+                        ; json-pointer from RFC 6901
+
+  origin-specification  = non-negative-integer [ index-manipulation ]
+  index-manipulation    = ( "+" / "-" ) non-negative-integer
+  non-negative-integer  = "0" / %x31-39 *DIGIT
+                        ; zero, or digits without a leading zero
+]]></sourcecode>
         </section>
 
         <section title="Evaluation">

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -83,11 +83,13 @@
             <t>
                 A Relative JSON Pointer is a Unicode string in UTF-8 encoding (see RFC 8259,
                 <xref target="RFC8259">Section 8</xref>), comprising a non-negative integer,
-                followed by either a '#' (%x23) character or a JSON Pointer
-                (<xref target="RFC6901">RFC 6901</xref>).
+                an optional index adjustment consisting of '+' (%x2B) or '-' (%x2D) followed
+                by a positive integer, followed by either a '#' (%x23) character or
+                a JSON Pointer (<xref target="RFC6901">RFC 6901</xref>).
             </t>
             <t>
-                The separation between the integer prefix and the JSON Pointer will
+                The separation between the integer prefix (with optional adjustment)
+                and the JSON Pointer will
                 always be unambiguous, because a JSON Pointer must be either zero-
                 length or start with a '/' (%x2F).  Similarly, a JSON Pointer will
                 never be ambiguous with the '#'.

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -103,9 +103,10 @@
                         ; json-pointer from RFC 6901
 
   origin-specification  = non-negative-integer [ index-manipulation ]
-  index-manipulation    = ( "+" / "-" ) non-negative-integer
-  non-negative-integer  = "0" / %x31-39 *DIGIT
-                        ; zero, or digits without a leading zero
+  index-manipulation    = ( "+" / "-" ) positive-integer
+  non-negative-integer  = "0" / positive-integer
+  positive-integer      = %x31-39 *DIGIT
+                        ; digits without a leading zero
 ]]></sourcecode>
         </section>
 

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -12,7 +12,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-bhutton-relative-json-pointer-00" ipr="trust200902" submissionType="IETF">
+<rfc category="info" docName="draft-handrews-relative-json-pointer-03" ipr="trust200902" submissionType="IETF">
     <front>
         <title abbrev="Relative JSON Pointers">Relative JSON Pointers</title>
 

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -98,10 +98,11 @@
                 </preamble>
                 <artwork>
 <![CDATA[
-   relative-json-pointer =  non-negative-integer [index-manipulation] <json-pointer>
-   relative-json-pointer =/ non-negative-integer "#"
+   relative-json-pointer =  origin-specification <json-pointer>
+   relative-json-pointer =/ origin-specification "#"
+   origin-specification  =  non-negative-integer [index-manipulation]
    index-manipulation    =  ("+" / "-") non-negative-integer
-   non-negative-integer      =  %x30 / %x31-39 *( %x30-39 )
+   non-negative-integer  =  %x30 / %x31-39 *( %x30-39 )
            ; "0", or digits without a leading "0"
 ]]>
                 </artwork>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -322,6 +322,12 @@
             </t>
             <t>
                 <list style="hanging">
+                    <t hangText="draft-handrews-relative-json-pointer-03">
+                        <list style="symbols">
+                            <t>Fix ABNF omission for using # with index manipulation</t>
+                            <t>Clarify handling of leading "0"</t>
+                        </list>
+                    </t>
                     <t hangText="draft-bhutton-relative-json-pointer-00">
                         <list style="symbols">
                             <t>Add array forward and backward index manipulation</t>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -199,7 +199,7 @@
                     <artwork>
 <![CDATA[
                       {
-                         "foo": ["bar", "baz"],
+                         "foo": ["bar", "baz", "biz"],
                          "highly": {
                             "nested": {
                                "objects": true
@@ -221,7 +221,7 @@
                   "0-1"                       "bar"
                   "2/highly/nested/objects"   true
                   "0#"                        1
-                  "0-1#"                      0
+                  "0+1#"                      2
                   "1#"                        "foo"
 ]]>
                     </artwork>


### PR DESCRIPTION
Replaces #1361 

~Adds an optional index manipulation to the syntax.~

It looks like this was already in the text, but the ABNF was just missing it.  This PR adds the missing syntax into the ABNF.