### PR TITLE
Fix allOf example in vocabularies proposal

### DIFF
--- a/specs/proposals/vocabularies.md
+++ b/specs/proposals/vocabularies.md
@@ -141,11 +141,11 @@ reference (via `$ref`) to the vocabulary schema's `$id` value.
     "https://example.org/vocab/vocab2": true,
     "https://example.org/vocab/vocab3": false
   },
-  "allOf": {
+  "allOf": [
     {"$ref": "meta/vocab1"},  // https://example.org/meta/vocab1
     {"$ref": "meta/vocab2"},  // https://example.org/meta/vocab2
     {"$ref": "meta/vocab3"}   // https://example.org/meta/vocab3
-  }
+  ]
   // ...
 }
 ```


### PR DESCRIPTION
This PR updates one `allOf` example in `specs/proposals/vocabularies.md` so it uses an array matching the spec definition of `allOf`.
