### PR TITLE
require that `$schema` cannot contain a fragment

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -931,8 +931,9 @@ resources, unless such a resource itself declares a different dialect by
 including the `$schema` keyword with a different value.
 
 The value of this keyword MUST be an
-[absolute IRI](https://www.rfc-editor.org/info/rfc3987) (without a fragment). This
-IRI MUST be normalized.
+[absolute IRI](https://www.rfc-editor.org/info/rfc3987) (without a fragment).
+This IRI MUST be normalized, the rules for which can be found in the
+[next section](#dereferencing).
 
 The `$schema` keyword SHOULD be used in the document root schema object, and MAY
 be used in the root schema objects of embedded schema resources. This keyword
@@ -943,7 +944,7 @@ schema resources.)
 Values for this property are defined elsewhere in this and other documents, and
 by other parties.
 
-### Base IRI, Anchors, and Dereferencing
+### Base IRI, Anchors, and Dereferencing {#dereferencing}
 
 To differentiate between schemas in a vast ecosystem, schema resources are
 identified by

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -931,8 +931,8 @@ resources, unless such a resource itself declares a different dialect by
 including the `$schema` keyword with a different value.
 
 The value of this keyword MUST be an
-[IRI](https://www.rfc-editor.org/info/rfc3987) (containing a scheme). This
-IRI MUST be normalized and MUST NOT contain a fragment.
+[absolute IRI](https://www.rfc-editor.org/info/rfc3987) (without a fragment). This
+IRI MUST be normalized.
 
 The `$schema` keyword SHOULD be used in the document root schema object, and MAY
 be used in the root schema objects of embedded schema resources. This keyword

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -931,8 +931,8 @@ resources, unless such a resource itself declares a different dialect by
 including the `$schema` keyword with a different value.
 
 The value of this keyword MUST be an
-[IRI](https://www.rfc-editor.org/info/rfc3987) (containing a scheme) and this
-IRI MUST be normalized.
+[IRI](https://www.rfc-editor.org/info/rfc3987) (containing a scheme). This
+IRI MUST be normalized and MUST NOT contain a fragment.
 
 The `$schema` keyword SHOULD be used in the document root schema object, and MAY
 be used in the root schema objects of embedded schema resources. This keyword


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

Clarification

### Issue & Discussion References

<!-- Pick at least one of the below options, and remove those which don't apply. -->
- Closes #1590 <!-- Replace ___ with the issue number this PR resolves -->

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->

Adds a requirement to `$schema` that its value cannot contain a fragment.  This prevents someone from using a non-canonical IRI in this keyword.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Technically, yes, but the likelyhood of people using fragments in `$schema` is low (probably non-zero, though).