### PR TITLE
fix: add missing 'annotation' property to output unit schema

### DIFF
--- a/output/schema.json
+++ b/output/schema.json
@@ -28,6 +28,7 @@
         "error": {
           "type": "string"
         },
+        "annotation": true,
         "errors": {
           "$ref": "#/$defs/outputUnitArray"
         },


### PR DESCRIPTION

The 2020-12 spec text states that the JSON key for successful validations
is 'annotation', but the output unit schema only defined 'error' (singular)
without the corresponding 'annotation' property.

Added 'annotation': true since annotation values can be of any type.

Fixes #1504