### PR TITLE
fix(meta-schema): disallow $schema fragments

### DIFF
--- a/specs/meta/meta.schema.json
+++ b/specs/meta/meta.schema.json
@@ -11,7 +11,11 @@
             "$comment": "Fragments not allowed.",
             "pattern": "^[^#]*$"
         },
-        "$schema": { "$ref": "#/$defs/iriString" },
+        "$schema": {
+            "$ref": "#/$defs/iriString",
+            "$comment": "Fragments not allowed.",
+            "pattern": "^[^#]*$"
+        },
         "$ref": { "$ref": "#/$defs/iriReferenceString" },
         "$anchor": { "$ref": "#/$defs/anchorString" },
         "$dynamicRef": { "$ref": "#/$defs/anchorString" },

--- a/specs/meta/test-suite/tests/schema.json
+++ b/specs/meta/test-suite/tests/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../test-suite.schema.json",
+
+  "description": "Tests for the $schema keyword",
+  "tests": [
+    {
+      "description": "Absolute URI without a fragment",
+      "schema": {
+        "$schema": "https://json-schema.org/v1"
+      },
+      "valid": true
+    },
+    {
+      "description": "Absolute URI with an empty fragment",
+      "schema": {
+        "$schema": "https://json-schema.org/v1#"
+      },
+      "valid": false
+    },
+    {
+      "description": "Absolute URI with a fragment",
+      "schema": {
+        "$schema": "https://json-schema.org/v1#frag"
+      },
+      "valid": false
+    }
+  ]
+}


### PR DESCRIPTION
## Description:

This PR disallows fragments in `$schema` values in `specs/meta/meta.schema.json` and adds meta-schema tests for valid and invalid fragment cases.

### Checks run, locally:
- [x] `git diff --check`
- [x] `npm test`
- [x] `npm run lint`
