### PR TITLE
fix: resolve #1622 — Proposal: JSON Schema Standardization under Ecma International

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -161,6 +161,23 @@ stable features. Questions to address may include:
 At least two (2) Core Team members must have implemented prototypes before the
 concept can continue to the formal proposal process.
 
+## Ecma International Standardization
+
+> **Status: Proposed / In Discussion — not yet current policy**
+
+There is an ongoing community proposal to bring JSON Schema under the umbrella
+of [Ecma International](https://www.ecma-international.org/) as a formal
+Technical Committee (TC). If adopted, the formal ratification process for JSON
+Schema specification versions would change to include Ecma General Assembly
+votes and Ecma document numbering.
+
+For background and current discussion, see:
+- [Community discussion #938](https://github.com/orgs/json-schema-org/discussions/938)
+
+Once a TC is established and the process is agreed upon, this document will be
+updated to reflect the new ratification requirements alongside the existing
+development process described above.
+
 ### Proposal
 
 Once a rough consensus for the idea has been reached, a formal proposal will be

--- a/adr/2026-04-ecma-international-standardization.md
+++ b/adr/2026-04-ecma-international-standardization.md
@@ -1,0 +1,52 @@
+# ADR: Ecma International Standardization of JSON Schema
+
+## Status
+
+Proposed
+
+## Context
+
+JSON Schema has grown significantly in adoption, becoming a foundational technology for API description, configuration validation, and data interchange across the industry. Despite this broad use, JSON Schema has lacked formal standardization through a recognized standards body, which affects its perceived stability, intellectual property protections, and long-term governance.
+
+In 2022, the project formally decoupled from the IETF standards track (see [2022-09-decouple-from-ietf.md](2022-09-decouple-from-ietf.md)), choosing to pursue independent governance while remaining open to future standardization under a more suitable body.
+
+Ecma International is a standards organization with direct relevance to JSON Schema:
+
+- **TC39** standardizes ECMAScript (JavaScript) under Ecma, demonstrating Ecma's ability to govern dynamic, community-driven language and data specifications.
+- **RFC 8259** (the JSON data format) is co-published by Ecma as ECMA-404, establishing a direct precedent for JSON-related standards under Ecma.
+
+Ecma's membership model, royalty-free patent policy, and technical committee structure offer a governance path that aligns with open-source community norms while providing the formal recognition the specification requires.
+
+Discussion of this proposal is tracked at: https://github.com/orgs/json-schema-org/discussions/938
+
+## Decision
+
+Pursue formal standardization of JSON Schema under Ecma International by establishing a new Technical Committee (TC), with JSON Schema as a founding Task Group within that committee.
+
+This involves:
+
+1. Engaging Ecma International to charter a new TC dedicated to JSON Schema.
+2. Structuring JSON Schema (core, validation, and related specifications) as a Task Group under the new TC.
+3. Migrating the normative specification process to Ecma's publication and review workflow.
+4. Retaining community participation through Ecma's royalty-free RF patent policy and open participation model.
+
+## Consequences
+
+**Positive:**
+
+- JSON Schema gains a formal standards track with versioned, citable Ecma publications.
+- The Ecma RF patent policy provides intellectual property protections for implementors.
+- Alignment with ECMA-404 (JSON) strengthens the JSON ecosystem's standards coherence.
+- Formal TC membership opens participation to organizations seeking standards-body representation.
+
+**Negative / Risks:**
+
+- Ecma's versioning and publication cadence may constrain the project's current release flexibility.
+- TC membership fees and organizational overhead introduce new operational requirements.
+- Community contributors outside formal TC membership may perceive a governance shift away from open participation; clear communication and Ecma's open associate membership model must be leveraged to mitigate this.
+- IP policy transition requires legal review to ensure compatibility with existing contributions.
+
+**Neutral:**
+
+- Existing JSON Schema drafts and implementations are unaffected during the transition period.
+- The GitHub-based community workflow will continue alongside the formal Ecma process during transition.


### PR DESCRIPTION
## Summary

fix: resolve #1622 — Proposal: JSON Schema Standardization under Ecma International

## Problem

**Severity**: `Medium` | **File**: `adr/2026-04-ecma-international-standardization.md`

The repository tracks significant architectural and governance decisions via ADR (Architecture Decision Record) files under `adr/`. Issue #1622 proposes formal standardization of JSON Schema under Ecma International as a new Technical Committee, which is a major governance decision that warrants a formal ADR. Existing ADRs like `2022-09-decouple-from-ietf.md` set a precedent for documenting standards-body relationship changes.

## Solution

Create `adr/2026-04-ecma-international-standardization.md` following the existing ADR format used in this repo. Include sections: (1) **Status** — Proposed, (2) **Context** — JSON Schema's growth, prior IETF relationship (reference `2022-09-decouple-from-ietf.md`), and Ecma's relevance (TC39/ECMAScript, JSON RFC 8259), (3) **Decision** — Pursue a new Ecma TC with JSON Schema as a founding Task Group, (4) **Consequences** — formal standards track, Ecma IP policy implications, versioning cadence alignment, community governance changes, reference to discussion https://github.com/orgs/json-schema-org/discussions/938.

## Changes

- `adr/2026-04-ecma-international-standardization.md` (new)
- `PROCESS.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*