### PR TITLE
docs: clarify annotation objective in use cases

### DIFF
--- a/ietf/jsonschema-use-cases.xml
+++ b/ietf/jsonschema-use-cases.xml
@@ -90,7 +90,7 @@
 
             <section title="Annotation">
                 <t>
-                    The second objective of JSON Schema is to map an input JSON document to an arbitrary output described by the user.
+                    The second objective of JSON Schema is to associate an input JSON document with user-defined metadata or output.
                     Annotations may be combined with validation (in the same schema) to specify the domain of inputs for which an output is defined.
                     This covers the key use case of documenting the meaning of properties and values in JSON documents, and other uses where the input document is being interpreted in some fashion.
                 </t>


### PR DESCRIPTION
### What kind of change does this PR introduce?

Documentation improvement (wording clarification).

### Issue & Discussion References

* Others: No related issue. This is a small documentation wording improvement.

### Summary

This PR improves the wording of the Annotation objective for better clarity.

It replaces:

> "map an input JSON document to an arbitrary output described by the user."

with:

> "associate an input JSON document with user-defined metadata or output."

The revised wording is more natural and easier to understand while preserving the original meaning. This is a documentation-only change and does not modify any technical behavior or normative requirements.

### Does this PR introduce a breaking change?

No. This change only clarifies documentation wording and does not introduce any breaking changes.
