### PR TITLE
incorporate RFC 9557 time zone extension into 'date-time' format

### DIFF
--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -399,7 +399,7 @@ These attributes apply to string instances.
 Date and time format names are derived from
 [RFC 9557, section 4.1](https://www.rfc-editor.org/info/rfc9557) which extends
 [RFC 3339, section 5.6](https://www.rfc-editor.org/info/rfc3339). The duration
-format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
+format is from ISO 8601 as formalized into ABNF by RFC 3339 Appendix A.
 
 - *date-time*: A string instance is valid against this attribute if it is a
   valid representation according to the "date-time" ABNF rule in RFC 3339,

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -402,8 +402,7 @@ Date and time format names are derived from
 format is from ISO 8601 as formalized into ABNF by RFC 3339 Appendix A.
 
 - *date-time*: A string instance is valid against this attribute if it is a
-  valid representation of either the "date-time" ABNF rule in RFC 3339 or the
-  "date-time-ext" rule in RFC 9557
+  valid representation of the "date-time-ext" rule in RFC 9557
 - *date*: A string instance is valid against this attribute if it is a valid
   representation according to the "full-date" ABNF rule in RFC 3339
 - *time*: A string instance is valid against this attribute if it is a valid

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -397,22 +397,24 @@ custom format values.
 These attributes apply to string instances.
 
 Date and time format names are derived from
+[RFC 9557, section 4.1](https://www.rfc-editor.org/info/rfc9557) which extends
 [RFC 3339, section 5.6](https://www.rfc-editor.org/info/rfc3339). The duration
 format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
 
 - *date-time*: A string instance is valid against this attribute if it is a
-  valid representation according to the "date-time" ABNF rule (referenced above)
+  valid representation according to the "date-time" ABNF rule in RFC 3339,
+  optionally with the "time-zone" rule in RFC 9557
 - *date*: A string instance is valid against this attribute if it is a valid
-  representation according to the "full-date" ABNF rule (referenced above)
+  representation according to the "full-date" ABNF rule in RFC 3339
 - *time*: A string instance is valid against this attribute if it is a valid
-  representation according to the "full-time" ABNF rule (referenced above)
+  representation according to the "full-time" ABNF rule in RFC 3339
 - *duration*: A string instance is valid against this attribute if it is a valid
-  representation according to the "duration" ABNF rule (referenced above)
+  representation according to the "duration" ABNF rule in ISO 8601
 
 Implementations MAY support additional attributes using the other format names
 defined anywhere in that RFC. Implementations SHOULD NOT define extension
-attributes with any name matching an RFC 3339 format unless it validates
-according to the rules of that format.[^5]
+attributes with any name matching an RFC 3339, RFC 9557, or ISO 8601 format
+unless it validates according to the rules of that format.[^5]
 
 [^5]: There is not currently consensus on the need for supporting all RFC 3339
 formats, so this approach of reserving the namespace will encourage

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -409,7 +409,7 @@ format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
 - *time*: A string instance is valid against this attribute if it is a valid
   representation according to the "full-time" ABNF rule in RFC 3339
 - *duration*: A string instance is valid against this attribute if it is a valid
-  representation according to the "duration" ABNF rule in ISO 8601
+  representation according to the "duration" ABNF rule in RFC 3339 Appendix A
 
 Implementations MAY support additional attributes using the other format names
 defined anywhere in that RFC. Implementations SHOULD NOT define extension

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -402,8 +402,8 @@ Date and time format names are derived from
 format is from ISO 8601 as formalized into ABNF by RFC 3339 Appendix A.
 
 - *date-time*: A string instance is valid against this attribute if it is a
-  valid representation according to the "date-time" ABNF rule in RFC 3339,
-  optionally with the "time-zone" rule in RFC 9557
+  valid representation of either the "date-time" ABNF rule in RFC 3339 or the
+  "date-time-ext" rule in RFC 9557
 - *date*: A string instance is valid against this attribute if it is a valid
   representation according to the "full-date" ABNF rule in RFC 3339
 - *time*: A string instance is valid against this attribute if it is a valid


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->
Enhancement

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
- Closes #1572 <!-- Replace ___ with the issue number this PR resolves -->

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->

Extends the `date-time` format by incorporating time zone information from RFC 9557.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
~No~ Yes? `date-time` strings that would have previously failed would now pass.
