### PR TITLE
fix: resolve meta-schema path as file URL for Windows compatibility

### DIFF
--- a/specs/meta/test-suite/meta-schema.test.js
+++ b/specs/meta/test-suite/meta-schema.test.js
@@ -14,10 +14,11 @@ for (const entry of await fs.readdir(`${import.meta.dirname}/tests`, { withFileT
   describe(suite.description, () => {
     for (const testCase of suite.tests) {
       test(testCase.description, async () => {
+        const metaSchemaUrl = new URL("../meta.schema.json", import.meta.url).href;
         if (testCase.valid) {
-          await expect(testCase.schema).to.matchJsonSchema(`${import.meta.dirname}/../meta.schema.json`);
+          await expect(testCase.schema).to.matchJsonSchema(metaSchemaUrl);
         } else {
-          await expect(testCase.schema).to.not.matchJsonSchema(`${import.meta.dirname}/../meta.schema.json`);
+          await expect(testCase.schema).to.not.matchJsonSchema(metaSchemaUrl);
         }
       });
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix (non-breaking change that fixes an issue)

---

## Issue & Discussion References

Closes #1730 

---

## Summary

This PR resolves a fatal crash that occurs when running `npm test` on Windows.

The test file `specs/meta/test-suite/meta-schema.test.js` resolves the local meta-schema path using a string template with `import.meta.dirname`:

```javascript
`${import.meta.dirname}/../meta.schema.json`
```

On Windows, `import.meta.dirname` resolves using backslashes (for example, `D:\path\to\specs\meta\test-suite`), resulting in a path with mixed directory separators. When this path is passed to the internally used `@hyperjump/uri` library, it throws:

```text
Error: Invalid IRI-reference
```

This happens because backslashes are not valid URI characters under RFC 3986. As a result, all seven tests in the meta-schema test suite crash before execution.

This PR fixes the issue by resolving the file using a standard cross-platform `file://` URL derived from `import.meta.url`:

```javascript
const metaSchemaUrl = new URL("../meta.schema.json", import.meta.url).href;
```

Using `new URL()` ensures the generated path is a valid URI on all operating systems, including Windows, macOS, and Linux.

### Verification

- ✅ Reproduced the failure on Windows.
- ✅ Verified that the crash is resolved after this change.
- ✅ Confirmed that all 7 tests in the meta-schema test suite now execute and pass successfully on Windows.

---

## Does this PR introduce a breaking change?

**No.**

This change only updates the way the test suite resolves the local meta-schema path. It does not modify the JSON Schema specification documents, validator behavior, or any runtime functionality.

## Screenshot: 
<img width="1366" height="729" alt="Screenshot (902)" src="https://github.com/user-attachments/assets/a7f36dc3-3a09-4434-b344-71a7b2dad6ed" />
