### PR TITLE
remove redundant sections about keyword independence

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -1468,19 +1468,6 @@ operators can contact the owner of a potentially misbehaving script.
 This section defines a set of keywords that enable schema combinations and
 composition.
 
-### Keyword Independence
-
-Schema keywords typically operate independently, without affecting each other's
-outcomes.
-
-For schema author convenience, there are some exceptions among these keywords:
-
-- `additionalProperties`, whose behavior is defined in terms of `properties` and
-  `patternProperties`
-- `items`, whose behavior is defined in terms of `prefixItems`
-- `contains`, whose behavior is affected by the presence and value of
-  `minContains`
-
 ### Keywords for Applying Subschemas in Place {#in-place}
 
 These keywords apply subschemas to the same location in the instance as the
@@ -1821,16 +1808,6 @@ subschemas.
 The behaviors of these keywords depend on adjacent keywords as well as any
 keywords in successfully validated subschemas that apply to the same instance
 location.
-
-### Keyword Independence
-
-Schema keywords typically operate independently, without affecting each other's
-outcomes. However, these keywords are notable exceptions:
-
-- `unevaluatedItems`, whose behavior is defined in terms of annotations from
-  `prefixItems`, `items`, `contains`, and itself
-- `unevaluatedProperties`, whose behavior is defined in terms of annotations
-  from `properties`, `patternProperties`, `additionalProperties`, and itself
 
 ### `unevaluatedItems` {#unevaluateditems}
 


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->
Clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
-  Closes #1218 <!-- Replace ___ with the issue number this PR resolves -->

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
Removes 2 redundant sections about keywords being independent.  We now have a "Keyword Independence" section, and each keyword section explicitly states their relations to other keywords.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No