### PR TITLE
Add security policy document

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,11 @@
+# Reporting Security Issues
+
+The JSON Schema project does not house any implementation of JSON Schema itself. If you have found a security issue in any implementation of JSON Schema, please contact the appropriate maintainers, per the projects security reporting guidelines, if any.
+
+To report a security issue, please use the GitHub Security Advisory "https://github.com/json-schema-org/json-schema-spec/security/advisories/new" tab.
+
+If you find a security issue in relation to the JSON Schema specification or another repository within this GitHub organization, please use the above.
+
+The JSON Schema project TSC will review and respond to all security reports. Please follow [coordinated disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/about-coordinated-disclosure-of-security-vulnerabilities).
+
+If you are a maintainer of an implementation, please consider [adding a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository). If you need assistance in understanding a report, or remediation of a confirmed issue, please feel free to reach out to us on our Slack server, in the `#implementations` channel, and ask for a temporary private channel to discuss your situation or concerns.


### PR DESCRIPTION
Resolves https://github.com/json-schema-org/community/issues/351

We have already previously enabled security reporting on the spec repo.

While I made it clear that people should not report impelementation security concerns here, I wanted to also offer potential help to implementers who might get reports.

I can't imagine we would get any reports given the repos/projects we currently have, although that could change in the future, and this is a requirement of the OpenJS Foundation onboarding process.