### PR TITLE
Rename metaschema's `$defs/simpleTypes` to singular

### DIFF
--- a/meta/validation.json
+++ b/meta/validation.json
@@ -11,10 +11,10 @@
     "properties": {
         "type": {
             "anyOf": [
-                { "$ref": "#/$defs/simpleTypes" },
+                { "$ref": "#/$defs/simpleType" },
                 {
                     "type": "array",
-                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "items": { "$ref": "#/$defs/simpleType" },
                     "minItems": 1,
                     "uniqueItems": true
                 }
@@ -72,7 +72,7 @@
             "$ref": "#/$defs/nonNegativeInteger",
             "default": 0
         },
-        "simpleTypes": {
+        "simpleType": {
             "enum": [
                 "array",
                 "boolean",


### PR DESCRIPTION
This is somewhat trivial but I think this is more correct. The string is a simple type, not multiple types.