### PR TITLE
Fix Dockerfile comment typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 
 COPY . .
 
-# First covert md to xml. Then convert xml to html
+# First convert md to xml. Then convert xml to html
 CMD sh -c "xml2rfc --version \
         && ls ietf/*.md | xargs -n1 sh -c 'kramdown-rfc \"\$0\" > \"\${0%.md}.xml\"' \
         && ls ietf/*.xml | xargs -n1 sh -c 'xml2rfc --html \"\$0\" -p web'"


### PR DESCRIPTION
This PR fixes a typo in the Dockerfile comment for the Markdown to XML build step.
