### PR TITLE
Update markdown list item lint rule

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -12,6 +12,7 @@ import remarkHeadingId from "remark-heading-id";
 import remarkHeadings from "./remark-headings.js";
 import remarkPresetLintMarkdownStyleGuide from "remark-preset-lint-markdown-style-guide";
 import remarkLintMaximumHeadingLength from "remark-lint-maximum-heading-length";
+import remarkLintListItemIndent from "remark-lint-list-item-indent";
 import remarkRehype from "remark-rehype";
 import remarkReferenceLinks from "./remark-reference-links.js";
 import remarkTableOfContents from "./remark-table-of-contents.js";
@@ -27,6 +28,7 @@ const build = async (filePath) => {
   const file = await remark()
     .use(remarkPresetLintMarkdownStyleGuide)
     .use(remarkLintMaximumHeadingLength, false)
+    .use(remarkLintListItemIndent, "one")
     .use(remarkGfm)
     .use(remarkHeadingId)
     .use(remarkHeadings, {

--- a/proposals/propertyDependencies.md
+++ b/proposals/propertyDependencies.md
@@ -93,7 +93,7 @@ The `propertyDependencies` keyword will be added to the
 `https://json-schema.org/vocab/applicator` [applicator
 vocabulary](../jsonschema-core.html#applicatorvocab).
 
-1.  The following will be added to the JSON Schema Core specification as a
+1. The following will be added to the JSON Schema Core specification as a
 subsection of "Keywords for Applying Subschemas Conditionally".
     > ### `propertyDependencies`
     >
@@ -110,7 +110,7 @@ subsection of "Keywords for Applying Subschemas Conditionally".
     >
     > Omitting this keyword has the same behavior as an empty object.
 
-2.  The following subschema will be added to the Applicator Vocabulary schema,
+2. The following subschema will be added to the Applicator Vocabulary schema,
    `https://json-schema.org/<version>/<release>/meta/applicator` at
    `/properties/propertyDependencies`:
 


### PR DESCRIPTION
@gregsdennis and I weren't a fan of the default markdown list-item linting rule. See, https://cirosantilli.com/markdown-style-guide/#spaces-after-list-marker for details. The default is "mixed". We prefer "one".