### PR TITLE
add a 'v' to the version number in the meta-schema uri

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -81,8 +81,8 @@ The specifications will be published on the JSON Schema website,
 <https://json-schema.org/>, using a path comprised of the version, year, and
 document name. For example,
 
-- `https://json-schema.org/1/2025/core.html`
-- `https://json-schema.org/1/2025/validation.html`
+- `https://json-schema.org/v1/2026/core.html`
+- `https://json-schema.org/v1/2026/validation.html`
 
 Once a specification document has been published, neither the document (save for
 minor errata such as spelling mistakes) nor its publication URL may change. If
@@ -94,14 +94,14 @@ future publications and are not retroactive.
 A release meta-schema will be published under the same path using `schema.json`
 as the file name.
 
-- `https://json-schema.org/1/2025/schema.json`
+- `https://json-schema.org/v1/2026/schema.json`
 
 The website will also be configured to:
 
 - serve the meta-schema from its release folder:
-  `https://json-schema.org/1/2025/`
+  `https://json-schema.org/v1/2026/`
 - serve the meta-schema for the latest release in a version from its version
-  folder: `https://json-schema.org/1/`
+  folder: `https://json-schema.org/v1/`
 
 The latest-release meta-schemas will be updated with proposals as indicated by
 the [Proposal section](#proposal) of this document.

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -429,8 +429,8 @@ they do not know how to process or explicitly choose not to process.
 
 ## Specification Versioning and Compatibility
 
-This specification is identified collectively by two values: version and release
-year.
+This specification is identified collectively by two values: version, denoted as
+the letter "v" and the version number, and release year.  For example,
 
 A schema written to conform with the requirements of a given version is
 compatible with successive specifications, which are published with the same
@@ -2358,7 +2358,7 @@ and only allows the "data" and "children" properties. An example instance with
 
 ```jsonschema "Tree schema, extensible"
 {
-  "$schema": "https://json-schema.org/1/2025",
+  "$schema": "https://json-schema.org/v1/2026",
   "$id": "https://example.com/tree",
   "$dynamicAnchor": "node",
 
@@ -2377,7 +2377,7 @@ and only allows the "data" and "children" properties. An example instance with
 
 ```jsonschema "Strict-tree schema, guards against misspelled properties"
 {
-  "$schema": "https://json-schema.org/1/2025",
+  "$schema": "https://json-schema.org/v1/2026",
   "$id": "https://example.com/strict-tree",
   "$dynamicAnchor": "node",
 

--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -103,10 +103,10 @@ specification.
 ## Meta-Schema {#meta-schema}
 
 The current IRI for the default JSON Schema dialect meta-schema is
-`https://json-schema.org/1/2025`. This IRI encodes the specification's version
+`https://json-schema.org/v1/2026`. This IRI encodes the specification's version
 and release year. Because all schemas written to conform to a given version are
 guaranteed to be compatible with later releases within the same version, the
-meta-schema IRI `https://json-schema.org/1` is also recognized to represent the
+meta-schema IRI `https://json-schema.org/v1` is also recognized to represent the
 latest release within the indicated version.
 
 The meta-schema describes a dialect consisting of all keywords defined in this

--- a/specs/meta/README.md
+++ b/specs/meta/README.md
@@ -27,7 +27,7 @@ First, create a schema that just defines the new keywords.
 
 ```json
 {
-  "$schema": "https://json-schema.org/1",
+  "$schema": "https://json-schema.org/v1",
   "$id": "https://example.com/schema/odds-evens",
 
   "properties": {
@@ -45,10 +45,10 @@ Second, create a new meta-schema that
 
 ```json
 {
-  "$schema": "https://json-schema.org/1",
+  "$schema": "https://json-schema.org/v1",
   "$id": "https://example.com/schema/odds-evens-extension",
 
-  "$ref": "https://json-schema.org/1",
+  "$ref": "https://json-schema.org/v1",
 
   "$defs": {
     "extension": {

--- a/specs/meta/meta.json
+++ b/specs/meta/meta.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://json-schema.org/1/2025",
-    "$id": "https://json-schema.org/1/2025",
+    "$schema": "https://json-schema.org/v1/2026",
+    "$id": "https://json-schema.org/v1/2026",
     "$dynamicAnchor": "meta",
 
     "title": "JSON Schema Core and Validation specification meta-schema",


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

General update

### Issue & Discussion References

None

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->

I saw this in Slack in a conversation between @karenetheridge and @jdesrosiers.  I'm not sure who came up with it, but I think it addresses @karenetheridge's concerns that the 1/2025 looks like a date.

### Does this PR introduce a breaking change?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.  It's already broken.
