### PR TITLE
keywords only exhibit the behaviors they're defined with

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -415,19 +415,36 @@ keywords MUST NOT begin with this prefix.
 Implementations MUST refuse to evaluate schemas which contain keywords which
 they do not know how to process or explicitly choose not to process.
 
-## Keyword Behaviors
+## Keyword Behaviors {#keyword-behaviors}
 
-JSON Schema keywords fall into several general behavior categories. Assertions
-validate that an instance satisfies constraints, producing a boolean result.
-Annotations attach information that applications may use in any way they see
-fit. Applicators apply subschemas to parts of the instance and combine their
-results.
+JSON Schema keywords may exhibit one or more behaviors. This specification
+defines three such behaviors:
 
-Extension keywords SHOULD stay within these categories, keeping in mind that
+- Assertions validate that an instance satisfies constraints, producing a
+  boolean result: `true` if the constraints are satisfied; `false` otherwise.
+- Annotations attach information that applications may use in any way they see
+  fit.
+- Applicators apply subschemas to parts of the instance and combine their
+  results.
+
+Extension keywords SHOULD be defined using these behaviors, keeping in mind that
 annotations in particular are extremely flexible. Complex behavior is usually
 better delegated to applications on the basis of annotation data than
 implemented directly as schema keywords. However, extension keywords MAY define
 other behaviors for specialized purposes.
+
+Keywords which are not defined to exhibit a particular behavior MUST NOT affect
+that aspect of evalution. For example, a keyword which does not act as an
+assertion MUST NOT affect the validation result.
+
+For the purposes of this document, an instance "validating against a keyword"
+means that the keyword produces an assertion result of `true` if the instance
+satisfies the given constraint; otherwise an assertion result of `false` is
+produced.
+
+<!-- The next two paragraphs and the following section seem to have to more to
+do with schema evaluation than keywords specifically. I'd like to move them out
+of the "keyword behaviors" h2, but will do so separately. [TODO: GD] -->
 
 Evaluating an instance against a schema involves processing all of the keywords
 in the schema against the appropriate locations within the instance. Typically,
@@ -569,11 +586,11 @@ the keyword's value. Alternatively, an applicator may refer to a schema
 elsewhere in the same schema document, or in a different one. The mechanism for
 identifying such referenced schemas is defined by the keyword.
 
