### PR TITLE
Fix possessive its typos in docs

### DIFF
--- a/adr/2022-11-stable-spec.md
+++ b/adr/2022-11-stable-spec.md
@@ -120,7 +120,7 @@ get them to a stable state much sooner. For example, we have changes to dynamic
 references that have been agreed upon and ready to go for over a year, but users
 can't benefit from the change until we can get the next full release published.
 With this model, the change could have been made available for over a year now
-and we would have a years worth of feedback on it's use. Having a mutable spec
+and we would have a years worth of feedback on its use. Having a mutable spec
 also allows us to introduce new features without having to wait for a release.
 For example, the `propertyDependencies` keyword has also been waiting for months
 for a release. Users could have been benefiting from it for months and providing

--- a/specs/proposals/propertyDependencies-adr.md
+++ b/specs/proposals/propertyDependencies-adr.md
@@ -54,7 +54,7 @@ schema.
 ### Option 1
 
 The `dependentSchemas` keyword is very close to what is needed except it checks
-for the presence of a property rather than it's value. This option builds on
+for the presence of a property rather than its value. This option builds on
 that concept to solve this problem.
 
 ```json
@@ -270,7 +270,7 @@ less used.
 We can describe this kind of constraint more efficiently and with with better
 error messaging by using `if`/`then`. This allows the user to explicitly specify
 the constraint to be used to select which alternative the schema should be used
-to validate the schema. However, this pattern has problems of it's own. It's
+to validate the schema. However, this pattern has problems of its own. It's
 verbose, error prone, and not particularly intuitive, which leads most people to
 avoid it.
 

--- a/specs/proposals/propertyDependencies.md
+++ b/specs/proposals/propertyDependencies.md
@@ -51,7 +51,7 @@ adopt or redefine `discriminator`.
 ### Solution
 
 The `dependentSchemas` keyword is very close to what is needed except it checks
-for the presence of a property rather than it's value. The chosen solution is to
+for the presence of a property rather than its value. The chosen solution is to
 build on that concept to solve this problem.
 
 ```jsonschema


### PR DESCRIPTION
This PR fixes 4 possessive `its` typos in proposal and ADR docs.