### PR TITLE
fix: escape dot in rehype-link-transformer regex

### DIFF
--- a/remark/rehype-link-transformer.js
+++ b/remark/rehype-link-transformer.js
@@ -9,7 +9,7 @@ const rehypeLinkTransformer = () => (tree, vfile) => {
     if (node.tagName === "a") {
       const href = url.parse(node.properties.href);
       if (href.hostname === null && href.pathname?.endsWith(".md") && existsSync(vfile.history[0])) {
-        href.pathname = basename(href.pathname).replace(/.md$/, ".html");
+        href.pathname = basename(href.pathname).replace(/\.md$/, ".html");
         node.properties.href = url.format(href);
       }
     }


### PR DESCRIPTION
Fixes #1677

Escape the dot in `/.md$/` → `/\.md$/` so it matches only literal `.md`
extensions, not any character followed by `md`