### PR TITLE
docs: fix capitalization of Stack Overflow and .NET Correct StackOver…

### DIFF
--- a/adr/2024-11-2-assertion-format.md
+++ b/adr/2024-11-2-assertion-format.md
@@ -38,8 +38,8 @@ The argument was that the behavior of a keyword shouldn't change based on
 whether the vocabulary was required or not.
 
 However, the fact remains that our users consistently report (via questions in
-Slack, GitHub, and Stack Overflow) that they expect format to validate. (The most
-recent case I can think of was only last week, in .NET's effort to build a
+Slack, GitHub, and Stack Overflow) that they expect format to validate. (The
+most recent case I can think of was only last week, in .NET's effort to build a
 short-term solution for schema generation from types.)
 
 Due to this consistency in user expectations, we have decided to:

--- a/adr/2024-11-2-assertion-format.md
+++ b/adr/2024-11-2-assertion-format.md
@@ -38,8 +38,8 @@ The argument was that the behavior of a keyword shouldn't change based on
 whether the vocabulary was required or not.
 
 However, the fact remains that our users consistently report (via questions in
-Slack, GitHub, and StackOverflow) that they expect format to validate. (The most
-recent case I can think of was only last week, in .Net's effort to build a
+Slack, GitHub, and Stack Overflow) that they expect format to validate. (The most
+recent case I can think of was only last week, in .NET's effort to build a
 short-term solution for schema generation from types.)
 
 Due to this consistency in user expectations, we have decided to:


### PR DESCRIPTION
What kind of change does this PR introduce?
Docs fix — minor typo/capitalization correction in ADR.

Issue & Discussion References
- Others? No related issue; trivial documentation fix.

Summary
Fixes "StackOverflow" to "Stack Overflow" and ".Net" to ".NET" in the
format-as-assertion ADR. "Stack Overflow" is the site's official two-word
name, and ".NET" is Microsoft's official capitalization for the platform.

Does this PR introduce a breaking change?
No.