### PR TITLE
Clarify repository purpose for new contributors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Financial Contributors on Open Collective](https://opencollective.com/json-schema/all/badge.svg?label=financial+contributors)](https://opencollective.com/json-schema)
 
+> **Note for new contributors**
+
+> While I was exploring this repository as a first-time contributor, it was not clear at first glance, whether this repository contains stable specifications or ongoing draft versions.
+
+> This repository contains *work-in-progress* specifications for upcoming *JSON Schema* drafts.
+> If you are looking for the latest stable JSON Schema versions, please refer to the
+> official Specification page on the website.
+
+> Also, new contributors do not need to build the specification locally in order to
+> contribute documentation improvements or small clarifications.
+
 JSON Schema is a vocabulary that allows you to validate, annotate, and
 manipulate JSON documents.
 


### PR DESCRIPTION
This PR adds a short clarification note based on first-time contributor experience.

The goal is to help new contributors distinguish between stable specifications
and work-in-progress drafts, and to clarify that local builds are not required
for documentation-only contributions.
