### PR TITLE
fix(core): remove trailing JSON comma

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -2417,7 +2417,7 @@ purposes, and is not intended to propose a functional code generation keyword.
       "$ref": "classes/foo.json"
     },
     "date": {
-      "$ref": "types/dateStruct.json",
+      "$ref": "types/dateStruct.json"
     }
   }
 }


### PR DESCRIPTION
This PR removes a trailing comma from a JSON Schema example in `specs/jsonschema-core.md` so it parses as JSON.
