### PR TITLE
Add .dockerignore for IETF build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+coverage
+web
+.refcache


### PR DESCRIPTION
## Description:

This PR adds a root `.dockerignore` so the IETF build does not send local `node_modules`, generated output, and cache files in the Docker build context.

On a fresh checkout after `npm ci`, `docker-compose build --progress plain` sent `113.76MB` of context. With this change, the same build sent `36.34kB`.

### Checks run, locally:
- [x] `git diff --check`.
- [x] `docker-compose build --progress plain`
- [x] `npm run build-ietf`