### PR TITLE
add subsection to point to the github process file for proposal requirements

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -106,7 +106,7 @@ The website will also be configured to:
 The latest-release meta-schemas will be updated with proposals as indicated by
 the [Proposal section](#proposal) of this document.
 
-> \[!IMPORTANT]
+> [!IMPORTANT]
 > These are only publication and availability URLs. The specification will
 > define the `$id` values for the meta-schemas.
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -106,7 +106,7 @@ The website will also be configured to:
 The latest-release meta-schemas will be updated with proposals as indicated by
 the [Proposal section](#proposal) of this document.
 
-> [!IMPORTANT]
+> \[!IMPORTANT]
 > These are only publication and availability URLs. The specification will
 > define the `$id` values for the meta-schemas.
 

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -439,7 +439,7 @@ provides a guarantee of compatibility for future releases within a version.
 
 ### Future Development and Support of Proposals
 
-Continued development of this specifications and support requirments for
+Continued development of these specifications and support requirments for
 proposed features is managed in the
 [json-schema-org/json-schema-spec](https://github.com/json-schema-org/json-schema-spec)
 GitHub repository and defined by _PROCESS.md_.

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -437,6 +437,13 @@ compatible with successive specifications, which are published with the same
 version and either the same or greater release year value. Thus, JSON Schema
 provides a guarantee of compatibility for future releases within a version.
 
+### Future Development and Support of Proposals
+
+Continued development of this specifications and support requirments for
+proposed features is managed in the
+[json-schema-org/json-schema-spec](https://github.com/json-schema-org/json-schema-spec)
+GitHub repository and defined by _PROCESS.md_.
+
 ## Keyword Behaviors {#keyword-behaviors}
 
 JSON Schema keywords may exhibit one or more behaviors. This specification


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
- Closes #1569
- Related to #___ <!-- Use when the PR doesn't completely resolve an issue -->
- Others? <!-- Add any additional notes or references here -->

### Summary

Adds a new section to help identify requirements for proposals.

It does feel odd to me that the specification is now pointing to a document that could be (and still needs to be) updated.

### Does this PR introduce a breaking change?

No.
