### PR TITLE
Regex editorial improvements, and permit "."

### DIFF
--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -400,16 +400,16 @@ tokens:
 
 - individual Unicode characters, as defined by the [JSON
   specification](#rfc8259);
-- simple atoms: "." (any character except line terminator);
-- simple character classes ("[abc]"), range character classes ("[a-z]");
-- complemented simple character classes ("[^abc]"),
-  complemented range character classes ("[^a-z]");
-- simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or one),
-  and their lazy versions ("+?", "*?", "??");
-- range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at most
+- simple atoms: `.` (any character except line terminator);
+- simple character classes (`[abc]`), range character classes (`[a-z]`);
+- complemented simple character classes (`[^abc]`),
+  complemented range character classes (`[^a-z]`);
+- simple quantifiers: `+` (one or more), `*` (zero or more), `?` (zero or one),
+  and their lazy versions (`+?`, `*?`, `??`);
+- range quantifiers: `{x}` (exactly x occurrences), `{x,y}` (at least x, at most
   y, occurrences), {x,} (x occurrences or more), and their lazy versions;
-- the beginning-of-input ("^") and end-of-input ("$") anchors;
-- simple grouping ("(" and ")") and alternation ("|").
+- the beginning-of-input (`^`) and end-of-input (`$`) anchors;
+- simple grouping (`(` and `)`) and alternation (`|`).
 
 Finally, implementations MUST NOT take regular expressions to be anchored,
 neither at the beginning nor at the end. This means, for instance, the pattern

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -400,11 +400,11 @@ tokens:
 
 - individual Unicode characters, as defined by the [JSON
   specification](#rfc8259);
+- simple atoms: "." (any character except line terminator);
 - simple character classes ("[abc]"), range character classes ("[a-z]");
 - complemented simple character classes ("[^abc]"),
   complemented range character classes ("[^a-z]");
-- simple quantifiers: "." (any character except line terminator),
-  "+" (one or more), "*" (zero or more), "?" (zero or one),
+- simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or one),
   and their lazy versions ("+?", "*?", "??");
 - range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at most
   y, occurrences), {x,} (x occurrences or more), and their lazy versions;

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -402,8 +402,8 @@ tokens:
   specification](#rfc8259);
 - simple atoms: `.` (any character except line terminator);
 - simple character classes (`[abc]`), range character classes (`[a-z]`);
-- complemented simple character classes (`[^abc]`),
-  complemented range character classes (`[^a-z]`);
+- complemented simple character classes (`[^abc]`);
+- complemented range character classes (`[^a-z]`);
 - simple quantifiers: `+` (one or more), `*` (zero or more), `?` (zero or one),
   and their lazy versions (`+?`, `*?`, `??`);
 - range quantifiers: `{x}` (exactly x occurrences), `{x,y}` (at least x, at most

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -409,7 +409,7 @@ tokens:
 - range quantifiers: `{x}` (exactly x occurrences), `{x,y}` (at least x, at most
   y, occurrences), {x,} (x occurrences or more), and their lazy versions;
 - the beginning-of-input (`^`) and end-of-input (`$`) anchors;
-- simple grouping (`(` and `)`) and alternation (`|`).
+- simple grouping (using `(` and `)`) and alternation (`|`).
 
 Finally, implementations MUST NOT take regular expressions to be anchored,
 neither at the beginning nor at the end. This means, for instance, the pattern

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -403,7 +403,8 @@ tokens:
 - simple character classes ("[abc]"), range character classes ("[a-z]");
 - complemented simple character classes ("[^abc]"),
   complemented range character classes ("[^a-z]");
-- simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or one),
+- simple quantifiers: "." (any character except line terminator),
+  "+" (one or more), "*" (zero or more), "?" (zero or one),
   and their lazy versions ("+?", "*?", "??");
 - range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at most
   y, occurrences), {x,} (x occurrences or more), and their lazy versions;

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -400,14 +400,15 @@ tokens:
 
 - individual Unicode characters, as defined by the [JSON
   specification](#rfc8259);
-- simple character classes ([abc]), range character classes ([a-z]);
-- complemented character classes ([^abc], [^a-z]);
+- simple character classes ("[abc]"), range character classes ("[a-z]");
+- complemented simple character classes ("[^abc]"),
+  complemented range character classes ("[^a-z]");
 - simple quantifiers: "+" (one or more), "*" (zero or more), "?" (zero or one),
   and their lazy versions ("+?", "*?", "??");
 - range quantifiers: "{x}" (exactly x occurrences), "{x,y}" (at least x, at most
   y, occurrences), {x,} (x occurrences or more), and their lazy versions;
 - the beginning-of-input ("^") and end-of-input ("$") anchors;
-- simple grouping ("(...)") and alternation ("|").
+- simple grouping ("(" and ")") and alternation ("|").
 
 Finally, implementations MUST NOT take regular expressions to be anchored,
 neither at the beginning nor at the end. This means, for instance, the pattern


### PR DESCRIPTION
Add "." to the permitted simple atoms, for issue #1469.
Consistently format the regex examples.
