### PR TITLE
docs: fix capitalization of GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ labels
 [![Low](https://img.shields.io/github/issues/json-schema-org/json-schema-spec/Priority:%20Low.svg)](https://github.com/json-schema-org/json-schema-spec/labels/Priority%3A%20Low)
 
 Labels are assigned based on
-[Sensible Github Labels](https://github.com/Relequestual/sensible-github-labels).
+[Sensible GitHub Labels](https://github.com/Relequestual/sensible-github-labels).
 
 ## Authoring and Building
 


### PR DESCRIPTION
<!-- Love json-schema? Please consider supporting our collective:
👉  https://opencollective.com/json-schema/donate -->
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->
### What kind of change does this PR introduce?
Docs fix — minor typo/capitalization correction in README.

### Issue & Discussion References
- Others? No related issue; trivial documentation fix.

### Summary
Fixes "Github" to "GitHub" in the README, in the link text referencing the "Sensible GitHub Labels" repository. "GitHub" is a proper noun and should be capitalized per the platform's official branding.

### Does this PR introduce a breaking change?
No.