### PR TITLE
fix: resolve #1678 — ✨ Proposal: redefine hostname and idn-hostname formats

### DIFF
--- a/specs/registries/format.json
+++ b/specs/registries/format.json
@@ -116,7 +116,7 @@
         "supportedBy": []
     },
     "hostname": {
-        "description": "A host name as defined by RFC1123",
+        "description": "A host name as defined by RFC3986 Section 3.2.2 (reg-name); for DNS-resolvable network-scheme hosts, RFC1034/RFC1123 applies",
         "definingBody": "JSON Schema",
         "definition": "https://json-schema.org/draft/2020-12/json-schema-validation.html#name-hostnames",
         "types": ["string"],
@@ -148,7 +148,7 @@
         "supportedBy": []
     },
     "idn-hostname": {
-        "description": "An internationalized host name as defined by IDNA2008 using the UTS #46 mapping",
+        "description": "An internationalized host name as defined by RFC3987 Section 3.3 (ireg-name); for network-scheme hosts, RFC5890/RFC5891 applies",
         "types": ["string"],
         "examples": ["exämple.com"],
         "deprecated": false,


### PR DESCRIPTION
## Summary

fix: resolve #1678 — ✨ Proposal: redefine hostname and idn-hostname formats

## Problem

**Severity**: `Low` | **File**: `specs/registries/format.json`

The format registry JSON file likely contains metadata or normative pointers for each registered format. The entries for `hostname` and `idn-hostname` should be updated to reference RFC 3986/3987 as the primary authority, with RFC 1034/1123 and RFC 5890/5891 noted as scheme-conditional requirements.

## Solution

Update the `hostname` entry's RFC reference from RFC 1123 to RFC 3986 (Section 3.2.2 `reg_name`), noting RFC 1034/1123 applies for DNS-resolvable network-scheme hosts. Update the `idn-hostname` entry's reference to RFC 3987 (Section 3.3 `ireg_name`), noting RFC 5890/5891 applies for network-scheme hosts. Keep existing references as conditional/informative rather than primary normative citations.

## Changes

- `specs/registries/format.json` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*