### PR TITLE
fix(remark-rfc2119): add word boundaries and skip spliced nodes (issue: #1684)

### DIFF
--- a/remark/remark-rfc2119.js
+++ b/remark/remark-rfc2119.js
@@ -1,5 +1,5 @@
 import { text } from "mdast-builder";
-import { visit } from "unist-util-visit";
+import { visit, SKIP } from "unist-util-visit";
 
 
 /**
@@ -21,7 +21,7 @@ const KEYWORDS = [
   "OPTIONAL"
 ];
 
-const KEYWORD_REGEX = new RegExp(`(?:${KEYWORDS.map((k) => k.replace(" ", "\\s")).join("|")})`, "gm");
+const KEYWORD_REGEX = new RegExp(`\\b(?:${KEYWORDS.map((k) => k.replace(" ", "\\s")).join("|")})\\b`, "gm");
 
 const skipNodes = new Set(["code", "inlineCode", "link", "definition", "html"]);
 
@@ -70,6 +70,7 @@ export default function remarkRfc2119() {
       }
 
       parent.children.splice(index, 1, ...children);
+      return [SKIP, index + children.length];
     });
   };
 }


### PR DESCRIPTION
- Add \b word boundary assertions to KEYWORD_REGEX to prevent matching keywords inside other words (e.g. MUST in EXHAUST, MAY in MAYHEM)

- Import SKIP from unist-util-visit and return [SKIP, index + children.length] after splicing to prevent re-visiting newly inserted nodes

closes #1684