### PR TITLE
fix: resolve #1690 — 🧹 Clarification: For future drafts: RFC 3339 date-time strictness (§5.6 ABNF vs. §5.7 prose)

### DIFF
--- a/specs/jsonschema-validation.md
+++ b/specs/jsonschema-validation.md
@@ -398,7 +398,7 @@ These attributes apply to string instances.
 
 Date and time format names are derived from
 [RFC 9557, section 4.1](https://www.rfc-editor.org/info/rfc9557) which extends
-[RFC 3339, section 5.6](https://www.rfc-editor.org/info/rfc3339). The duration
+[RFC 3339, sections 5.6 and 5.7](https://www.rfc-editor.org/info/rfc3339). The duration
 format is from ISO 8601 as formalized into ABNF by RFC 3339 Appendix A.
 
 - *date-time*: A string instance is valid against this attribute if it is a


### PR DESCRIPTION
## Summary

fix: resolve #1690 — 🧹 Clarification: For future drafts: RFC 3339 date-time strictness (§5.6 ABNF vs. §5.7 prose)

## Problem

**Severity**: `Medium` | **File**: `specs/jsonschema-validation.md`

Section 7.3.1 currently cites only RFC 3339 §5.6 (the ABNF grammar). Under strict ABNF rules, comments after `;` are non-normative, meaning calendar constraints like `time-hour = 2DIGIT ; 00-23` technically only require 2 digits structurally. The actual semantic restrictions (valid month ranges, hour 00-23, leap year rules, etc.) live exclusively in RFC 3339 §5.7 ("Restrictions"). The omission creates a spec loophole where a validator rejecting `25:00:00` could still claim literal compliance with the current text. The fix is to add an explicit reference to §5.7 so implementers and test suite authors cannot reasonably argue calendar math is optional.

## Solution

Find the paragraph in Section 7.3.1 that reads:

## Changes

- `specs/jsonschema-validation.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*