### PR TITLE
fix(meta-schema): allow Unicode anchor names

### DIFF
--- a/specs/meta/meta.schema.json
+++ b/specs/meta/meta.schema.json
@@ -164,7 +164,7 @@
         },
         "anchorString": {
             "type": "string",
-            "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+            "pattern": "^[_A-Za-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\u{10000}-\\u{EFFFF}][-_A-Za-z0-9.\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\u{10000}-\\u{EFFFF}\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"
         },
         "iriString": {
             "type": "string",

--- a/specs/meta/test-suite/tests/anchors.json
+++ b/specs/meta/test-suite/tests/anchors.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../test-suite.schema.json",
+
+  "description": "Tests for anchor keywords",
+  "tests": [
+    {
+      "description": "Unicode $anchor",
+      "schema": {
+        "$schema": "https://json-schema.org/v1",
+        "$anchor": "é"
+      },
+      "valid": true
+    },
+    {
+      "description": "Unicode $dynamicRef",
+      "schema": {
+        "$schema": "https://json-schema.org/v1",
+        "$dynamicRef": "é"
+      },
+      "valid": true
+    },
+    {
+      "description": "Unicode $dynamicAnchor",
+      "schema": {
+        "$schema": "https://json-schema.org/v1",
+        "$dynamicAnchor": "é"
+      },
+      "valid": true
+    }
+  ]
+}


### PR DESCRIPTION
## Description:

This PR updates `anchorString` in `specs/meta/meta.schema.json` to accept Unicode plain name fragment identifiers and adds meta-schema tests for Unicode `$anchor`, `$dynamicRef`, and `$dynamicAnchor` values.

Closes #1766.

### Checks run, locally:

- [x] `git diff --check`
- [x] `npm test`
- [x] `npm run lint`
