### PR TITLE
clarify that contentSchema holds a subschema and when/how it applies

### DIFF
--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -544,8 +544,8 @@ The value of this property MUST be a valid JSON schema. The subschema is
 produced as an annotation.
 
 Since `contentMediaType` is required to provide instruction on how to interpret
-the string content, the annotation schema produced by this keyword has no
-meaning if `contentMediaType` is not present.
+string content, the annotation schema produced by this keyword has no meaning if
+`contentMediaType` is not present.
 
 Accessing the schema through the schema location IRI included as part of the
 annotation will ensure that it is correctly processed as a subschema. Using the

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -544,7 +544,7 @@ The value of this property MUST be a valid JSON schema. The subschema is
 produced as an annotation.
 
 Since `contentMediaType` is required to provide instruction on how to interpret
-string content, the annotation schema produced by this keyword has no meaning if
+string content, `contentSchema` SHOULD NOT produce an annotation if
 `contentMediaType` is not present.
 
 Note that evaluating the `contentSchema` subschema in-place (i.e. as part of its

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -533,19 +533,24 @@ defined by [RFC 2046](#rfc2046).
 
 ### `contentSchema`
 
-If the instance is a string, and if `contentMediaType` is present, this property
-contains a schema which describes the structure of the string.
+If the instance is a string, and if `contentMediaType` is present, this
+property's subschema describes the structure of the string.
 
 This keyword MAY be used with any media type that can be mapped into JSON
 Schema's data model. Specifying such mappings is outside of the scope of this
 specification.
 
-The value of this property MUST be a valid JSON schema. It SHOULD be ignored if
-`contentMediaType` is not present. Accessing the schema through the schema
-location IRI included as part of the annotation will ensure that it is correctly
-processed as a subschema. Using the extracted annotation value directly is only
-safe if the schema is an embedded resource with both `$schema` and an
-absolute IRI `$id`.
+The value of this property MUST be a valid JSON schema. The subschema is
+produced as an annotation.
+
+Since `contentMediaType` is required to provide instruction on how to interpret
+the string content, the annotation schema produced by this keyword has no
+meaning if `contentMediaType` is not present.
+
+Accessing the schema through the schema location IRI included as part of the
+annotation will ensure that it is correctly processed as a subschema. Using the
+extracted annotation value directly is only safe if the subschema is an embedded
+resource with both `$schema` and an absolute IRI `$id`.
 
 ### Example
 

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -534,7 +534,7 @@ defined by [RFC 2046](#rfc2046).
 ### `contentSchema`
 
 If the instance is a string, and if `contentMediaType` is present, this
-property's subschema describes the structure of the string.
+keyword's subschema describes the structure of the string.
 
 This keyword MAY be used with any media type that can be mapped into JSON
 Schema's data model. Specifying such mappings is outside of the scope of this

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -550,7 +550,7 @@ string content, `contentSchema` SHOULD NOT produce an annotation if
 Note that evaluating the `contentSchema` subschema in-place (i.e. as part of its
 parent schema) will ensure that it is correctly processed. Independent use of
 the extracted subschema (as returned in an annotation) is only safe if the
-subschema is an embedded reource which defines both a `$schema` and an absolute
+subschema is an embedded resource which defines both a `$schema` and an absolute
 IRI `$id`.[^7]
 
 [^7] Processing a non-resource subschema in place will ensure that any

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -547,10 +547,18 @@ Since `contentMediaType` is required to provide instruction on how to interpret
 string content, the annotation schema produced by this keyword has no meaning if
 `contentMediaType` is not present.
 
-Accessing the schema through the schema location IRI included as part of the
-annotation will ensure that it is correctly processed as a subschema. Using the
-extracted annotation value directly is only safe if the subschema is an embedded
-resource with both `$schema` and an absolute IRI `$id`.
+Note that evaluating the `contentSchema` subschema in-place (i.e. as part of its
+parent schema) will ensure that it is correctly processed. Independent use of
+the extracted subschema (as returned in an annotation) is only safe if the
+subschema is an embedded reource which defines both a `$schema` and an absolute
+IRI `$id`.[^7]
+
+[^7] Processing a non-resource subschema in place will ensure that any
+references (e.g. `$ref`) are always resolved properly. This isn't a problem when
+the subschema is itself a resource. See
+https://github.com/json-schema-org/json-schema-spec/issues/1381 for several
+examples where processing this subschema independently can cause `$ref`
+resolution failure.
 
 ### Example
 


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->
clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
-  Closes #1381 <!-- Replace ___ with the issue number this PR resolves -->
-  Related to #1288 <!-- Use when the PR doesn't completely resolve an issue -->

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->

Updates the text for `contentSchema` to indicate that its value is indeed a subschema (and therefore should be treated as such when scanning for identifiers).  Also cleans up language around its dependency on `contentMediaType`.

I didn't include any explicit text about it containing identifiers.  Instead I declare that the value _is_ a subschema and removed the "SHOULD ignore" text discussed in the issue.

Also pertinent to the issue discussion is the final couple sentences (already present), which I ~broke out into a new paragraph~ rewrote to make it more apparent that it is a note of guidance rather than a requirement.

> Accessing the schema through the schema location IRI included as part of the
> annotation will ensure that it is correctly processed as a subschema. Using the
> extracted annotation value directly is only safe if the subschema is an embedded
> resource with both `$schema` and an absolute IRI `$id`.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.