### PR TITLE
Fix wording in relative JSON Pointer draft

### DIFF
--- a/ietf/relative-json-pointer.xml
+++ b/ietf/relative-json-pointer.xml
@@ -246,7 +246,7 @@
 
         <section title="Non-use in URI Fragment Identifiers">
             <t>
-                Unlike a JSON Pointer, a Relative JSON Pointer can not be used in a
+                Unlike a JSON Pointer, a Relative JSON Pointer cannot be used in a
                 URI fragment identifier.  Such fragments specify exact positions
                 within a document, and therefore Relative JSON Pointers are not
                 suitable.


### PR DESCRIPTION
This PR replaces one inconsistent `can not` usage with `cannot` in `ietf/relative-json-pointer.xml`.