### PR TITLE
fix: correct grammar and wording in use case descriptions

### DIFF
--- a/ietf/jsonschema-use-cases.xml
+++ b/ietf/jsonschema-use-cases.xml
@@ -158,7 +158,7 @@
                     <t>or declare relationships between data.</t>
                 </list>
                 <t>
-                    A schema may be used to describe a machine-readable <xref target="RFC6906">profile</xref> of JSON document. Even when two schemas identify the same set of JSON documents; depending on the context, a given JSON document may be a profile of one but not the other.
+                    A schema may be used to describe a machine-readable <xref target="RFC6906">profile</xref> of a JSON document. Even when two schemas identify the same set of JSON documents; depending on the context, a given JSON document may be a profile of one but not the other.
                 </t>
             </section>
 
@@ -221,7 +221,7 @@
                 </t>
                 <t>
                     <cref>
-                        There's two directions this can work: an application should be able to determine if a third-party schema is making a distinction that it does not support; and an application may want to publish a schema indicating it works in a reduced value space.
+                        There are two directions this can work: an application should be able to determine if a third-party schema is making a distinction that it does not support; and an application may want to publish a schema indicating it works in a reduced value space.
                     </cref>
                 </t>
             </section>
@@ -264,7 +264,7 @@
                     A JSON document may carry relational data that must be internally consistent. Example constraints include:
                 </t>
                 <ul>
-                    <li>One-to-one calculations, like that children's birthdates come after their parent's birthdates;</li>
+                    <li>One-to-one calculations, such as children's birthdates come after their parent's birthdates;</li>
                     <li>One-to-many calculations, like a reference to an anchor points to an anchor defined somewhere in the same document.</li>
                 </ul>
             </section>


### PR DESCRIPTION
### What kind of change does this PR introduce?

Documentation fix.

### Issue & Discussion References

- Others: Editorial changes only.

### Summary

Correct several grammar and wording issues in the use case descriptions.

#### Changes

- Added the missing article in "a profile of a JSON document".
- Replaced "There's two directions this can work" with "There are two directions this can work".
- Improved the wording in the one-to-one calculation example.

These changes are editorial only and do not modify any technical or normative behavior.

### Does this PR introduce a breaking change?

No.