### PR TITLE
Remark build: Style JSONC code titles as JSON

### DIFF
--- a/build/remark-code-titles.js
+++ b/build/remark-code-titles.js
@@ -25,6 +25,9 @@ const remarkNumberHeadings = () => (tree) => {
     } else if (language.toLowerCase() === "json") {
       title = "JSON";
       titleClasses.push("code-title-json");
+    } else if (language.toLowerCase() === "jsonc") {
+      title = "JSON";
+      titleClasses.push("code-title-json");
     } else {
       titleClasses.push("code-title-unknown");
     }


### PR DESCRIPTION
The remark-code-titles plugin adds styling for JSON Schema and JSON code blocks. This adds support for JSONC as well, styling it the same as JSON.