### PR TITLE
fix: resolve #1546 — ✨ Proposal: uniqueItems based several properties or subschema

### DIFF
--- a/specs/proposals/uniqueKeys-adr.md
+++ b/specs/proposals/uniqueKeys-adr.md
@@ -1,0 +1,92 @@
+# Architecture Decision Record: `uniqueKeys`
+
+## Status
+
+Proposed
+
+## Context
+
+JSON Schema already has `uniqueItems`, which requires every item in an array to be distinct from every other item using the standard JSON Schema equality algorithm. However, there is a common real-world constraint that is not expressible with `uniqueItems`: requiring that a specific subset of properties act as a composite key across an array of objects, while allowing duplicated values elsewhere.
+
+Examples of this constraint:
+
+- A list of DNS records where the combination of `name` and `type` must be unique, but `value` may repeat.
+- A list of environment variables where `name` must be unique across all entries.
+- A configuration list where `id` serves as a primary key.
+
+Before introducing `uniqueKeys`, schema authors worked around this limitation by:
+
+1. Writing complex `contains` + `not` combinations that are difficult to read and often exponential in validation cost.
+2. Moving uniqueness enforcement entirely out of JSON Schema into application logic.
+3. Misusing `uniqueItems` and accepting false failures when unrelated properties differ.
+
+Two design directions were considered:
+
+### Option A — Extend `uniqueItems`
+
+Allow `uniqueItems` to accept an array of property names in addition to a boolean:
+
+```json
+{ "uniqueItems": ["name", "type"] }
+```
+
+Pros:
+- No new keyword.
+
+Cons:
+- Breaks the established meaning of `uniqueItems` (boolean keyword).
+- Implementations that do not recognise the array form silently ignore it if they treat unknown types as ignored, or error if they enforce strict types — neither behaviour is safe.
+- Conflates two distinct concepts under one keyword, making the schema harder to read when both constraints are needed simultaneously.
+- Complicates the meta-schema and type system for `uniqueItems`.
+
+### Option B — Introduce a new keyword `uniqueKeys`
+
+Add a dedicated keyword whose value is an array of strings:
+
+```json
+{ "uniqueKeys": ["name", "type"] }
+```
+
+Pros:
+- `uniqueItems` retains its existing boolean semantics; no risk of breakage.
+- Both keywords can coexist in the same schema when both constraints apply.
+- Intent is immediately clear to readers.
+- Simpler meta-schema: `uniqueKeys` is always an array of strings.
+- Implementations can add support incrementally without changing existing keyword behaviour.
+
+Cons:
+- Adds a keyword to the vocabulary.
+
+## Decision
+
+**Introduce a new keyword `uniqueKeys`** (Option B).
+
+The value of `uniqueKeys` is a non-empty array of strings. Each string names a property. An instance is valid against this keyword if and only if, for every pair of items in the array that are both objects and that both contain at least one of the named properties, there is no pair of items whose values for all of the named properties are equal under the JSON Schema equality algorithm.
+
+Items that are not objects, and objects that contain none of the named properties, are ignored for the purposes of this keyword (they do not participate in the uniqueness comparison).
+
+### Rationale for key sub-decisions
+
+#### Non-object items are ignored
+
+Arrays may be heterogeneous. Requiring non-objects to participate would make the keyword inapplicable to any mixed array, which is overly restrictive and inconsistent with how `properties` and related keywords treat non-objects.
+
+#### Objects missing all named keys are ignored
+
+An object with no entry for any of the named keys has no key value to compare. Treating such objects as equal to each other (because they all map to the empty projection) would silently invalidate schemas that authors intend to be permissive about optional properties. Ignoring them is the least surprising behaviour.
+
+#### Equality follows the JSON Schema equality algorithm
+
+Using a separate equality definition would create two subtly different equality semantics within the same specification. Reusing the existing algorithm keeps behaviour predictable and consistent with `uniqueItems`.
+
+#### The keyword is ignored when the instance is not an array
+
+Consistent with the behaviour of `uniqueItems` and `contains`: keywords that constrain arrays are vacuously satisfied by non-array instances.
+
+## Consequences
+
+- Schema authors gain a concise, readable way to express composite-key constraints on arrays of objects.
+- `uniqueItems` is unchanged; existing schemas and implementations are unaffected.
+- Implementations must iterate over pairs of array items to check uniqueness, which is O(n²) in the worst case — the same complexity as `uniqueItems`. No new algorithmic complexity is introduced.
+- The meta-schema gains one new property definition for `uniqueKeys`.
+- The Applicator vocabulary is not affected; `uniqueKeys` belongs to the Validation vocabulary alongside `uniqueItems`.

