### PR TITLE
Improve remark-reference-links plugin by trimming whitespace and adding safety checks

### DIFF
--- a/remark/remark-reference-links.js
+++ b/remark/remark-reference-links.js
@@ -2,20 +2,35 @@ import { text, link } from "mdast-builder";
 import { toString as nodeToString } from "mdast-util-to-string";
 import { findAndReplace } from "mdast-util-find-and-replace";
 
-
 const referenceLink = /\{\{(?<id>.*?)\}\}/ug;
 
 const remarkReferenceLinks = () => (tree, file) => {
-  findAndReplace(tree, [referenceLink, (value, id) => {
-    // file.data.headings comes from ./remark-headings.js
-    if (!(id in file.data.headings)) {
-      throw Error(`ReferenceLinkError: No header found with id "${id}"`);
-    }
+  findAndReplace(tree, [
+    referenceLink,
+    (value, id) => {
+      // Remove accidental spaces inside {{ }}
+      id = id.trim();
 
-    const headerText = nodeToString(file.data.headings[id]);
-    const linkText = text(file.data.headings[id].data.section);
-    return link(`#${id}`, headerText, [linkText]);
-  }]);
+      // Ensure headings data exists
+      if (!file.data || !file.data.headings) {
+        throw new Error(
+          "ReferenceLinkError: Heading data not found. Ensure remark-headings plugin runs before remark-reference-links."
+        );
+      }
+
+      // Validate that referenced section exists
+      if (!(id in file.data.headings)) {
+        throw new Error(`ReferenceLinkError: No header found with id "${id}"`);
+      }
+
+      const heading = file.data.headings[id];
+
+      const headerText = nodeToString(heading);
+      const linkText = text(heading.data.section);
+
+      return link(`#${id}`, headerText, [linkText]);
+    }
+  ]);
 };
 
 export default remarkReferenceLinks;


### PR DESCRIPTION
### What kind of change does this PR introduce?

Refactoring / improvement to the remark-reference-links plugin used in the spec build process.

### Issue & Discussion References

Others: No related issue. This PR introduces a small robustness improvement to the remark plugin.

### Summary

This PR improves the `remark-reference-links` plugin by making the reference parsing more robust.

The change trims whitespace inside `{{ }}` references and adds safer checks when accessing `file.data.headings`. These improvements help prevent errors caused by accidental whitespace in references and improve the reliability of the documentation build process.

### Does this PR introduce a breaking change?

No.