### PR TITLE
markdown errata

### DIFF
--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -3165,7 +3165,7 @@ This meta-schema combines several vocabularies for general use.
     {"$ref": "https://json-schema.org/draft/next/meta/core"},
     {"$ref": "https://json-schema.org/draft/next/meta/applicator"},
     {"$ref": "https://json-schema.org/draft/next/meta/validation"},
-    {"$ref": "https://example.com/meta/example-vocab",
+    {"$ref": "https://example.com/meta/example-vocab"},
   ],
   "patternProperties": {
     "^unevaluated": false

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -2079,10 +2079,10 @@ consumers will need to properly interpret validation results.
 ### Format
 
 JSON Schema output is defined using the JSON Schema data instance model as
-described in [Instance Data Model](#data-model). Implementations MAY deviate from this as supported
-by their specific languages and platforms, however it is RECOMMENDED that the
-output be convertible to the JSON format defined herein via serialization or
-other means.
+described in [Instance Data Model](#data-model). Implementations MAY deviate
+from this as supported by their specific languages and platforms, however it
+is RECOMMENDED that the output be convertible to the JSON format defined herein
+via serialization or other means.
 
 ### Output Formats
 

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -2079,7 +2079,7 @@ consumers will need to properly interpret validation results.
 ### Format
 
 JSON Schema output is defined using the JSON Schema data instance model as
-described in section 4.2.1. Implementations MAY deviate from this as supported
+described in [Instance Data Model](#data-model). Implementations MAY deviate from this as supported
 by their specific languages and platforms, however it is RECOMMENDED that the
 output be convertible to the JSON format defined herein via serialization or
 other means.
@@ -2092,8 +2092,7 @@ section for the requirements of each format.
 - *Flag*: A boolean which simply indicates the overall validation result with no
   further details.
 - *List*: Provides validation information in a flat list structure.
-
-Hierarchical: Provides validation information in a hierarchical structure that
+- *Hierarchical*: Provides validation information in a hierarchical structure that
 follows the evaluation paths generated while processing the schema.
 
 An implementation MUST provide the "flag" format and SHOULD provide at least one
@@ -2283,7 +2282,6 @@ For these examples, the following schema and instances will be used.
 }
 ```
 
-
 ```json "Failing instance"
 {
   "foo": {"foo-prop": "not 1", "other-prop": false},
@@ -2324,9 +2322,9 @@ allows their users to craft their own messages.
 
 The passing instance will produce the following annotations:
 
-- The keyword `title` evaluated at `` by following the path `` will produce
+- The keyword `title` evaluated at the instance root by the root schema will produce
   `"root"`.
-- The keyword `properties` evaluated at `` by following the path `` will produce
+- The keyword `properties` evaluated at instance root by the root schema will produce
   `["foo", "bar"]`.
 - The keyword `title` evaluated at `/properties/foo` by following the path
   `/properties/foo` will produce `"foo-title"`.


### PR DESCRIPTION
This is in prep for extracting the output sections into their own spec in order to support multiple outputs for different purposes (cc: @karenetheridge).  I expect this to take place over several PRs, but #1385 shows the gist of the end goal.