### PR TITLE
New Security Considerations

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -2076,8 +2076,8 @@ the paper or impose limits on dynamic reference resolution.
 
 Infinite loops can occur when evaluating schemas that produce cycles during
 reference resolution. These cycles may involve multiple schemas. Not all
-recursive schemas create loops, but implementations are advised to detect and
-break these cycles when they are encountered.
+recursive schemas create loops, but implementations are advised to detect these
+cycles and terminate evaluation when they are encountered.
 
 ### Schema Identity and Collisions
 

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -2089,8 +2089,8 @@ in overwriting or shadowing of trusted schemas.
 
 Implementations should consider rejecting schemas that have identifiers
 (including embedded schema identifiers) that conflict with registered schemas
-and should apply consistent URI normalization and comparison logic to detect and
-prevent conflicts.
+and should apply any URI normalization and comparison logic consistently to
+detect and prevent conflicts.
 
 ### External Schema Resolution
 

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -2147,11 +2147,11 @@ issues:
   converting them to relative URIs) to avoid exposing host filesystem structure
   to users.
 
-### Vocabulary-Specific Risks
+### Extension-Specific Risks
 
-Third-party JSON Schema vocabularies may introduce additional risks.
-Implementers are advised to consult the specifications of any extensions they
-support and take into account their security considerations as well.
+Third-party JSON Schema extensions may introduce additional risks. Implementers
+are advised to consult the specifications of any extensions they support and
+take into account their security considerations as well.
 
 ## IANA Considerations
 


### PR DESCRIPTION
Resolves #1231 
Replaces #1600 

This is a full rewrite of the Security Considerations sections of the Core spec. It retains most of the original content plus a lot more. The only thing I left out from the original is the part about `$comment`, which I don't think makes sense. If there's an argument for keeping it, I can add it back in.

This new Security Consideration section is inspired by the guidelines and examples in [RFC 3552 - Guidelines for Writing RFC Text on Security Considerations](https://datatracker.ietf.org/doc/html/rfc3552). Some principles I'm trying to follow are,

- This section should not make SHOULD/MUST requirements. Instead, it should state the implications of the requirements made elsewhere in the document.
- This section may discuss threats that are mitigated by spec requirements, but also makes recommendations for mitigating threats that aren't specifically addressed by the spec.
- The audience of the spec is implementers. Schema authors should only be referred to in terms of how implementations should handle their schemas.

Something worth mentioning is that this PR advises not to use `file:` URIs in `$id`. However, we use file URIs in a couple tests in the official test suite. We should consider changing, removing, or moving those tests to optional.