### PR TITLE
Fix wording in decouple-from-IETF ADR

### DIFF
--- a/adr/2022-09-decouple-from-ietf.md
+++ b/adr/2022-09-decouple-from-ietf.md
@@ -117,7 +117,7 @@ that happens.
 
 There are other concerns including skepticism that even with an extension
 mechanism that the RFC wouldn't need regular updates, which is not normal
-practice for an RFC and would require significant effort to issue a replacing
+practice for an RFC and would require significant effort to issue a replacement
 RFC. Without a concrete proposal on the scope of the RFC and the extension
 mechanisms, it's hard to commit to this path.
 


### PR DESCRIPTION
This PR fixes one editorial wording issue in `adr/2022-09-decouple-from-ietf.md`.