### PR TITLE
add implicit reference string schemas

### DIFF
--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -190,7 +190,7 @@ always be given the media type `application/schema+json` rather than
 defined to offer a superset of the fragment identifier syntax and semantics
 provided by `application/schema-instance+json`.
 
-A JSON Schema MUST be an object or a boolean.
+A JSON Schema MUST be an object, a boolean, or a string.
 
 #### JSON Schema Objects and Keywords
 
@@ -239,6 +239,28 @@ this document).
 While the empty schema object is unambiguous, there are many possible
 equivalents to the `false` schema. Using the boolean values ensures that the
 intent is clear to both human readers and implementations.
+
+#### String JSON Schemas
+
+A string schema operates as an implicit reference to another schema object.
+A string schema is a shorthand for a schema containing only the `$ref` keyword.
+
+For example, the string schema
+
+```json
+"https://example.com/schema"
+```
+
+is equivalent to
+
+```json
+{
+  "$ref": "https://example.com/schema"
+}
+```
+
+For a string to operate as a schema, the value MUST conform to the requirements
+defined in {{ref}}.
 
 #### Schema Vocabularies
 
@@ -1217,7 +1239,7 @@ the positive integer constraint is a subschema in `$defs`:
 ```jsonschema
 {
   "type": "array",
-  "items": { "$ref": "#/$defs/positiveInteger" },
+  "items": "#/$defs/positiveInteger",
   "$defs": {
     "positiveInteger": {
       "type": "integer",
@@ -1340,12 +1362,12 @@ For example, consider this schema:
 {
   "$id": "https://example.net/root.json",
   "type": "array",
-  "items": { "$ref": "#item" },
+  "items": "#item",
   "$defs": {
     "single": {
       "$anchor": "item",
       "type": "object",
-      "additionalProperties": { "$ref": "other.json" }
+      "additionalProperties": "other.json"
     }
   }
 }
@@ -1417,9 +1439,7 @@ value for `$ref`:
 ```jsonschema
 {
   "$id": "https://example.com/foo",
-  "items": {
-    "$ref": "bar"
-  }
+  "items": "bar"
 }
 ```
 
@@ -2699,10 +2719,10 @@ This meta-schema combines several vocabularies for general use.
     "https://example.com/vocab/example-vocab": true
   },
   "allOf": [
-    {"$ref": "https://json-schema.org/draft/next/meta/core"},
-    {"$ref": "https://json-schema.org/draft/next/meta/applicator"},
-    {"$ref": "https://json-schema.org/draft/next/meta/validation"},
-    {"$ref": "https://example.com/meta/example-vocab"},
+    "https://json-schema.org/draft/next/meta/core",
+    "https://json-schema.org/draft/next/meta/applicator",
+    "https://json-schema.org/draft/next/meta/validation",
+    "https://example.com/meta/example-vocab",
   ],
   "patternProperties": {
     "^unevaluated": false
@@ -2779,18 +2799,14 @@ purposes, and is not intended to propose a functional code generation keyword.
       "classRelation": "is-a",
       "$ref": "classes/base.json"
     },
-    {
-      "$ref": "fields/common.json"
-    }
+    "fields/common.json"
   ],
   "properties": {
     "foo": {
       "classRelation": "has-a",
       "$ref": "classes/foo.json"
     },
-    "date": {
-      "$ref": "types/dateStruct.json",
-    }
+    "date": "types/dateStruct.json",
   }
 }
 ```
@@ -2850,6 +2866,7 @@ to the document.
 - Rename "absoluteKeywordLocation" and "keywordLocation" to "schemaLocation" and "evaluationPath"
 - Output units in new format group by "schemaLocation", "instanceLocation", and "evaluationPath"
 - Add "droppedAnnotations" to output formats
+- Add string schemas as implicit references
 
 ### draft-bhutton-json-schema-01
 - Improve and clarify the `type`, `contains`, `unevaluatedProperties`, and

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -245,17 +245,27 @@ intent is clear to both human readers and implementations.
 A string schema operates as an implicit reference to another schema object.
 A string schema is a shorthand for a schema containing only the `$ref` keyword.
 