--- a/specs/proposals/uniqueKeys.md
+++ b/specs/proposals/uniqueKeys.md
@@ -1,0 +1,167 @@
+# Proposal: `uniqueKeys` Keyword
+
+- **Status**: Draft
+- **Champions**: TBD
+- **Tracking Issue**: TBD
+
+## Abstract
+
+This proposal introduces a new keyword `uniqueKeys` that enables uniqueness constraints based on a composite key — a subset of properties — rather than comparing entire objects. This addresses a common use case where `uniqueItems: true` is insufficient because users need DB-style composite unique keys.
+
+## Motivation
+
+The existing `uniqueItems` keyword compares entire array items for equality. While this works for scalar values, it falls short when:
+
+1. Array items are objects and uniqueness should be scoped to specific properties (composite keys).
+2. Some properties are intentionally variable (e.g., timestamps, UUIDs) and should not participate in the uniqueness comparison.
+3. Users need to model database-style `UNIQUE (col1, col2)` constraints.
+
+### Example Problem
+
+Given an array of user records, `uniqueItems: true` would reject two records that differ only in `updatedAt`, even if they share the same `userId` and `email`:
+
+```json
+[
+  { "userId": 1, "email": "a@example.com", "updatedAt": "2024-01-01" },
+  { "userId": 1, "email": "a@example.com", "updatedAt": "2024-06-01" }
+]
+```
+
+Conversely, `uniqueItems: true` cannot enforce that `userId` + `email` combinations are unique while ignoring `updatedAt`.
+
+## Specification
+
+### Keyword Name
+
+`uniqueKeys`
+
+### Applies To
+
+Arrays (`"type": "array"`).
+
+### Value
+
+An array of one or more non-empty strings. Each string is a property name that participates in the composite key. The array itself MUST contain at least one element and MUST NOT contain duplicate strings.
+
+```
+uniqueKeys: [string, ...string]
+```
+
+### Behavior
+
+For each pair of items in the array instance, the validation extracts the values of the listed properties from both items and compares them using the same deep-equality algorithm defined for `uniqueItems`. If any two items produce an identical tuple of extracted values, validation MUST fail.
+
+Properties listed in `uniqueKeys` that are absent from an item are treated as `undefined` / JSON `null` for the purposes of comparison (consistent with how `required` and `properties` interact elsewhere in the spec).
+
+Items that are not objects MUST cause the keyword to be ignored for those items (the keyword applies only to object-typed items within the array).
+
+`uniqueKeys` does not interact with `uniqueItems`. Both keywords may appear together; each is evaluated independently.
+
+### JSON Schema Meta-Schema Fragment
+
+```json
+{
+  "uniqueKeys": {
+    "type": "array",
+    "items": { "type": "string" },
+    "minItems": 1,
+    "uniqueItems": true
+  }
+}
+```
+
+## Examples
+
+### Single-property Unique Key
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id":   { "type": "integer" },
+      "name": { "type": "string" }
+    }
+  },
+  "uniqueKeys": ["id"]
+}
+```
+
+**Valid** — items have distinct `id` values:
+```json
+[
+  { "id": 1, "name": "Alice" },
+  { "id": 2, "name": "Alice" }
+]
+```
+
+**Invalid** — two items share `id: 1`:
+```json
+[
+  { "id": 1, "name": "Alice" },
+  { "id": 1, "name": "Bob" }
+]
+```
+
+### Composite Key
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "region":    { "type": "string" },
+      "productId": { "type": "integer" },
+      "stock":     { "type": "integer" }
+    }
+  },
+  "uniqueKeys": ["region", "productId"]
+}
+```
+
+**Valid** — same `productId` but different `region`:
+```json
+[
+  { "region": "us-east", "productId": 42, "stock": 10 },
+  { "region": "eu-west", "productId": 42, "stock": 5 }
+]
+```
+
+**Invalid** — duplicate `(region, productId)` tuple:
+```json
+[
+  { "region": "us-east", "productId": 42, "stock": 10 },
+  { "region": "us-east", "productId": 42, "stock": 99 }
+]
+```
+
+### Interaction with `uniqueItems`
+
+```json
+{
+  "type": "array",
+  "uniqueItems": true,
+  "uniqueKeys": ["userId"]
+}
+```
+
+Both constraints are enforced independently. An instance must satisfy each one.
+
+## Alternatives Considered
+
+### Using `contains` + `not`
+
+This can be approximated with complex `contains`/`not`/`if-then` compositions but results in schemas that are difficult to read and impossible to optimise.
+
+### Extending `uniqueItems` to Accept an Array
+
+Changing the type of an existing keyword would be a breaking change for validators that pre-validate schemas.
+
+## References
+
+- [JSON Schema Core Specification](https://json-schema.org/draft/2020-12/json-schema-core.html)
+- [`uniqueItems` keyword](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.4.3)
+- Related proposal: [`propertyDependencies`](propertyDependencies.md)
+- Prior art: SQL `UNIQUE (col1, col2)` composite constraints


### PR DESCRIPTION
## Summary

fix: resolve #1546 — ✨ Proposal: uniqueItems based several properties or subschema

## Problem

**Severity**: `Medium` | **File**: `specs/proposals/uniqueKeys.md`

Create a formal proposal for a new `uniqueKeys` keyword that enables uniqueness constraints based on a composite key (subset of properties), addressing the gap where `uniqueItems: true` compares entire objects but users need DB-style composite unique keys. This follows the existing pattern of `propertyDependencies.md`.

## Solution



## Changes

- `specs/proposals/uniqueKeys.md` (new)
- `specs/proposals/uniqueKeys-adr.md` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*