### PR TITLE
Updates that were needed in order to publish RJP

### DIFF
--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -305,6 +305,12 @@
                 programming languages that use NUL to mark the end of a string.
             </t>
         </section>
+
+        <section title="IANA Considerations">
+            <t>
+                This document has no IANA actions.
+            </t>
+        </section>
     </middle>
 
     <back>

--- a/relative-json-pointer.xml
+++ b/relative-json-pointer.xml
@@ -12,7 +12,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc comments="yes"?>
 <?rfc inline="yes" ?>
-<rfc category="info" docName="draft-handrews-relative-json-pointer-03" ipr="trust200902" submissionType="IETF">
+<rfc category="info" docName="draft-hha-relative-json-pointer-00" ipr="trust200902" submissionType="IETF">
     <front>
         <title abbrev="Relative JSON Pointers">Relative JSON Pointers</title>
 
@@ -27,7 +27,7 @@
             </address>
         </author>
 
-        <author fullname="Henry Andrews" initials="H" surname="Andrews" role="editor">
+        <author fullname="Henry H. Andrews" initials="H" surname="Andrews" role="editor">
             <address>
                 <email>andrews_henry@yahoo.com</email>
             </address>
@@ -324,7 +324,7 @@
             </t>
             <t>
                 <list style="hanging">
-                    <t hangText="draft-handrews-relative-json-pointer-03">
+                    <t hangText="draft-hha-relative-json-pointer-00">
                         <list style="symbols">
                             <t>Fix ABNF omission for using # with index manipulation</t>
                             <t>Clarify handling of leading "0"</t>


### PR DESCRIPTION
In order to publish a new RJP draft per agreement (@gregsdennis), I needed to make a few changes due to updates in the publishing requirements and restrictions on re-use of draft numbering sequences.  This aligns the XML file with the published [draft-hha-relative-json-pointer-00](https://datatracker.ietf.org/doc/html/draft-hha-relative-json-pointer-00).