-For example, the string schema
+For example, the schema
 
 ```json
-"https://example.com/schema"
+{
+  "type": "object",
+  "properties": {
+    "foo": "https://example.com/schema"
+  }
+}
 ```
 
 is equivalent to
 
 ```json
 {
-  "$ref": "https://example.com/schema"
+  "type": "array",
+  "properties": {
+    "foo": {
+      "$ref": "https://example.com/schema"
+    }
+  }
 }
 ```
 

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -260,7 +260,7 @@ is equivalent to
 
 ```json
 {
-  "type": "array",
+  "type": "object",
   "properties": {
     "foo": {
       "$ref": "https://example.com/schema"

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -242,8 +242,9 @@ intent is clear to both human readers and implementations.
 
 #### String JSON Schemas
 
-A string schema operates as an implicit reference to another schema object.
-A string schema is a shorthand for a schema containing only the `$ref` keyword.
+A string schema operates as an implicit reference to another schema resource. A
+string schema is a shorthand for a schema object containing only the `$ref`
+keyword.
 
 For example, the schema
 

--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -4,11 +4,12 @@
     "$dynamicAnchor": "meta",
 
     "title": "Applicator vocabulary meta-schema",
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
-        "prefixItems": { "$ref": "#/$defs/schemaArray" },
+        "prefixItems": "#/$defs/schemaArray",
         "items": { "$dynamicRef": "#meta" },
-        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "maxContains": "#/$defs/nonNegativeInteger",
         "minContains": {
             "$ref": "#/$defs/nonNegativeInteger",
             "default": 1
@@ -44,9 +45,9 @@
         "if": { "$dynamicRef": "#meta" },
         "then": { "$dynamicRef": "#meta" },
         "else": { "$dynamicRef": "#meta" },
-        "allOf": { "$ref": "#/$defs/schemaArray" },
-        "anyOf": { "$ref": "#/$defs/schemaArray" },
-        "oneOf": { "$ref": "#/$defs/schemaArray" },
+        "allOf": "#/$defs/schemaArray",
+        "anyOf": "#/$defs/schemaArray",
+        "oneOf": "#/$defs/schemaArray",
         "not": { "$dynamicRef": "#meta" }
     },
     "$defs": {

--- a/meta/content.json
+++ b/meta/content.json
@@ -5,7 +5,8 @@
 
     "title": "Content vocabulary meta-schema",
 
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "contentEncoding": { "type": "string" },
         "contentMediaType": { "type": "string" },

--- a/meta/core.json
+++ b/meta/core.json
@@ -4,21 +4,22 @@
     "$dynamicAnchor": "meta",
 
     "title": "Core vocabulary meta-schema",
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "$id": {
             "$ref": "#/$defs/iriReferenceString",
             "$comment": "Fragments not allowed.",
             "pattern": "^[^#]*$"
         },
-        "$schema": { "$ref": "#/$defs/iriString" },
-        "$ref": { "$ref": "#/$defs/iriReferenceString" },
-        "$anchor": { "$ref": "#/$defs/anchorString" },
-        "$dynamicRef": { "$ref": "#/$defs/iriReferenceString" },
-        "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
+        "$schema": "#/$defs/iriString",
+        "$ref": "#/$defs/iriReferenceString",
+        "$anchor": "#/$defs/anchorString",
+        "$dynamicRef": "#/$defs/iriReferenceString",
+        "$dynamicAnchor": "#/$defs/anchorString",
         "$vocabulary": {
             "type": "object",
-            "propertyNames": { "$ref": "#/$defs/iriString" },
+            "propertyNames": "#/$defs/iriString",
             "additionalProperties": {
                 "type": "boolean"
             }

--- a/meta/format-annotation.json
+++ b/meta/format-annotation.json
@@ -4,7 +4,8 @@
     "$dynamicAnchor": "meta",
 
     "title": "Format vocabulary meta-schema for annotation results",
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "format": { "type": "string" }
     }

--- a/meta/format-assertion.json
+++ b/meta/format-assertion.json
@@ -4,7 +4,8 @@
     "$dynamicAnchor": "meta",
 
     "title": "Format vocabulary meta-schema for assertion results",
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "format": { "type": "string" }
     }

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -5,7 +5,8 @@
 
     "title": "Meta-data vocabulary meta-schema",
 
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "title": {
             "type": "string"

--- a/meta/unevaluated.json
+++ b/meta/unevaluated.json
@@ -4,7 +4,8 @@
     "$dynamicAnchor": "meta",
 
     "title": "Unevaluated applicator vocabulary meta-schema",
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "unevaluatedItems": { "$dynamicRef": "#meta" },
         "unevaluatedProperties": { "$dynamicRef": "#meta" }

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -4,14 +4,15 @@
     "$dynamicAnchor": "meta",
 
     "title": "Validation vocabulary meta-schema",
-    "type": ["object", "boolean"],
+    "type": ["object", "boolean", "string"],
+    "format": "iri-reference",
     "properties": {
         "type": {
             "anyOf": [
-                { "$ref": "#/$defs/simpleTypes" },
+                "#/$defs/simpleTypes",
                 {
                     "type": "array",
-                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "items": "#/$defs/simpleTypes",
                     "minItems": 1,
                     "uniqueItems": true
                 }
@@ -38,26 +39,24 @@
         "exclusiveMinimum": {
             "type": "number"
         },
-        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
-        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "maxLength": "#/$defs/nonNegativeInteger",
+        "minLength": "#/$defs/nonNegativeIntegerDefault0",
         "pattern": {
             "type": "string",
             "format": "regex"
         },
-        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
-        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "maxItems": "#/$defs/nonNegativeInteger",
+        "minItems": "#/$defs/nonNegativeIntegerDefault0",
         "uniqueItems": {
             "type": "boolean",
             "default": false
         },
-        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
-        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
-        "required": { "$ref": "#/$defs/stringArray" },
+        "maxProperties": "#/$defs/nonNegativeInteger",
+        "minProperties": "#/$defs/nonNegativeIntegerDefault0",
+        "required": "#/$defs/stringArray",
         "dependentRequired": {
             "type": "object",
-            "additionalProperties": {
-                "$ref": "#/$defs/stringArray"
-            }
+            "additionalProperties": "#/$defs/stringArray"
         }
     },
     "$defs": {

--- a/schema.json
+++ b/schema.json
@@ -14,13 +14,13 @@
 
     "title": "Core and Validation specifications meta-schema",
     "allOf": [
-        {"$ref": "meta/core"},
-        {"$ref": "meta/applicator"},
-        {"$ref": "meta/unevaluated"},
-        {"$ref": "meta/validation"},
-        {"$ref": "meta/meta-data"},
-        {"$ref": "meta/format-annotation"},
-        {"$ref": "meta/content"}
+        "meta/core",
+        "meta/applicator",
+        "meta/unevaluated",
+        "meta/validation",
+        "meta/meta-data",
+        "meta/format-annotation",
+        "meta/content"
     ],
     "type": ["object", "boolean"],
     "$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
@@ -38,7 +38,7 @@
             "additionalProperties": {
                 "anyOf": [
                     { "$dynamicRef": "#meta" },
-                    { "$ref": "meta/validation#/$defs/stringArray" }
+                    "meta/validation#/$defs/stringArray"
                 ]
             },
             "deprecated": true,


### PR DESCRIPTION
This is just a concept PR to get an idea of what #1078 might look like.

I'm not too particular on the wording of the new core spec section, but it's interesting to see the effect on the meta-schemas.  It definitely eliminates the cruft of having to wrap every reference in `{ "$ref": ... }`.

There _is_ an [argument](https://github.com/json-schema-org/json-schema-spec/issues/1078#issuecomment-1019409047) to be made about readability, but I'm sure it's just a matter of getting used to seeing it (like boolean schemas was).