### PR TITLE
fix(scripts): replace semicolon with && in lint script for cross-plat…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . ; remark --no-stdout --frail .",
+    "lint": "eslint . && remark --no-stdout --frail .",
     "build": "remark --rc-path specs/.remarkrc-build.js --output web/",
     "build-ietf": "docker-compose run --rm build",
     "test": "vitest run --config=vitest-schema.config.js",


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bugfix

### Issue & Discussion References

- Closes #1756 

### Summary

This PR resolves an issue where running `npm run lint` fails on Windows environments.

Currently, the `lint` script in `package.json` is defined as:
```json
"lint": "eslint . ; remark --no-stdout --frail ."
```

When `npm run lint` is executed on Windows, `npm` passes the command string to `cmd.exe`. Because `cmd.exe` does not treat the semicolon `;` as a command separator, it passes `; remark --no-stdout --frail .` as command-line arguments directly into `eslint`. This causes ESLint v9 to throw an `Invalid option '--stdout'` error and crash.

This PR updates the script to use `&&` instead of `;`:
```json
"lint": "eslint . && remark --no-stdout --frail ."
```

Using `&&` ensures both `eslint` and `remark` run sequentially across all operating systems (Windows, macOS, Linux).

### Verification & Screenshots

- Tested `npm run lint` on Windows — both `eslint` and `remark` now execute sequentially and exit cleanly with code 0.
- Re-verified all spec builds (`npm run build -- specs`) — all spec documents build cleanly with 0 warnings.

<img width="1366" height="725" alt="Screenshot (950)" src="https://github.com/user-attachments/assets/ab49ff5d-3b3a-44ae-ab0f-dfd16eb5e71d" />


### Does this PR introduce a breaking change?

No.