### PR TITLE
Clarify IRI comparison for identity tokens (#1623)

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -978,9 +978,18 @@ To differentiate between schemas in a vast ecosystem, schema resources are
 identified by
 [absolute IRIs](https://www.rfc-editor.org/rfc/rfc3987.html#section-2.2)
 (without fragments). These identifiers are used to create references between
-schema resources. When comparing IRIs for the purposes of resource
-identification, implementations SHOULD first follow the IRI normalization
-procedures defined in [RFC 3987][rfc3987], section 5.3.
+schema resources. ### IRI comparison for identity tokens
+
+When IRIs are used as **identity tokens** (not locators), implementations **MUST use Simple String Comparison** as defined in RFC 3987 section 5.3.1.  
+Normalization or scheme-based comparison is **not required** in this context.
+
+Example:
+
+- `https://example.com/schema/α`  
+- `https://example.com/schema/α`  
+
+These two IRIs are considered identical only if their strings match exactly, without performing additional normalization.
+
 
 Several keywords can accept a relative IRI reference, or a value
 used to construct a relative IRI reference. For these keywords, it is necessary


### PR DESCRIPTION
…ison (#1623)

<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

Documentation / specification clarification


### Issue & Discussion References

- Closes #1623


### Summary

This PR updates the JSON Schema specification to clarify that when IRIs are used as identity tokens (not locators), implementations **must use Simple String Comparison** according to RFC 3987 section 5.3.1.  

Full normalization or scheme-based comparison is **not required** in this context.  

Example for clarity:

- `https://example.com/schema/α`  
- `https://example.com/schema/α`  

These two IRIs are considered identical only if their strings match exactly, without performing additional normalization.  

This fixes the inconsistency between the spec and RFC 3987 recommendations.

### Does this PR introduce a breaking change?

No. This is a documentation/specification update and does not affect existing implementations.

