### PR TITLE
Update lint automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
           node-version: latest
           cache: npm
       - run: npm ci
-      - run: npm run lint
+      - run: npm run lint:js
+      - run: npm run lint:md
       - run: npm run build -- specs
 
   specs-ietf:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . ; remark --no-stdout --frail specs/",
+    "lint:js": "eslint .",
+    "lint:md": "remark --no-stdout --frail specs/",
     "build": "remark --rc-path specs/.remarkrc-build.js --output web/"
   },
   "license": "MIT",


### PR DESCRIPTION
The `npm run lint` command currently runs both `eslint` for JavaScript and `remark` for markdown. The problem is that it uses `;` to run both commands and that doesn't work on windows. To address that problem, I split the commands into `lint:js` and `lint:md`.