### PR TITLE
fix: add $vocabulary to meta-schema propertyNames regex pattern

### DIFF
--- a/specs/meta/meta.schema.json
+++ b/specs/meta/meta.schema.json
@@ -150,7 +150,7 @@
         "^x-": true
     },
     "propertyNames": {
-      "pattern": "^[^$]|^\\$(id|schema|ref|anchor|dynamicRef|dynamicAnchor|comment|defs)$"
+      "pattern": "^[^$]|^\\$(id|schema|ref|anchor|dynamicRef|dynamicAnchor|comment|defs|vocabulary)$"
     },
     "$dynamicRef": "extension",
     "unevaluatedProperties": false,

--- a/specs/meta/test-suite/tests/vocabulary.json
+++ b/specs/meta/test-suite/tests/vocabulary.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../test-suite.schema.json",
+
+  "description": "Tests for the $vocabulary keyword in propertyNames",
+  "tests": [
+    {
+      "description": "$vocabulary with valid object value",
+      "schema": {
+        "$schema": "https://json-schema.org/v1",
+        "$vocabulary": {
+          "https://json-schema.org/v1/vocab/core": true,
+          "https://json-schema.org/v1/vocab/applicator": false
+        }
+      },
+      "valid": true
+    },
+    {
+      "description": "$vocabulary with empty object",
+      "schema": {
+        "$schema": "https://json-schema.org/v1",
+        "$vocabulary": {}
+      },
+      "valid": true
+    }
+  ]
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bugfix

### Issue & Discussion References

- Closes #1759

### Summary

While running meta-schema validations using `@hyperjump/json-schema`, I found that `$vocabulary` is declared under `properties` in `meta.schema.json` (line 142) but was missing from the `propertyNames` regex pattern (line 153). This caused any valid schema containing `$vocabulary` to fail validation with a `propertyNames/pattern` error, even though the keyword is explicitly allowed.

**Changes:**

1. **`specs/meta/meta.schema.json`** — Added `vocabulary` to the `propertyNames` regex pattern.

2. **`specs/meta/test-suite/tests/vocabulary.json`** (new) — Added two test cases to verify `$vocabulary` is accepted by the meta-schema.

3. **`specs/meta/test-suite/meta-schema.test.js`** — Used `pathToFileURL` from `node:url` to resolve the meta-schema path as a proper `file://` URI. The `@hyperjump/uri` library rejects raw Windows backslash paths as invalid IRI references, so this ensures the test runner works cross-platform.

**Test Results (9/9 passing):**

<img width="1366" height="725" alt="Screenshot (959)" src="https://github.com/user-attachments/assets/dd4ef70b-fed8-4e08-8903-185364a5cdea" />


### Does this PR introduce a breaking change?

No