### PR TITLE
fix: prevent RFC-2119 keywords from matching inside other words

### DIFF
--- a/remark/remark-rfc2119.js
+++ b/remark/remark-rfc2119.js
@@ -21,7 +21,7 @@ const KEYWORDS = [
   "OPTIONAL"
 ];
 
-const KEYWORD_REGEX = new RegExp(`(?:${KEYWORDS.map((k) => k.replace(" ", "\\s")).join("|")})`, "gm");
+const KEYWORD_REGEX = new RegExp(`\\b(?:${KEYWORDS.map((k) => k.replace(" ", "\\s")).join("|")})\\b`, "gm");
 
 const skipNodes = new Set(["code", "inlineCode", "link", "definition", "html"]);
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bugfix

### Issue & Discussion References

- Closes #1740

### Summary

While working on the spec builder, I noticed that the `remark-rfc2119` plugin was incorrectly highlighting RFC-2119 keywords when they appeared as part of a larger word.

For example, words like `SHALLOW`, `MAYBE`, and `OPTIONALLY` were being partially wrapped in styled `<span>` tags because the plugin matched the substrings `SHALL`, `MAY`, and `OPTIONAL` inside them. The resulting HTML looked like this:

```html
<span class="rfc2119 shall">SHALL</span>OW
<span class="rfc2119 may">MAY</span>BE
<span class="rfc2119 optional">OPTIONAL</span>LY
```

This corrupts the text in the rendered HTML and is not the intended behavior — RFC-2119 keywords should only be highlighted when they appear as complete, standalone words.

After looking into it, I found that the `KEYWORD_REGEX` in `remark/remark-rfc2119.js` was missing word boundary checks (`\b`), which caused it to match keywords anywhere inside a string of text.

The fix is a one-line change — wrapping the regex with `\b` boundaries so only whole words are matched:

```diff
- const KEYWORD_REGEX = new RegExp(`(?:${KEYWORDS.map((k) => k.replace(" ", "\\s")).join("|")})`, "gm");
+ const KEYWORD_REGEX = new RegExp(`\\b(?:${KEYWORDS.map((k) => k.replace(" ", "\\s")).join("|")})\\b`, "gm");
```

I tested this locally and confirmed:
- Standalone RFC keywords like `MUST`, `SHOULD`, `MAY`, and `OPTIONAL` still get highlighted correctly.
- Words like `SHALLOW`, `MAYBE`, and `OPTIONALLY` now render as normal text without any broken `<span>` tags.
- All spec documents build cleanly with no regressions (`npm run build -- specs`).

I've also attached a screenshot below showing the before and after output from the build.

### Screenshot

<img width="1366" height="727" alt="AFT" src="https://github.com/user-attachments/assets/29b37f22-1a19-460e-a22c-138e368ca7ff" />


### Does this PR introduce a breaking change?

No. This change only affects how the RFC-2119 plugin matches text during HTML generation. It does not change any spec content, validator behavior, or runtime functionality.
