### PR TITLE
Fix `links` not adhering to its meta-schema given invalid `dependencies`

### DIFF
--- a/links.json
+++ b/links.json
@@ -36,6 +36,6 @@
 	"required" : ["rel", "href"],
 	
 	"dependencies" : {
-		"enctype" : "method"
+		"enctype" : ["method"]
 	}
 }


### PR DESCRIPTION
In Draft 4, `dependencies` is either a schema or an array of unique strings.

See: https://json-schema.org/draft-04/draft-fge-json-schema-validation-00#rfc.section.5.4.5
See: https://www.learnjsonschema.com/draft4/validation/dependencies/