### PR TITLE
Change idn-* formats to use UTS #46 and move to registry

### DIFF
--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -437,12 +437,7 @@ These attributes apply to string instances.
 A string instance is valid against these format values if it is a valid Internet
 email address as follows:
 
-- *email:* As defined by the "Mailbox" ABNF rule in [RFC 5321, section
-  4.1.2](https://www.rfc-editor.org/info/rfc5321).
-- *idn-email:* As defined by the extended "Mailbox" ABNF rule in [RFC 6531,
-  section 3.3](https://www.rfc-editor.org/info/rfc6531). Note that all strings
-  valid against the "email" attribute are also valid against the "idn-email"
-  attribute.
+- *email:* As defined by the "Mailbox" ABNF rule in [RFC 5321, section 4.1.2](https://www.rfc-editor.org/info/rfc5321).
 
 #### Hostnames
 
@@ -451,15 +446,7 @@ These attributes apply to string instances.
 A string instance is valid against these attributes if it is a valid
 representation for an Internet hostname as follows:
 
-- *hostname:* As defined by
-  [RFC 1123, section 2.1](https://www.rfc-editor.org/info/rfc1123), including
-  host names produced using the Punycode algorithm specified in [RFC 5891,
-  section 4.4](https://www.rfc-editor.org/info/rfc5891).
-- *idn-hostname:* As defined by either RFC 1123 as for hostname, or an
-  internationalized hostname as defined by [RFC 5890, section
-  2.3.2.3](https://www.rfc-editor.org/info/rfc5890). Note that all strings valid
-  against the "hostname" attribute are also valid against the "idn-hostname"
-  attribute.
+- *hostname:* As defined by [RFC 1123, section 2.1](https://www.rfc-editor.org/info/rfc1123).
 
 #### IP Addresses
 
@@ -853,7 +840,7 @@ to the document.
     document
   - Also allow RFC 4648 encodings in `contentEncoding`
   - Added `minContains` and `maxContains`
-  - Update RFC reference for nhostname" and "idn-hostname"
+  - Update RFC reference for "hostname" and "idn-hostname"
   - Add "uuid" and "duration" formats
 - *draft-handrews-json-schema-validation-01*
   - This draft is purely a clarification with no functional changes

--- a/specs/registries/format.json
+++ b/specs/registries/format.json
@@ -141,18 +141,14 @@
         "supportedBy": []
     },
     "idn-email": {
-        "description": "An email address as defined as Mailbox in RFC6531",
-        "definingBody": "JSON Schema",
-        "definition": "https://json-schema.org/draft/2020-12/json-schema-validation.html#name-email-addresses",
+        "description": "An email address as defined by Mailbox in RFC6531 with the domain using the UTS #46 mapping for IDNs",
         "types": ["string"],
         "examples": ["user@exämple.com"],
         "deprecated": false,
         "supportedBy": []
     },
     "idn-hostname": {
-        "description": "An internationalized host name as defined by RFC5890",
-        "definingBody": "JSON Schema",
-        "definition": "https://json-schema.org/draft/2020-12/json-schema-validation.html#name-hostnames",
+        "description": "An internationalized host name as defined by IDNA2008 using the UTS #46 mapping",
         "types": ["string"],
         "examples": ["exämple.com"],
         "deprecated": false,


### PR DESCRIPTION
Resolves #1636 

- Revert `hostname` to it's draft-06 definition that doesn't require validating IDNs.
- Require full validation of `idn-hostname` and `idn-email`
- Update the `idn-hostname` and `idn-email` to the format registry and update to be defined by IDNA2008 using the `UTS #46` mapping.

I was a little uncertain what to do with the `definingBody` and `definition` field in this case. It would seem to make sense to link to `UTS #46` (and maybe the related RFCs as well), but that doesn't seem to be the convention. Those fields are dedicated to where those formats are defined as formats, not the specification that defines them.

Should we change that convention? Should we add another field for the specification? Should we just leave it as I've done here and just leave out those fields like similar cases in the registry?

I think it makes more sense for the registry to reference the specification of the format, not JSON Schema, or OpenAPI unless there is no other specification and that's where the format is actually defined. I'm don't think that's the case for any formats we have registered.