### PR TITLE
Fix remark headings map to avoid Object.prototype collisions (fixes #1673)

### DIFF
--- a/remark/remark-headings.js
+++ b/remark/remark-headings.js
@@ -75,11 +75,11 @@ const remarkNumberHeadings = (options) => (tree, file) => {
     file.data = {};
   }
 
-  file.data.headings = {};
+  file.data.headings = Object.create(null);
 
   visit(tree, "heading", (headingNode) => {
     if (headingNode.data?.id) {
-      if (headingNode.data.id in file.data.headings) {
+      if (Object.prototype.hasOwnProperty.call(file.data.headings, headingNode.data.id)) {
         file.message(`Found duplicate heading id "${headingNode.data.id}"`);
       }
       file.data.headings[headingNode.data.id] = headingNode;

--- a/remark/remark-reference-links.js
+++ b/remark/remark-reference-links.js
@@ -8,12 +8,13 @@ const referenceLink = /\{\{(?<id>.*?)\}\}/ug;
 const remarkReferenceLinks = () => (tree, file) => {
   findAndReplace(tree, [referenceLink, (value, id) => {
     // file.data.headings comes from ./remark-headings.js
-    if (!(id in file.data.headings)) {
+    if (!Object.prototype.hasOwnProperty.call(file.data.headings, id)) {
       throw Error(`ReferenceLinkError: No header found with id "${id}"`);
     }
 
-    const headerText = nodeToString(file.data.headings[id]);
-    const linkText = text(file.data.headings[id].data.section);
+    const headingNode = file.data.headings[id];
+    const headerText = nodeToString(headingNode);
+    const linkText = text(headingNode.data.section);
     return link(`#${id}`, headerText, [linkText]);
   }]);
 };

--- a/remark/remark-reference-links.test.js
+++ b/remark/remark-reference-links.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import remarkHeadings from "./remark-headings.js";
+import remarkReferenceLinks from "./remark-reference-links.js";
+
+const createFile = () => ({
+  data: {},
+  message: () => {}
+});
+
+test("throws ReferenceLinkError for prototype key without real heading", () => {
+  const tree = {
+    type: "root",
+    children: [{
+      type: "paragraph",
+      children: [{ type: "text", value: "Reference: {{constructor}}" }]
+    }]
+  };
+
+  const file = createFile();
+
+  remarkHeadings({ startDepth: 2, skip: [] })(tree, file);
+
+  assert.throws(
+    () => remarkReferenceLinks()(tree, file),
+    /ReferenceLinkError: No header found with id "constructor"/
+  );
+});
+
+test("resolves constructor reference when real heading exists", () => {
+  const tree = {
+    type: "root",
+    children: [
+      {
+        type: "heading",
+        depth: 2,
+        data: { id: "constructor", hProperties: { id: "constructor" } },
+        children: [{ type: "text", value: "constructor" }]
+      },
+      {
+        type: "paragraph",
+        children: [{ type: "text", value: "Reference: {{constructor}}" }]
+      }
+    ]
+  };
+
+  const file = createFile();
+
+  remarkHeadings({ startDepth: 2, skip: [] })(tree, file);
+  remarkReferenceLinks()(tree, file);
+
+  const paragraphNode = tree.children[1];
+  const referenceNode = paragraphNode.children.find((node) => node.type === "link");
+
+  assert.ok(referenceNode);
+  assert.equal(referenceNode.url, "#constructor");
+});


### PR DESCRIPTION
## Summary

Fixes a build crash in the docs remark pipeline when a heading ID collides with an `Object.prototype` property (for example, `constructor`), causing `remark-reference-links` to treat a prototype property as a heading and later crash when reading its metadata.

This PR ensures the headings collection is stored and accessed safely, so only real headings are considered.

Fixes #1673.

## Problem

Previously, `remark-headings.js` stored headings on `file.data.headings` as a plain object.

`remark-reference-links.js` then used:

- `id in file.data.headings` to check if a heading exists, and
- `file.data.headings[id]` to read heading metadata.

If a document contained a heading like:

```markdown
# constructor

Reference: {{constructor}}
```

then `id === "constructor"` would match via `Object.prototype.constructor`, so the check would pass but the stored value would not be a proper heading node. Later access to heading properties (such as `.data.section`) could fail with a `TypeError` during spec build.

## Implementation

This PR:

- Changes `remark-headings.js` to initialize `file.data.headings` as `Object.create(null)`.
- Updates heading existence checks to `Object.prototype.hasOwnProperty.call(...)` instead of `in`.
- Keeps direct keyed access (`file.data.headings[id]`) but only after the safe own-property check.
- Leaves external markdown/reference-link behavior unchanged, except prototype property names are no longer treated as valid headings.

## Tests

Added a regression test in `remark/remark-reference-links.test.js` that covers:

1. Missing-heading reference: `{{constructor}}` with no matching heading throws `ReferenceLinkError`.
2. Real-heading reference: a real `constructor` heading plus `{{constructor}}` resolves correctly without crashing.

Local validation:

- `node --test remark/remark-reference-links.test.js`
- `npm run build -- specs`

Both commands pass (exit code 0).
