### PR TITLE
use more accurate regex vocabulary

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -374,9 +374,9 @@ tokens:
 - complemented simple character classes (`[^abc]`);
 - complemented range character classes (`[^a-z]`);
 - simple quantifiers: `+` (one or more), `*` (zero or more), `?` (zero or one),
-  and their lazy versions (`+?`, `*?`, `??`);
+  and their non-greedy versions (`+?`, `*?`, `??`);
 - range quantifiers: `{x}` (exactly x occurrences), `{x,y}` (at least x, at most
-  y, occurrences), {x,} (x occurrences or more), and their lazy versions;
+  y, occurrences), {x,} (x occurrences or more), and their non-greedy versions;
 - the beginning-of-input (`^`) and end-of-input (`$`) anchors;
 - simple grouping (using `(` and `)`) and alternation (`|`).
 

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -376,7 +376,7 @@ tokens:
 - simple quantifiers: `+` (one or more), `*` (zero or more), `?` (zero or one),
   and their non-greedy versions (`+?`, `*?`, `??`);
 - range quantifiers: `{x}` (exactly x occurrences), `{x,y}` (at least x, at most
-  y, occurrences), {x,} (x occurrences or more), and their non-greedy versions;
+  y, occurrences), `{x,}` (x occurrences or more), and their non-greedy versions;
 - the beginning-of-input (`^`) and end-of-input (`$`) anchors;
 - simple grouping (using `(` and `)`) and alternation (`|`).
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

Editorial

### Issue & Discussion References

-  Related to #1470
- Related to #599
- Related to 314b5c3040c5af13f838165189df3e0585b35a26

### Summary

Referring to the difference between e.g. `.+` and `.+?` as "laziness" isn't wrong, but it is less accurate than "greediness".

### Does this PR introduce a breaking change?

No.