### PR TITLE
clarify that a meta-schema applies to the schema resource, not necessarily the whole document

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -833,9 +833,11 @@ Meta-schemas are used to inform an implementation how to interpret a schema.
 Every schema has a meta-schema, which can be explicitly declared using the
 `$schema` keyword.
 
-The meta-schema serves to describe valid schema syntax. A schema MUST
+The meta-schema serves to describe valid schema syntax. A schema resource MUST
 successfully validate against its meta-schema, which constrains the syntax of
-the available keywords. The syntax described for a given keyword is expected to
+the available keywords. (See {{compound-validation}} for information on
+validating schemas which contain embedded schema resources that declare a
+different meta-schema.) The syntax described for a given keyword is expected to
 be compatible with the document which defines the keyword; while it is possible
 to describe an incompatible syntax, such a meta-schema would be unlikely to be
 useful.
@@ -1339,7 +1341,7 @@ Since any schema that can be referenced can also be embedded, embedded schema
 resources MAY specify different processing dialects using the `$schema` values
 from their enclosing resource.
 
-#### Validating
+#### Validating {#compound-validation}
 
 Given that a Compound Schema Document may have embedded resources which identify
 as using different dialects, these documents SHOULD NOT be validated by applying


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->
clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
-  Closes #1442

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
Clarifies that meta-schema validation applies to the schema _resource_ that declares the meta-schema with `$schema`.  Also adds a pointer to the section on validating compound documents to reinforce that meta-schema validation should be a special activity separate from applying a schema to an instance.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.
