### PR TITLE
Fix editorial typos in docs and specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Each milestone is an estimation of the work that will be done for the next
 draft. Milestones are typically named after the meta-schema draft number, and
 the *open* milestone with the lowest draft number is the current active project.
 
-Issues may be removed from a milestoned due to lack of consensus, lack of anyone
+Issues may be removed from a milestone due to lack of consensus, lack of anyone
 with the correct expertise to make a PR, or simply because we wish to publish a
 draft and defer the remaining issues to the next draft.
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -134,8 +134,8 @@ stateDiagram-v2
     Experimentation --> Proposal
   }
   Development --> Stable
-  Stable --> Deprectated
-  Deprectated --> Removed
+  Stable --> Deprecated
+  Deprecated --> Removed
 ```
 
 ### Concept

--- a/adr/2024-11-2-assertion-format.md
+++ b/adr/2024-11-2-assertion-format.md
@@ -63,7 +63,7 @@ This is the current state. The primary benefit is that we don't need to make a
 breaking change.
 
 The primary downside is that the current system of (1) configuring the tool or
-(2) incluing the `format-assertion` vocab[^1] is confusing for many and doesn't
+(2) including the `format-assertion` vocab[^1] is confusing for many and doesn't
 align with user expectations.
 
 ### `format` becomes an assertion keyword by default

--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -1475,7 +1475,7 @@ or malicious results.
 #### Failure to resolve references {#failed-refs}
 
 If for any reason a reference cannot be resolved, the evaluation MUST halt and
-return an indeterminant result. Specifically, it MUST NOT return a passing or
+return an indeterminate result. Specifically, it MUST NOT return a passing or
 failing validation result or any annotations. Instead it MUST inform the
 consuming application or user of the evaluation failure via other means. It is
 RECOMMENDED that implementations utilize native functionality for this purpose,

--- a/specs/proposals/propertyDependencies-adr.md
+++ b/specs/proposals/propertyDependencies-adr.md
@@ -258,7 +258,7 @@ not wide-spread or consistent behavior, nor is it expected or required from
 implementations.
 
 This pattern is also inefficient. Generally, there is a single value in the
-object that determines which alternative to chose, but the `oneOf` pattern has
+object that determines which alternative to choose, but the `oneOf` pattern has
 no way to specify what that value is and therefore needs to evaluate the entire
 schema. This is made worse in that every alternative needs to be fully validated
 to ensure that only one of the alternative passes and all the others fail. This


### PR DESCRIPTION
## Description:

This PR fixes 5 small editorial typos in the contributor docs, process docs, core spec, and a related ADR.

### Checks run, locally:
- [x] `git diff --check`.
- [x] `npx remark --no-stdout --frail CONTRIBUTING.md PROCESS.md adr/2024-11-2-assertion-format.md specs/jsonschema-core.md specs/proposals/propertyDependencies-adr.md`.
- [x] `npm run build -- specs/jsonschema-core.md specs/proposals/propertyDependencies-adr.md`