### PR TITLE
Fix small documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ The following is a not-necessarily-complete list of configured plugins and the
 features they make available to you.
 
 - [remark-lint](https://github.com/remarkjs/remark-lint) -- Enforce markdown
-  styles guide.
+  style guide.
 - [remark-validate-links](https://github.com/remarkjs/remark-validate-links) --
   Check for broken links.
 - [remark-gfm](https://github.com/remarkjs/remark-gfm) -- Adds support for
-  Github Flavored Markdown specific markdown features such as autolink literals,
+  GitHub Flavored Markdown specific markdown features such as autolink literals,
   footnotes, strikethrough, tables, and tasklists.
 - [remark-heading-id](https://github.com/imcuttle/remark-heading-id) -- Adds
   support for `{#my-anchor}` syntax to add an `id` to an element so it can be

--- a/adr/2022-09-decouple-from-ietf.md
+++ b/adr/2022-09-decouple-from-ietf.md
@@ -73,7 +73,7 @@ that our "drafts" are intended for use in production.
 1. Join W3C and pursue a standards track with them using their process.
 1. Decouple completely from any standards organization and come up with our own
    specification development lifecycle (SDLC) model inspired by well established
-   projects with an SDLC that more closely meets or needs.
+   projects with an SDLC that more closely meets our needs.
 
 ## Decision Outcome
 
@@ -162,7 +162,7 @@ to be an exception to the rule, and not frequently used.
   member of the OpenJS Foundation, which is a sub-group of the Linux Foundation,
   so we expect standards developers to be just as comfortable referencing JSON
   Schema as they are referencing OpenAPI.
-- Defining our own SLDC process will be a lot of work and none of us have
+- Defining our own SDLC process will be a lot of work and none of us have
   expertise in defining such a process. However, we can take inspiration from
   existing well established projects and we would have the freedom to update our
   process as we learn what works and what doesn't.


### PR DESCRIPTION
This PR fixes a few small documentation typos in the README and ADR text.