### PR TITLE
Restrict markdown builds to spec files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . && remark --no-stdout --frail .",
-    "build": "remark --rc-path specs/.remarkrc-build.js --ignore-pattern \"*\" --ignore-pattern \"!specs\" --ignore-pattern \"!specs/**\" --ignore-pattern \"specs/**/README.md\" --output web/",
+    "build": "remark --rc-path specs/.remarkrc-build.js --ignore-pattern \"*,!specs,!specs/**,README.md\" --output web/",
     "build-ietf": "docker-compose run --rm build",
     "test": "vitest run --config=vitest-schema.config.js",
     "test:coverage": "npm test -- --coverage"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . && remark --no-stdout --frail .",
-    "build": "remark --rc-path specs/.remarkrc-build.js --output web/",
+    "build": "remark --rc-path specs/.remarkrc-build.js --ignore-pattern \"*\" --ignore-pattern \"!specs\" --ignore-pattern \"!specs/**\" --ignore-pattern \"specs/**/README.md\" --output web/",
     "build-ietf": "docker-compose run --rm build",
     "test": "vitest run --config=vitest-schema.config.js",
     "test:coverage": "npm test -- --coverage"


### PR DESCRIPTION
## Description:

This PR keeps the build filtering inside `remark` by ignoring non-`specs/` inputs and `README.md` files under `specs/`, so colliding `web/README.html` outputs are rejected before they can be written. Resolves #1741.

### Checks run, locally:
- [x] `git diff --check`.
- [x] `npm run lint`.
- [x] `npm run build -- specs`.
- [x] `npm run build -- README.md specs/jsonschema-core.md adr/README.md specs/meta/README.md`.
- [x] `npm test`.

### Before the fix:

```text
README.md > web\README.html: written
adr\README.md > web\README.html: written
specs\meta\README.md > web\README.html: written
```

### After the fix:

```text
specs\jsonschema-core.md > web\jsonschema-core.html: written
README.md
 error Cannot process specified file: it’s ignored

adr\README.md
 error Cannot process specified file: it’s ignored

specs\meta\README.md
 error Cannot process specified file: it’s ignored

✖ 3 errors
```
