### PR TITLE
Update deprecated Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
   specs-ietf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - run: pip install --requirement requirements.txt
       - run: xml2rfc --version
       - run: make all
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: specification-docs
           path: |


### PR DESCRIPTION
We got a notice that the version of `actions/upload-artifact` that we are using is going to be deprecated. This updates that action and other outdated actions to the latest version.