### PR TITLE
Fix `prefixItems` keyword omitted behavior

### DIFF
--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -1832,7 +1832,7 @@ results.
 
 ##### `prefixItems`
 
-The value of "prefixItems` MUST be a non-empty array of valid JSON Schemas.
+The value of `prefixItems` MUST be a non-empty array of valid JSON Schemas.
 
 Validation succeeds if each element of the instance validates against the
 subschema at the same position, if any. This keyword does not constrain the

--- a/jsonschema-core.md
+++ b/jsonschema-core.md
@@ -1844,8 +1844,6 @@ this keyword applied a subschema. The value MAY be a boolean true if a subschema
 was applied to every index of the instance, such as is produced by the `items`
 keyword. This annotation affects the behavior of `items` and `unevaluatedItems`.
 
-Omitting this keyword has the same assertion behavior as an empty array.
-
 ##### `items` {#items}
 
 The value of `items` MUST be a valid JSON Schema.


### PR DESCRIPTION
Fixes https://github.com/json-schema-org/json-schema-spec/issues/1480 to omit the sentence about omitting the keyword, as `allOf` etc do.
Also fixes a small markdown error while I'm touching that section.