### PR TITLE
clarify that `type` must be a non-empty array

### DIFF
--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -108,7 +108,8 @@ an instance. These keywords are all assertions without any annotation behavior.
 #### `type`
 
 The value of this keyword MUST be either a string or an array. If it is an
-array, elements of the array MUST be strings and MUST be unique.
+array, it MUST be non-empty, and elements of the array MUST be strings and MUST
+be unique.
 
 String values MUST be one of the six primitive types ("null", "boolean",
 "object", "array", "number", or "string"), or "integer" which matches any number


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->
clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
-  Closes #1404

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
Clarifies that `type` as an array must be non-empty.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Technically yes?  @awwright did point out that there is a niche use case as an alternative to `{not:{}}`, but the keyword certainly wasn't intended to be used this way.  Also, given that we present `{not:{}}` as the analog to `false`, it's extremely unlikely that anyone will be using it this way on purpose.