### PR TITLE
Improve remark-flexible-container styling

### DIFF
--- a/specs/spec.css
+++ b/specs/spec.css
@@ -14,6 +14,9 @@
   --pico-muted-color: #57606a;
   --pico-muted-border-color: #d0d7de;
   --pico-code-background-color: #dde2e8;
+  --spec-code-block-background-color: #ffffff;
+  --spec-warning-accent-color: #d73a49;
+  --spec-note-accent-color: #005cc5;
 }
 
 @media only screen and (prefers-color-scheme: dark) {
@@ -26,6 +29,9 @@
     --pico-muted-color: #768390;
     --pico-muted-border-color: #444c56;
     --pico-code-background-color: #2d333d;
+    --spec-code-block-background-color: #22272e;
+    --spec-warning-accent-color: #f47067;
+    --spec-note-accent-color: #6cb6ff;
   }
 }
 
@@ -38,6 +44,9 @@
   --pico-muted-color: #768390;
   --pico-muted-border-color: #444c56;
   --pico-code-background-color: #2d333d;
+  --spec-code-block-background-color: #22272e;
+  --spec-warning-accent-color: #f47067;
+  --spec-note-accent-color: #6cb6ff;
 }
 
 body {
@@ -204,31 +213,59 @@ figure:has(figcaption) code {
 /* remark-flexible-containers */
 
 .remark-container {
-  border: thin solid var(--pico-muted-border-color);
-  border-radius: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: var(--pico-typography-spacing-vertical);
+  border: 1px solid var(--pico-muted-border-color);
+  border-left: 3px solid var(--pico-primary);
+  border-radius: var(--pico-border-radius);
   background-color: var(--pico-code-background-color);
 }
 
 .remark-container-title {
-  border-radius: 1rem 1rem 0 0;
+  border-radius: var(--pico-border-radius) var(--pico-border-radius) 0 0;
   position: relative;
-  padding: 0.5rem 0 0.5rem 2.5rem;
-  background-color: var(--pico-mark-background-color);
-  background-repeat: no-repeat;
-  background-size: 1.75rem;
-  background-position-y: center;
-  background-position-x: 0.25rem;
+  padding: 0.5rem 3rem;
+  border-bottom: 1px solid var(--pico-muted-border-color);
+  background-color: color-mix(in srgb, var(--pico-primary) 20%, var(--pico-code-background-color));
+}
+
+.remark-container-title::before {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask-repeat: no-repeat;
+  mask-size: contain;
 }
 
 .remark-container > :not(.remark-container-title) {
-  padding: 0 1rem;
+  padding: 0.25rem 1rem;
+  margin-bottom: 0;
+  background-color: var(--spec-code-block-background-color);
+  border-radius: 0 0 var(--pico-border-radius) var(--pico-border-radius);
+}
+
+.remark-container.warning {
+  border-left-color: var(--spec-warning-accent-color);
 }
 
 .remark-container-title.warning {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg id='SVGRepo_bgCarrier' stroke-width='0'%3E%3C/g%3E%3Cg id='SVGRepo_tracerCarrier' stroke-linecap='round' stroke-linejoin='round'%3E%3C/g%3E%3Cg id='SVGRepo_iconCarrier'%3E%3Ccircle cx='12' cy='17' r='1' fill='%23ffffff'%3E%3C/circle%3E%3Cpath d='M12 10L12 14' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3Cpath d='M3.44722 18.1056L10.2111 4.57771C10.9482 3.10361 13.0518 3.10362 13.7889 4.57771L20.5528 18.1056C21.2177 19.4354 20.2507 21 18.7639 21H5.23607C3.7493 21 2.78231 19.4354 3.44722 18.1056Z' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3C/g%3E%3C/svg%3E");
+  background-color: color-mix(in srgb, var(--spec-warning-accent-color) 20%, var(--pico-code-background-color));
+}
+
+.remark-container-title.warning::before {
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg id='SVGRepo_bgCarrier' stroke-width='0'%3E%3C/g%3E%3Cg id='SVGRepo_tracerCarrier' stroke-linecap='round' stroke-linejoin='round'%3E%3C/g%3E%3Cg id='SVGRepo_iconCarrier'%3E%3Ccircle cx='12' cy='17' r='1' fill='%23ffffff'%3E%3C/circle%3E%3Cpath d='M12 10L12 14' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3Cpath d='M3.44722 18.1056L10.2111 4.57771C10.9482 3.10361 13.0518 3.10362 13.7889 4.57771L20.5528 18.1056C21.2177 19.4354 20.2507 21 18.7639 21H5.23607C3.7493 21 2.78231 19.4354 3.44722 18.1056Z' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3C/path%3E%3C/g%3E%3C/svg%3E");
+}
+
+.remark-container.note {
+  border-left-color: var(--spec-note-accent-color);
 }
 
 .remark-container-title.note {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 32 32' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' xmlns:sketch='http://www.bohemiancoding.com/sketch/ns' fill='%23ffffff'%3E%3Cg id='SVGRepo_bgCarrier' stroke-width='0'%3E%3C/g%3E%3Cg id='SVGRepo_tracerCarrier' stroke-linecap='round' stroke-linejoin='round'%3E%3C/g%3E%3Cg id='SVGRepo_iconCarrier'%3E%3Ctitle%3Enote-text%3C/title%3E%3Cdesc%3ECreated with Sketch Beta.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd' sketch:type='MSPage'%3E%3Cg id='Icon-Set' sketch:type='MSLayerGroup' transform='translate(-308.000000, -99.000000)' fill='%23ffffff'%3E%3Cpath d='M332,107 L316,107 C315.447,107 315,107.448 315,108 C315,108.553 315.447,109 316,109 L332,109 C332.553,109 333,108.553 333,108 C333,107.448 332.553,107 332,107 L332,107 Z M338,127 C338,128.099 336.914,129.012 335.817,129.012 L311.974,129.012 C310.877,129.012 309.987,128.122 309.987,127.023 L309.987,103.165 C309.987,102.066 310.902,101 312,101 L336,101 C337.098,101 338,101.902 338,103 L338,127 L338,127 Z M336,99 L312,99 C309.806,99 308,100.969 308,103.165 L308,127.023 C308,129.22 309.779,131 311.974,131 L335.817,131 C338.012,131 340,129.196 340,127 L340,103 C340,100.804 338.194,99 336,99 L336,99 Z M332,119 L316,119 C315.447,119 315,119.448 315,120 C315,120.553 315.447,121 316,121 L332,121 C332.553,121 333,120.553 333,120 C333,119.448 332.553,119 332,119 L332,119 Z M332,113 L316,113 C315.447,113 315,113.448 315,114 C315,114.553 315.447,115 316,115 L332,115 C332.553,115 333,114.553 333,114 C333,113.448 332.553,113 332,113 L332,113 Z' id='note-text' sketch:type='MSShapeGroup'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  background-color: color-mix(in srgb, var(--spec-note-accent-color) 20%, var(--pico-code-background-color));
+}
+
+.remark-container-title.note::before {
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 32 32' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' xmlns:sketch='http://www.bohemiancoding.com/sketch/ns' fill='%23ffffff'%3E%3Cg id='SVGRepo_bgCarrier' stroke-width='0'%3E%3C/g%3E%3Cg id='SVGRepo_tracerCarrier' stroke-linecap='round' stroke-linejoin='round'%3E%3C/g%3E%3Cg id='SVGRepo_iconCarrier'%3E%3Ctitle%3Enote-text%3C/title%3E%3Cdesc%3ECreated with Sketch Beta.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd' sketch:type='MSPage'%3E%3Cg id='Icon-Set' sketch:type='MSLayerGroup' transform='translate(-308.000000, -99.000000)' fill='%23ffffff'%3E%3Cpath d='M332,107 L316,107 C315.447,107 315,107.448 315,108 C315,108.553 315.447,109 316,109 L332,109 C332.553,109 333,108.553 333,108 C333,107.448 332.553,107 332,107 L332,107 Z M338,127 C338,128.099 336.914,129.012 335.817,129.012 L311.974,129.012 C310.877,129.012 309.987,128.122 309.987,127.023 L309.987,103.165 C309.987,102.066 310.902,101 312,101 L336,101 C337.098,101 338,101.902 338,103 L338,127 L338,127 Z M336,99 L312,99 C309.806,99 308,100.969 308,103.165 L308,127.023 C308,129.22 309.779,131 311.974,131 L335.817,131 C338.012,131 340,129.196 340,127 L340,103 C340,100.804 338.194,99 336,99 L336,99 Z M332,119 L316,119 C315.447,119 315,119.448 315,120 C315,120.553 315.447,121 316,121 L332,121 C332.553,121 333,120.553 333,120 C333,119.448 332.553,119 332,119 L332,119 Z M332,113 L316,113 C315.447,113 315,113.448 315,114 C315,114.553 315.447,115 316,115 L332,115 C332.553,115 333,114.553 333,114 C333,113.448 332.553,113 332,113 L332,113 Z' id='note-text' sketch:type='MSShapeGroup'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }


### PR DESCRIPTION
When we restyled the spec css, we neglected the remark-flexible-container styling that were intended to be used as a replacement for footnotes. This is my attempt to clean that up. I think it came out ok.

Here's some examples.

<img width="1590" height="1324" alt="image" src="https://github.com/user-attachments/assets/b95531d6-de66-4cdd-b906-d6f8142223cf" />
<img width="1590" height="1324" alt="image" src="https://github.com/user-attachments/assets/66dd17cf-25f2-43cd-b244-d3af2ee3755b" />
