### PR TITLE
remove `$vocabulary` from vocab meta-schemas (2020-12)

### DIFF
--- a/meta/applicator.json
+++ b/meta/applicator.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/applicator",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/applicator": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Applicator vocabulary meta-schema",

--- a/meta/content.json
+++ b/meta/content.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/content",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/content": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Content vocabulary meta-schema",

--- a/meta/core.json
+++ b/meta/core.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/core",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/core": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Core vocabulary meta-schema",

--- a/meta/format-annotation.json
+++ b/meta/format-annotation.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Format vocabulary meta-schema for annotation results",

--- a/meta/format-assertion.json
+++ b/meta/format-assertion.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/format-assertion",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Format vocabulary meta-schema for assertion results",

--- a/meta/hyper-schema.json
+++ b/meta/hyper-schema.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/hyper-schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/hyper-schema",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2019-09/vocab/hyper-schema": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "JSON Hyper-Schema Vocabulary Schema",

--- a/meta/meta-data.json
+++ b/meta/meta-data.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/meta-data",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/meta-data": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Meta-data vocabulary meta-schema",

--- a/meta/unevaluated.json
+++ b/meta/unevaluated.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/unevaluated",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Unevaluated applicator vocabulary meta-schema",

--- a/meta/validation.json
+++ b/meta/validation.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://json-schema.org/draft/2020-12/meta/validation",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/validation": true
-    },
     "$dynamicAnchor": "meta",
 
     "title": "Validation vocabulary meta-schema",


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

Relates to [Discussion #511](https://github.com/orgs/json-schema-org/discussions/511).