### PR TITLE
Fix Windows lint script portability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . ; remark --no-stdout --frail .",
+    "lint": "eslint . && remark --no-stdout --frail .",
     "build": "remark --rc-path specs/.remarkrc-build.js --output web/",
     "build-ietf": "docker-compose run --rm build",
     "test": "vitest run --config=vitest-schema.config.js",


### PR DESCRIPTION
## Description:

This PR makes `npm run lint` portable on Windows by replacing the shell specific `;` with `&&` so that `eslint` no longer consumes `remark` flags.

### Checks run, locally:
- [x] `git diff --check`.
- [x] `npm run lint`.
- [x] `npm run build -- specs`.

### Before the fix:

<img width="1988" height="188" alt="image" src="https://github.com/user-attachments/assets/e4376097-ea35-45f1-9330-c34eca3f70e1" />

### After the fix:

<img width="1088" height="804" alt="image" src="https://github.com/user-attachments/assets/cd96b556-8824-4299-b213-4a538b1e4ed9" />
