### PR TITLE
docs: fix ADR template placeholder typo

### DIFF
--- a/adr/template.md
+++ b/adr/template.md
@@ -50,7 +50,7 @@ three sentences. You may want to articulate the problem in form of a question.]
 ## Decision Outcome
 
 "\[option 1]" was chosen because \[justification. e.g., only option, which meets
-k.o. criterion decision driver | which resolves force force | ... | comes out
+k.o. criterion decision driver | which resolves force \[force] | ... | comes out
 best (see below)].
 
 ### Positive Consequences <!-- optional -->


### PR DESCRIPTION
Fix duplicated placeholder text in the ADR template.