### PR TITLE
fix: resolve meta-schema path as file URL for Windows compatibility

### DIFF
--- a/specs/meta/test-suite/meta-schema.test.js
+++ b/specs/meta/test-suite/meta-schema.test.js
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const metaSchemaUrl = new URL("../meta.schema.json", import.meta.url).href;
 
 for (const entry of await fs.readdir(`${import.meta.dirname}/tests`, { withFileTypes: true })) {
   if (entry.isDirectory() || path.extname(entry.name) !== ".json") {
@@ -16,9 +15,9 @@ for (const entry of await fs.readdir(`${import.meta.dirname}/tests`, { withFileT
     for (const testCase of suite.tests) {
       test(testCase.description, async () => {
         if (testCase.valid) {
-          await expect(testCase.schema).to.matchJsonSchema(metaSchemaUrl);
+          await expect(testCase.schema).to.matchJsonSchema("specs/meta/meta.schema.json");
         } else {
-          await expect(testCase.schema).to.not.matchJsonSchema(metaSchemaUrl);
+          await expect(testCase.schema).to.not.matchJsonSchema("specs/meta/meta.schema.json");
         }
       });
     }

--- a/specs/meta/test-suite/meta-schema.test.js
+++ b/specs/meta/test-suite/meta-schema.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+const metaSchemaUrl = new URL("../meta.schema.json", import.meta.url).href;
 
 for (const entry of await fs.readdir(`${import.meta.dirname}/tests`, { withFileTypes: true })) {
   if (entry.isDirectory() || path.extname(entry.name) !== ".json") {
@@ -15,9 +16,9 @@ for (const entry of await fs.readdir(`${import.meta.dirname}/tests`, { withFileT
     for (const testCase of suite.tests) {
       test(testCase.description, async () => {
         if (testCase.valid) {
-          await expect(testCase.schema).to.matchJsonSchema(`${import.meta.dirname}/../meta.schema.json`);
+          await expect(testCase.schema).to.matchJsonSchema(metaSchemaUrl);
         } else {
-          await expect(testCase.schema).to.not.matchJsonSchema(`${import.meta.dirname}/../meta.schema.json`);
+          await expect(testCase.schema).to.not.matchJsonSchema(metaSchemaUrl);
         }
       });
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix (non-breaking change that fixes an issue)

---

## Issue & Discussion References

Closes #1730

---

## Summary

This fixes a Windows-only issue where the meta-schema test suite crashes before running.

The test currently resolves the meta-schema using:

```js
`${import.meta.dirname}/../meta.schema.json`
```

On Windows, `import.meta.dirname` contains backslashes, which results in an invalid URI being passed to `@hyperjump/uri`, causing the following error:

```text
Error: Invalid IRI-reference
```

The fix is to resolve the file relative to `import.meta.url` instead:

```js
const metaSchemaUrl = new URL("../meta.schema.json", import.meta.url).href;
```

This generates a valid `file://` URL on Windows, macOS, and Linux, avoiding the mixed path separator issue.

### Verification

- Reproduced the failure on Windows.
- Verified that the test suite no longer crashes after the change.
- Confirmed all 7 meta-schema tests pass successfully on Windows.

---

## Does this PR introduce a breaking change?

**No.**

This change only updates how the test file resolves the local meta-schema. It does not affect validator behavior or any runtime functionality.

## Screenshot

<img width="1366" height="729" alt="Screenshot (902)" src="https://github.com/user-attachments/assets/a7f36dc3-3a09-4434-b344-71a7b2dad6ed" />