### PR TITLE
docs: fix grammar in media type application descriptions

### DIFF
--- a/ietf/json-schema-media-types.md
+++ b/ietf/json-schema-media-types.md
@@ -133,7 +133,7 @@ Published specification:
 
 Applications that use this media type:
 : JSON Schema is used in a variety of applications including API servers and
-  clients that validate JSON requests and responses, IDEs that valid
+  clients that validate JSON requests and responses, IDEs that validate
   configuration files, and databases that store JSON.
 
 Fragment identifier considerations:
@@ -248,7 +248,7 @@ Published specification:
 
 Applications that use this media type:
 : JSON Schema is used in a variety of applications including API servers and
-  clients that validate JSON requests and responses, IDEs that valid
+  clients that validate JSON requests and responses, IDEs that validate
   configuration files, databases that store JSON, and more.
 
 Fragment identifier considerations:


### PR DESCRIPTION
### What kind of change does this PR introduce?

Documentation improvement (grammar fix).

### Issue & Discussion References

* Others: No related issue. This PR fixes a minor grammar error in the documentation.

### Summary

This PR fixes a grammar mistake in the "Applications that use this media type" sections.

The word **"valid"** has been corrected to **"validate"** in two places:

* `IDEs that valid configuration files` → `IDEs that validate configuration files`

This is a documentation-only change that improves readability without changing the meaning of the specification.

### Does this PR introduce a breaking change?

No. This change only fixes a grammar error in the documentation and does not affect functionality or the specification.