-Applicator keywords also define how subschema or referenced schema boolean
-[assertion](#assertions) results are modified and/or combined to produce the
-boolean result of the applicator. Applicators may apply any boolean logic
-operation to the assertion results of subschemas, but MUST NOT introduce new
-assertion conditions of their own.
+Applicator keywords also behave as assertions by defining how subschema or
+referenced schema boolean [assertion](#assertions) results are modified and/or
+combined to produce the boolean result of the applicator. Applicators may apply
+any boolean logic operation to the assertion results of subschemas, but MUST NOT
+introduce new assertion conditions of their own.
 
 [Annotation](#annotations) results from subschemas are preserved in accordance
 with {{collect}} so that applications can decide how to interpret multiple
@@ -1002,10 +1019,15 @@ identified schema. Its results are the results of the referenced schema.[^5]
 other keywords can appear alongside of `$ref` in the same schema object.
 
 The value of the `$ref` keyword MUST be a string which is an IRI reference.
+The value of the `$ref` keyword MUST be a string which is an IRI reference.
 Resolved against the current IRI base, it produces the IRI of the schema to
 apply. This resolution is safe to perform on schema load, as the process of
 evaluating an instance cannot change how the reference resolves.
 
+The resolved IRI produced by `$ref` is not necessarily a network locator, only
+an identifier. A schema need not be downloadable from the address if it is a
+network-addressable URL. Implementations which can access the network SHOULD
+default to operating offline.
 The resolved IRI produced by `$ref` is not necessarily a network locator, only
 an identifier. A schema need not be downloadable from the address if it is a
 network-addressable URL. Implementations which can access the network SHOULD
@@ -1476,8 +1498,8 @@ operators can contact the owner of a potentially misbehaving script.
 
 ## Keywords for Applying Subschemas
 
-This section defines a set of keywords that enable schema combinations and
-composition.
+This section defines a set of applicator keywords that enable schema
+combinations and composition.
 
 ### Keywords for Applying Subschemas in Place {#in-place}
 
@@ -1737,8 +1759,8 @@ The value of this keyword MUST be a non-negative integer.
 This keyword modifies the behavior of `contains` within the same schema object,
 as described below in the section for that keyword.
 
-Validation MUST always succeed against this keyword. The value of this keyword
-is used as its annotation result.
+This keyword produces no assertion result. The value of this keyword is used as
+its annotation result.
 
 ##### `minContains`
 
@@ -1747,8 +1769,8 @@ The value of this keyword MUST be a non-negative integer.
 This keyword modifies the behavior of `contains` within the same schema object,
 as described below in the section for that keyword.
 
-Validation MUST always succeed against this keyword. The value of this keyword
-is used as its annotation result.
+This keyword produces no assertion result. The value of this keyword is used as
+its annotation result.
 
 Per {{default-behaviors}}, omitted keywords MUST NOT produce annotation results.
 However, as described in {{contains}}, the absence of this keyword's annotation

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -434,7 +434,7 @@ implemented directly as schema keywords. However, extension keywords MAY define
 other behaviors for specialized purposes.
 
 Keywords which are not defined to exhibit a particular behavior MUST NOT affect
-that aspect of evalution. For example, a keyword which does not act as an
+that aspect of evaluation. For example, a keyword which does not act as an
 assertion MUST NOT affect the validation result.
 
 For the purposes of this document, an instance "validating against a keyword"

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -442,7 +442,7 @@ means that the keyword produces an assertion result of `true` if the instance
 satisfies the given constraint; otherwise an assertion result of `false` is
 produced.
 
-<!-- The next two paragraphs and the following section seem to have to more to
+<!-- The next two paragraphs and the following section seem to have more to
 do with schema evaluation than keywords specifically. I'd like to move them out
 of the "keyword behaviors" h2, but will do so separately. [TODO: GD] -->
 

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -394,6 +394,18 @@ Additional schema keywords MAY be defined by any entity. Save for explicit
 agreement, schema authors SHALL NOT expect these additional keywords to be
 supported by implementations that do not explicitly document such support.
 
+Extension keywords MUST NOT interfere with the operation of keywords defined by
+this document or the companion JSON Schema Validation specificiation, and SHOULD
+NOT interfere with the operation of keywords defined by other extension
+documents.[^11]
+
+[^11]: JSON Schema currently does not have a namespacing mechanism, which would
+allow multiple extensions to define the same keyword differently while also
+giving the schema author the ability to declare which definition is intended.
+Such a feature is planned for future releases. See the
+[Vocabularies / Extensions project](https://github.com/orgs/json-schema-org/projects/28/views/2)
+in GitHub for more information.
+
 Implementations MAY provide the ability to register or load handlers for
 keywords that they do not support directly. The exact mechanism for registering
 and implementing such handlers is implementation-dependent.
@@ -422,16 +434,15 @@ defines three such behaviors[^7]:
 
 - Assertions validate that an instance satisfies constraints, producing a
   boolean result: `true` if the constraints are satisfied; `false` otherwise.
-- Annotations attach information to instance locations that applications may use in any way they see
-  fit.
+- Annotations attach information to instance locations that applications may use
+  in any way they see fit.
 - Applicators apply subschemas to parts of the instance and combine their
   results.
 
 [^7]: This specification also defines several operational directive keywords,
-such as `$id` and `$schema`. As such, these keywords do not exhibit these
-behaviors. However, it is recommended that extensions avoid defining additional
-directive keywords as they could interfere with schema processing and produce
-unexpected or undesirable results.
+such as `$id` and `$schema`, which do not exhibit these behaviors. Instead,
+these keywords provide metadata that instruct implementations on how to
+interpret and process the schema.
 
 Extension keywords SHOULD be defined using these behaviors, keeping in mind that
 annotations in particular are extremely flexible. Complex behavior is usually
@@ -439,9 +450,7 @@ better delegated to applications on the basis of annotation data than
 implemented directly as schema keywords. However, extension keywords MAY define
 other behaviors for specialized purposes.
 
-Keywords which are not defined to exhibit a particular behavior MUST NOT affect
-that aspect of evaluation. For example, a keyword which does not act as an
-assertion MUST NOT affect the validation result.
+Implementations SHOULD NOT add unspecified behaviors to keywords.
 
 For the purposes of this document, an instance "validating against a keyword"
 means that the keyword produces an assertion result of `true` if the instance

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -394,9 +394,9 @@ Additional schema keywords MAY be defined by any entity. Save for explicit
 agreement, schema authors SHALL NOT expect these additional keywords to be
 supported by implementations that do not explicitly document such support.
 
-Extension keywords MUST NOT interfere with the operation of keywords defined by
+Extension keywords MUST NOT directly modify the operation of keywords defined by
 this document or the companion JSON Schema Validation specificiation, and SHOULD
-NOT interfere with the operation of keywords defined by other extension
+NOT directly modify the operation of keywords defined by other extension
 documents.[^11]
 
 [^11]: JSON Schema currently does not have a namespacing mechanism, which would

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -418,7 +418,7 @@ they do not know how to process or explicitly choose not to process.
 ## Keyword Behaviors {#keyword-behaviors}
 
 JSON Schema keywords may exhibit one or more behaviors. This specification
-defines three such behaviors:
+defines three such behaviors[^7]:
 
 - Assertions validate that an instance satisfies constraints, producing a
   boolean result: `true` if the constraints are satisfied; `false` otherwise.
@@ -426,6 +426,12 @@ defines three such behaviors:
   fit.
 - Applicators apply subschemas to parts of the instance and combine their
   results.
+
+[^7]: This specification also defines several operational directive keywords,
+such as `$id` and `$schema`. As such, these keywords do not exhibit these
+behaviors. However, it is recommended that extensions avoid defining additional
+directive keywords as they could interfere with schema processing and produce
+unexpected or undesirable results.
 
 Extension keywords SHOULD be defined using these behaviors, keeping in mind that
 annotations in particular are extremely flexible. Complex behavior is usually
@@ -589,8 +595,14 @@ identifying such referenced schemas is defined by the keyword.
 Applicator keywords also behave as assertions by defining how subschema or
 referenced schema boolean [assertion](#assertions) results are modified and/or
 combined to produce the boolean result of the applicator. Applicators may apply
-any boolean logic operation to the assertion results of subschemas, but MUST NOT
-introduce new assertion conditions of their own.
+any boolean logic operation to the assertion results of subschemas, but SHOULD
+NOT introduce new assertion conditions of their own.[^2]
+
+[^2]: It is recommended that keywords have a single resposibility. An example of
+this in action is the separation between `properties`, which verifies object
+property values have the right data _if_ they exist, and `required`, which
+verifies that object properties exist. Separating these concerns allows for more
+reusable components.
 
 [Annotation](#annotations) results from subschemas are preserved in accordance
 with {{collect}} so that applications can decide how to interpret multiple

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -604,10 +604,10 @@ identifying such referenced schemas is defined by the keyword.
 Applicator keywords also behave as assertions, using the assertion results of
 each subschema or referenced schema of the keyword. These boolean results are
 modified (e.g. the `not` keyword negates its subschema's assertion) and/or
-combined (e.g. `allOf` takes the conjunction of its subschemas' assertions)
-to produce the boolean result of the applicator.
-any boolean logic operation to the assertion results of subschemas, but SHOULD
-NOT introduce new assertion conditions of their own.[^2]
+combined (e.g. `allOf` takes the conjunction of its subschemas' assertions) to
+produce the boolean result of the applicator. Applicators may apply any boolean
+logic operation to the assertion results of subschemas, but SHOULD NOT introduce
+new assertion conditions of their own.[^2]
 
 [^2]: It is recommended that keywords have a single resposibility. An example of
 this in action is the separation between `properties`, which verifies object

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -1785,7 +1785,7 @@ The value of this keyword MUST be a non-negative integer.
 This keyword modifies the behavior of `contains` within the same schema object,
 as described below in the section for that keyword.
 
-This keyword produces no assertion result. The value of this keyword is used as
+This keyword has no assertion behavior. The value of this keyword is used as
 its annotation result.
 
 Per {{default-behaviors}}, omitted keywords MUST NOT produce annotation results.

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -422,7 +422,7 @@ defines three such behaviors[^7]:
 
 - Assertions validate that an instance satisfies constraints, producing a
   boolean result: `true` if the constraints are satisfied; `false` otherwise.
-- Annotations attach information that applications may use in any way they see
+- Annotations attach information to instance locations that applications may use in any way they see
   fit.
 - Applicators apply subschemas to parts of the instance and combine their
   results.

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -601,9 +601,11 @@ the keyword's value. Alternatively, an applicator may refer to a schema
 elsewhere in the same schema document, or in a different one. The mechanism for
 identifying such referenced schemas is defined by the keyword.
 
-Applicator keywords also behave as assertions by defining how subschema or
-referenced schema boolean [assertion](#assertions) results are modified and/or
-combined to produce the boolean result of the applicator. Applicators may apply
+Applicator keywords also behave as assertions, using the assertion results of
+each subschema or referenced schema of the keyword. These boolean results are
+modified (e.g. the `not` keyword negates its subschema's assertion) and/or
+combined (e.g. `allOf` takes the conjunction of its subschemas' assertions)
+to produce the boolean result of the applicator.
 any boolean logic operation to the assertion results of subschemas, but SHOULD
 NOT introduce new assertion conditions of their own.[^2]
 

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -1040,15 +1040,10 @@ identified schema. Its results are the results of the referenced schema.[^5]
 other keywords can appear alongside of `$ref` in the same schema object.
 
 The value of the `$ref` keyword MUST be a string which is an IRI reference.
-The value of the `$ref` keyword MUST be a string which is an IRI reference.
 Resolved against the current IRI base, it produces the IRI of the schema to
 apply. This resolution is safe to perform on schema load, as the process of
 evaluating an instance cannot change how the reference resolves.
 
-The resolved IRI produced by `$ref` is not necessarily a network locator, only
-an identifier. A schema need not be downloadable from the address if it is a
-network-addressable URL. Implementations which can access the network SHOULD
-default to operating offline.
 The resolved IRI produced by `$ref` is not necessarily a network locator, only
 an identifier. A schema need not be downloadable from the address if it is a
 network-addressable URL. Implementations which can access the network SHOULD

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -68,7 +68,7 @@ The keywords defined by this document exhibit one or more behaviors as defined b
 the [JSON Schema Core Specification](./jsonschema-core.md#keyword-behaviors).
 
 Keywords which are not defined to exhibit a particular behavior MUST NOT affect
-that aspect of the evalution outcome. In particular, the keywords defined in
+that aspect of the evaluation outcome. In particular, the keywords defined in
 {{annotations}} produce no assertion result and therefore are not considered
 during validation.
 

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -62,6 +62,21 @@ information. The {{format}} keyword is intended primarily as an annotation, but
 can optionally be used as an assertion. The {{content}} keywords are annotations
 for working with documents embedded as JSON strings.
 
+## Keyword Behaviors
+
+The keywords defined by this document exhibit one or more behaviors as defined by
+the [JSON Schema Core Specification](./jsonschema-core.md#keyword-behaviors).
+
+Keywords which are not defined to exhibit a particular behavior MUST NOT affect
+that aspect of the evalution outcome. In particular, the keywords defined in
+{{annotations}} produce no assertion result and therefore are not considered
+during validation.
+
+For the purposes of this document, an instance "validating against a keyword"
+means that the keyword produces an assertion result of `true` if the instance
+satisfies the given constraint; otherwise an assertion result of `false` is
+produced.
+
 ## Interoperability Considerations
 
 ### Validation of String Instances
@@ -642,7 +657,7 @@ structures: first the header, and then the payload. Since the JWT media type
 ensures that the JWT can be represented in a JSON string, there is no need for
 further encoding or decoding.
 
-## Keywords for Basic Meta-Data Annotations
+## Keywords for Basic Meta-Data Annotations {#annotations}
 
 These general-purpose annotation keywords provide commonly used information for
 documentation and user interface display purposes. They are not intended to form


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->
clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
- Closes #1540
- Closes #1447

### Summary

The previous language could imply that all keywords needed to have an assertion result, e.g. annotations would always produce a "true" assertion result.

For `min/maxContains`, I added explicit text that they do not produce an assertion result, emphasizing that the assertion comes from `contains` and that these keywords are informative.

This change clarifies that keywords only exhibit the behaviors they're defined with.

### Does this PR introduce a breaking change?

No.
