### PR TITLE
fix(core): label JSON instance as JSON

### DIFF
--- a/specs/jsonschema-core.md
+++ b/specs/jsonschema-core.md
@@ -2345,7 +2345,7 @@ and only allows the "data" and "children" properties. An example instance with
 }
 ```
 
-```jsonschema "Instance with misspelled field"
+```json "Instance with misspelled field"
 {
   "children": [ { "daat": 1 } ]
 }


### PR DESCRIPTION
## Description:

This PR labels the JSON instance example as JSON in `specs/jsonschema-core.md`.

### Checks run, locally:

- [x] `git diff --check`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build -- specs/jsonschema-core.md`