### PR TITLE
Remove the funding file to use the org wide settings.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,0 @@
-# These are supported funding model platforms
-
-github: [] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: json-schema
-ko_fi: # Single username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
As of now the button to sponsor on Github is not working in this repo because if this file. We have org wide version in the .github repo and if we remove this we'll have the consistent setup applied accross.