### PR TITLE
fix(meta-test-suite): allow invalid schema fixtures

### DIFF
--- a/specs/meta/test-suite/test-suite.schema-files.test.js
+++ b/specs/meta/test-suite/test-suite.schema-files.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+
+describe("meta test suite files", () => {
+  test("suite files match the test suite schema", async () => {
+    for (const entry of await fs.readdir(`${import.meta.dirname}/tests`, { withFileTypes: true })) {
+      if (entry.isDirectory() || path.extname(entry.name) !== ".json") {
+        continue;
+      }
+
+      const suiteJson = await fs.readFile(`${entry.parentPath}/${entry.name}`, "utf8");
+      const suite = JSON.parse(suiteJson);
+      await expect(suite).to.matchJsonSchema("specs/meta/test-suite/test-suite.schema.json");
+    }
+  });
+});

--- a/specs/meta/test-suite/test-suite.schema.json
+++ b/specs/meta/test-suite/test-suite.schema.json
@@ -15,7 +15,7 @@
       "type": "object",
       "properties": {
         "description": { "type": "string" },
-        "schema": { "$ref": "../meta.schema.json" },
+        "schema": true,
         "valid": { "type": "boolean" }
       }
     }


### PR DESCRIPTION
## Description:

This PR allows invalid schema fixtures in `specs/meta/test-suite/test-suite.schema.json` and adds a test that validates the existing meta test suite files against that schema.

### Checks run, locally:

- [x] `git diff --check`
- [x] `npm test`
- [x] `npm run lint`
